### PR TITLE
Change code so it compiles, but doesn't make sense.

### DIFF
--- a/kitchen/runtimes/super-node-runtime/src/lib.rs
+++ b/kitchen/runtimes/super-node-runtime/src/lib.rs
@@ -17,7 +17,7 @@ use sr_primitives::{
 };
 use sr_primitives::traits::{NumberFor, BlakeTwo256, Block as BlockT, StaticLookup, Verify, ConvertInto};
 use sr_primitives::weights::Weight;
-use babe::{AuthorityId as BabeId, SameAuthoritiesForever};
+use babe::{AuthorityId as BabeId/*, SameAuthoritiesForever*/};
 use grandpa::{AuthorityId as GrandpaId, AuthorityWeight as GrandpaWeight};
 use grandpa::fg_primitives;
 use client::{
@@ -203,7 +203,7 @@ parameter_types! {
 impl babe::Trait for Runtime {
 	type EpochDuration = EpochDuration;
 	type ExpectedBlockTime = ExpectedBlockTime;
-	type EpochChangeTrigger = SameAuthoritiesForever;
+	//type EpochChangeTrigger = SameAuthoritiesForever;
 }
 
 impl grandpa::Trait for Runtime {


### PR DESCRIPTION
Works around #63.

With this change, the code compiles, but I don't understand _why_ it compiles. `babe::Trait` is clearly supposed to have a `EpochChangeTrigger`
* https://crates.parity.io/srml_babe/trait.Trait.html
* https://github.com/paritytech/substrate/blob/master/srml/babe/src/lib.rs#L140