### PR TITLE
Add substrate dev hub and references doc link in resources.

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -18,3 +18,7 @@
     - [Declarative Programming](./safety/cop.md)
     - [Optimizations](./safety//optimizations.md)
 - [Open Source Dessert](./dessert/README.md)
+
+-----------
+
+[More Resources](./misc/resource.md)

--- a/src/misc/resource.md
+++ b/src/misc/resource.md
@@ -1,0 +1,6 @@
+# More Resources
+
+You can learn more knowledge about Substrate by following these resources:
+
+* [**Substrate Developer Hub**](https://substrate.dev) - the official Substrate documentation for blockchain developers.
+* [**Reference Docs**](https://substrate.dev/rustdocs) - the details about Substrate implementation in Rust.


### PR DESCRIPTION
Fix https://github.com/substrate-developer-hub/substrate-developer-hub.github.io/issues/45 in recipes.

We could improve this after mdbook resolve the external link issue in sidebar https://github.com/rust-lang-nursery/mdBook/issues/919.