### PR TITLE
Double maps require explicit second hasher

### DIFF
--- a/kitchen/modules/double-map/src/lib.rs
+++ b/kitchen/modules/double-map/src/lib.rs
@@ -22,7 +22,7 @@ pub type GroupIndex = u32;
 decl_storage! {
 	trait Store for Module<T: Trait> as DMap {
         // member score (double map)
-        MemberScore: double_map GroupIndex, T::AccountId => u32;
+        MemberScore: double_map GroupIndex, twox_128(T::AccountId) => u32;
         // get group ID for member
         GroupMembership get(group_membership): map T::AccountId => GroupIndex;
         // for fast membership checks, see check-membership recipe for more details


### PR DESCRIPTION
I thought I learned that from https://crates.parity.io/srml_support/storage/trait.StorageDoubleMap.html, but I don't see any mention of it there. I guess it's oral tradition.

I don't know anything about `twox_128`, what the other alternatives are, or their trade-offs. But this does compile now.