### PR TITLE
Runtime Configuration Section

### DIFF
--- a/kitchen/hook/Cargo.toml
+++ b/kitchen/hook/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "generating-randomness"
+name = "runtime-hooks"
 version = "0.1.0"
 authors = ["4meta5"]
 edition = "2018"
@@ -11,7 +11,6 @@ std = [
     'support/std',
     'system/std',
     'balances/std',
-    'primitives/std',
     'runtime-primitives/std',
 ]
 
@@ -44,7 +43,7 @@ git = 'https://github.com/paritytech/substrate.git'
 package = 'sr-primitives'
 branch = 'master'
 
-[dependencies.primitives]
+[dev-dependencies.primitives]
 default_features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'substrate-primitives'

--- a/kitchen/hook/src/lib.rs
+++ b/kitchen/hook/src/lib.rs
@@ -1,0 +1,1 @@
+/// runtime hooks

--- a/kitchen/random/src/lib.rs
+++ b/kitchen/random/src/lib.rs
@@ -1,40 +1,45 @@
+/// Generating randomness with weak entropy
 #![cfg_attr(not(feature = "std"), no_std)]
+#![recursion_limit = "128"]
 
-use primitives::{ed25519, Blake2Hasher, Hasher, H256};
+use primitives::{Blake2Hasher, Hasher};
 /// Generating Randomness example(s)
-use support::{decl_event, decl_module, decl_storage, dispatch::Result, ensure, StorageValue};
-use system::ensure_signed;
+use parity_scale_codec::{Encode, Decode};
+use support::{decl_event, decl_module, decl_storage, StorageValue, dispatch::Result};
+use system::{self, ensure_signed};
 
 pub trait Trait: system::Trait {
     type Event: From<Event> + Into<<Self as system::Trait>::Event>;
-}
-
-decl_storage! {
-    trait Store for Module<T: Trait> as PGeneric {
-        Nonce get(nonce): u32;
-    }
 }
 
 decl_module! {
     pub struct Module<T: Trait> for enum Call where origin: T::Origin {
         fn deposit_event() = default;
 
-        fn weak_entropy(origin) -> u32{
+        fn use_weak_entropy(origin) -> Result {
+            let _ = ensure_signed(origin)?;
+
+            let random_seed = <system::Module<T>>::random_seed();
             let nonce = <Nonce>::get();
-            let new_random = (<system::Module<T>>::random_seed(), nonce)
+            let new_random = (random_seed, nonce)
                 .using_encoded(|b| Blake2Hasher::hash(b))
                 .using_encoded(|mut b| u64::decode(&mut b))
                 .expect("Hash must be bigger than 8 bytes; Qed");
-            let new_nonce = <Nonce>::get() + 1;
-            <Nonce>::put(new_nonce);
-            Self::deposit_event(RawEvent::RNGenerate(new_random));
-            new_random
+            Self::deposit_event(Event::WeakEntropy(new_random));
+            <Nonce>::put(nonce + 1);
+            Ok(())
         }
     }
 }
 
 decl_event!(
     pub enum Event {
-        RNGenerate(u32),
+        WeakEntropy(u64),
     }
 );
+
+decl_storage! {
+    trait Store for Module<T: Trait> as Ranodom {
+        Nonce get(nonce): u64;
+    }
+}

--- a/src/common/random.md
+++ b/src/common/random.md
@@ -13,13 +13,11 @@ let new_random = (<system::Module<T>>::random_seed(), nonce)
     .using_encoded(|b| Blake2Hasher::hash(b))
     .using_encoded(|mut b| u64::decode(&mut b))
     .expect("Hash must be bigger than 8 bytes; Qed");
-
-<Nonce<T>>::mutate(|n| *n += 1);
+<Nonce<T>>::put(nonce + 1);
 ```
 
- 
 **also see...**
-
+* [code in kitchen](https://github.com/substrate-developer-hub/recipes/blob/master/kitchen/random/src/lib.rs)
 * https://github.com/paritytech/ink/issues/57
 
 **[Back to Recipes](https://substrate.dev/recipes/)**

--- a/src/types/hook.md
+++ b/src/types/hook.md
@@ -1,0 +1,8 @@
+# Runtime Hooks
+
+* still planning how to do this
+
+* might add this to a new section on runtime configuration
+
+## more
+see the [docs]https://substrate.dev/docs/en/tutorials/adding-a-module-to-your-runtime#adding-runtime-hooks)


### PR DESCRIPTION
The current recipes are focused almost exclusively on module development and that's OK, but runtime configuration gives module development context. So, I'm going to add a runtime config section, but I'm still considering organization and how it fits in with the existing structure. 

The content will not repeat what is in existing docs, but rather provide more minimal examples with associated code in the kitchen. It will probably require splitting the kitchen between modules and runtimes. The *problem* is that I would prefer to keep the kitchen flat instead of adding depth (nested directories). 

### updating old recipes

- [ ] add runtime configuration directions for each recipe as shown in #41 
- [ ] create example runtime configurations for tightly vs loosely coupled modules

### new recipes

- [ ] tight vs loose inheritance (and reference traits as behavioral abstractions, see Currency recipe) 
- [ ] runtime hooks
- [ ] genesis configuration

### probably in a future PR, but fits in this section

- [ ] custom traits in modules (like Joshy's marketplace reputation trait)
- [ ] srml-panic

### unrelated maintenance

- [x] fix randomness generation in kitchen