### PR TITLE
Breaking Up Ch3

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -2,7 +2,10 @@
 
 - [Introduction](./base/README.md)
 - [Learn Rust](./base/rust.md)
-- [Installation](./base/setup.md)
+- [Getting Started](./base/setup.md)
+    - [Running a Node](./base/runnode.md)
+    - [Interacting with a Node](./base/interactnode.md)
+    - [Using the Kitchen](./base/kitchenoverview.md)
 - [Hello Substrate](./basics/README.md)
     - [Events Verify Execution](./basics/events.md)
     - [Adding Machine](./basics/adder.md)

--- a/src/base/interactnode.md
+++ b/src/base/interactnode.md
@@ -2,4 +2,4 @@
 
 If you followed [the instructions](./runnode.md) to get your node running, you should see blocks created on the console. You can now use our [Polkadot-JS Apps to interact with your locally running node](https://polkadot.js.org/apps/#/explorer?rpc=ws://127.0.0.1:9944). You will use the **Chain state** tab to query the blockchain status and **Extrinsics** to send transactions to the blockchain.
 
-To configure relevant type definitions with the UI, follow the directions in the [Collectables tutorial](https://substrate.dev/substrate-collectables-workshop/#/4/rendering-kitties).
+To configure relevant type definitions, follow the directions in the [polkadot-js docs](https://polkadot.js.org/api/api/#registering-custom-types).

--- a/src/base/interactnode.md
+++ b/src/base/interactnode.md
@@ -1,5 +1,5 @@
 # Interact with the Kitchen Node
 
-If you followed [the instructions](./runnode.md) to get your node running, you should see blocks are being created on the console. You can now use our [Polkadot-JS Apps to interact with your locally running node](https://polkadot.js.org/apps/#/explorer?rpc=ws://127.0.0.1:9944). You will be mainly using the **Chain state** tab to query the blockchain status and **Extrinsics** to send transactions to the blockchain.
+If you followed [the instructions](./runnode.md) to get your node running, you should see blocks created on the console. You can now use our [Polkadot-JS Apps to interact with your locally running node](https://polkadot.js.org/apps/#/explorer?rpc=ws://127.0.0.1:9944). You will use the **Chain state** tab to query the blockchain status and **Extrinsics** to send transactions to the blockchain.
 
-Congratulation on running the Kitchen Node and able to interact with it!
+To configure relevant type definitions with the UI, follow the directions in the [Collectables tutorial](https://substrate.dev/substrate-collectables-workshop/#/4/rendering-kitties).

--- a/src/base/interactnode.md
+++ b/src/base/interactnode.md
@@ -1,0 +1,5 @@
+# Interact with the Kitchen Node
+
+If you followed [the instructions](./runnode.md) to get your node running, you should see blocks are being created on the console. You can now use our [Polkadot-JS Apps to interact with your locally running node](https://polkadot.js.org/apps/#/explorer?rpc=ws://127.0.0.1:9944). You will be mainly using the **Chain state** tab to query the blockchain status and **Extrinsics** to send transactions to the blockchain.
+
+Congratulation on running the Kitchen Node and able to interact with it!

--- a/src/base/runnode.md
+++ b/src/base/runnode.md
@@ -29,5 +29,3 @@ Once the compilation is completed, you can first purge any existing blockchain d
 # Start the Kitchen Node
 ./target/release/kitchen-node --dev
 ```
-
-[Next](./interactnode.md), learn how to interact with your node.

--- a/src/base/runnode.md
+++ b/src/base/runnode.md
@@ -1,0 +1,33 @@
+# Run the Kitchen Node
+
+To run the code in the recipes, `git clone` the source repository. We also want to kick-start the node compilation as it may take about 30 minutes to complete depending on your hardware.
+
+```bash
+git clone https://github.com/substrate-developer-hub/recipes.git
+cd recipes/kitchen/node
+./scripts/init.sh
+
+# This step takes a while to complete
+cargo build --release
+```
+
+> **Notes**
+>
+> Refer to the following sections to:
+>
+>  * Learn more about [Substrate runtime](https://substrate.dev/docs/en/runtime/architecture-of-a-runtime)
+>  * Learn more about [Substrate modules](https://substrate.dev/docs/en/runtime/substrate-runtime-module-library)
+
+Once the compilation is completed, you can first purge any existing blockchain data (useful to start your node from a clean state in future) and then start the node.
+
+```bash
+# Inside `recipes/kitchen/node` folder
+
+# Purge any existing blockchain data. Enter `y` upon prompt.
+./target/release/kitchen-node purge-chain --dev
+
+# Start the Kitchen Node
+./target/release/kitchen-node --dev
+```
+
+[Next](./interactnode.md), learn how to interact with your node.

--- a/src/base/setup.md
+++ b/src/base/setup.md
@@ -19,7 +19,7 @@ The [`recipes/kitchen`](https://github.com/substrate-developer-hub/recipes/tree/
 
   * [`node`](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/node) - contains the code to start the Kitchen Node.
   * [`runtimes`](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/runtimes) - contains the runtime of the Kitchen Node.
-  * [`modules`](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/modules) - the runtime includes multiple modules. Each module gives the runtime a new set of functionality. Most of the recipe module code we discuss afterwards is stored under this folder.
+  * [`modules`](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/modules) - each runtime includes multiple modules. Each module gives the runtime a new set of functionality. Most of the recipe module code we discuss afterwards is stored under this folder.
 
 This section teaches users to interact with [`recipes/kitchen`](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen) by
 * [Running a Node](./runnode.md)

--- a/src/base/setup.md
+++ b/src/base/setup.md
@@ -1,8 +1,6 @@
-# Installation and Running the Kitchen Node
+# Getting Started
 
-## Setup
-
-If you do not have a Subtrate development environment setup on your machine, please install it.
+If you do not have a Substrate development environment setup on your machine, please install it by following these directions.
 
 ### For Linux / macOS
 
@@ -15,127 +13,15 @@ curl https://getsubstrate.io -sSf | bash
 
 Refer to our [Substrate Installation on Windows](https://substrate.dev/docs/en/next/getting-started#getting-started-on-windows).
 
-## Running the Kitchen Node
+## Kitchen Overview
 
-To interact with the code in these recipes, `git clone` the source repository. We also want to kick-start the node compilation as it may take about 30 minutes to complete depending on your hardware.
+The [`recipes/kitchen`](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen) folder contains all the code necessary to run a Substrate node. Let us call it the Kitchen Node. There are three folders inside:
 
-```bash
-git clone https://github.com/substrate-developer-hub/recipes.git
-cd recipes/kitchen/node
-./scripts/init.sh
+  * [`node`](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/node) - contains the code to start the Kitchen Node.
+  * [`runtimes`](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/runtimes) - contains the runtime of the Kitchen Node.
+  * [`modules`](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/modules) - the runtime includes multiple modules. Each module gives the runtime a new set of functionality. Most of the recipe module code we discuss afterwards is stored under this folder.
 
-# This step takes a while to complete
-cargo build --release
-```
-
-Here, `recipes/kitchen` folder contains all the code necessary to run a Substrate node. Let us call it the Kitchen Node. There are three folders inside:
-
-  * `node` - contains the code to start the Kitchen Node.
-  * `runtimes` - contains the runtime of the Kitchen Node.
-  * `modules` - the runtime includes multiple modules. Each module gives the runtime a new set of functionality. Most of the recipe module code we discuss afterwards is stored under this folder
-
-> **Notes**
->
-> Refer to the following sections to:
->
->  * Learn more about [Substrate runtime](https://substrate.dev/docs/en/runtime/architecture-of-a-runtime)
->  * Learn more about [Substrate modules](https://substrate.dev/docs/en/runtime/substrate-runtime-module-library)
-
-Once the compilation is completed, you can first purge any existing blockchain data (useful to start your node from a clean state in future) and then start the node.
-
-```bash
-# Inside `recipes/kitchen/node` folder
-
-# Purge any existing blockchain data. Enter `y` upon prompt.
-./target/release/kitchen-node purge-chain --dev
-
-# Start the Kitchen Node
-./target/release/kitchen-node --dev
-```
-
-## Interact with your Node
-
-You should see blocks are being created on the console. You can now use our [Polkadot-JS Apps to interact with your locally running node](https://polkadot.js.org/apps/#/explorer?rpc=ws://127.0.0.1:9944). You will be mainly using the **Chain state** tab to query the blockchain status and **Extrinsics** to send transactions to the blockchain.
-
-Congratulation on running the Kitchen Node and able to interact with it!
-
-## Understanding the Kitchen Node
-
-Let us take a deeper look at the Kitchen Node. Inside
-
-**`kitchen/node/Cargo.toml`**
-
-```TOML
-# -- snip --
-runtime = { package = "super-runtime", path = "../runtimes/super-runtime" }
-# -- snip --
-```
-
-You see `node` is bringing in the `runtime` modules in, and use it to build up the node service in
-
-**`kitchen/node/src/service.rs`**
-
-```Rust
-// -- snip --
-use runtime::{self, GenesisConfig, opaque::Block, RuntimeApi};
-// -- snip --
-
-macro_rules! new_full_start {
-  // -- snip --
-  let builder = substrate_service::ServiceBuilder::new_full::<
-    runtime::opaque::Block, runtime::RuntimeApi, crate::service::Executor
-  >($config)?
-  // -- snip --
-}
-```
-
-The `runtime` folder contains two folders, `super-genesis` for specifying how the first block on the blockchain (genesis block) is being produced, and `super-runtime` for specifying how the node runtime behaves. Let us focus on one module `simple-event` in the runtime. In
-
-**`kitchen/runtimes/super-runtime/Cargo.toml`**
-
-```TOML
-# -- snip --
-
-# `simple-event` module is specified as a relative path to the `modules` folder
-[dependencies]
-simple-event = { package = "simple-event", path = "../../modules/simple-event", default_features = false }
-
-# -- snip --
-```
-
-This is where the node runtime includes additional module `simple-event` written in this recipe. The module is then included into the runtime by:
-
-**`kitchen/runtimes/super-runtime/src/lib.rs`**
-
-```Rust
-// -- snip --
-use simple_event;
-
-// -- snip --
-impl simple_event::Trait for Runtime {
-  type Event = Event;
-}
-
-// -- snip --
-construct_runtime!(
-  pub enum Runtime where
-    Block = Block,
-    NodeBlock = opaque::Block,
-    UncheckedExtrinsic = UncheckedExtrinsic
-  {
-    // -- snip --
-    SingleValue: single_value::{Module, Call, Storage, Event<T>},
-  }
-);
-```
-
-Finally, you can see how the `simple-event` module is specified in `kitchen/modules/simple-event/src/lib.rs`.
-
-This is the general pattern used throughout these recipes. We first talk about a new piece of module code stored in `kitchen/modules/<module-name>/src/lib.rs`. The module is then included into the runtime by adding the module name and relative path in `kitchen/runtimes/super-runtime/Cargo.toml` (if not yet added) and updating `kitchen/runtimes/super-runtime/src/lib.rs`.
-
-## Learn More
-
-In fact, the Kitchen Node and runtime structure has been refactored to cater for the recipe purpose. If you are interested to learn more about how to include your own module in a node runtime, we recommend you to go through the following two tutorials.
-
-* [Writing a Runtime Module in its Own Crate Tutorial](https://substrate.dev/docs/en/tutorials/ creating-a-runtime-module)
-* [Adding `Contract` Module to Your Runtime Tutorial](https://substrate.dev/docs/en/tutorials/adding-a-module-to-your-runtime)
+This section teaches users to interact with [`recipes/kitchen`](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen) by
+* [Running a Node](./runnode.md)
+* [Interacting with the Node](./interactnode.md)
+* [Understanding the Kitchen Architecture](./usingkitchen.md)

--- a/src/base/usingkitchen.md
+++ b/src/base/usingkitchen.md
@@ -1,6 +1,6 @@
 # Using the Kitchen
 
-Let us take a deeper look at the Kitchen Node. Inside
+Let us take a deeper look at the [Kitchen Node](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/node). Inside
 
 **`kitchen/node/Cargo.toml`**
 

--- a/src/base/usingkitchen.md
+++ b/src/base/usingkitchen.md
@@ -1,0 +1,80 @@
+# Using the Kitchen
+
+Let us take a deeper look at the Kitchen Node. Inside
+
+**`kitchen/node/Cargo.toml`**
+
+```TOML
+# -- snip --
+runtime = { package = "super-runtime", path = "../runtimes/super-runtime" }
+# -- snip --
+```
+
+You see `node` is bringing in the `runtime` modules in, and use it to build up the node service in
+
+**`kitchen/node/src/service.rs`**
+
+```Rust
+// -- snip --
+use runtime::{self, GenesisConfig, opaque::Block, RuntimeApi};
+// -- snip --
+
+macro_rules! new_full_start {
+  // -- snip --
+  let builder = substrate_service::ServiceBuilder::new_full::<
+    runtime::opaque::Block, runtime::RuntimeApi, crate::service::Executor
+  >($config)?
+  // -- snip --
+}
+```
+
+The `runtime` folder contains two folders, `super-genesis` for specifying how the first block on the blockchain (genesis block) is being produced, and `super-runtime` for specifying how the node runtime behaves. Let us focus on one module `simple-event` in the runtime. In
+
+**`kitchen/runtimes/super-runtime/Cargo.toml`**
+
+```TOML
+# -- snip --
+
+# `simple-event` module is specified as a relative path to the `modules` folder
+[dependencies]
+simple-event = { package = "simple-event", path = "../../modules/simple-event", default_features = false }
+
+# -- snip --
+```
+
+This is where the node runtime includes additional module `simple-event` written in this recipe. The module is then included into the runtime by:
+
+**`kitchen/runtimes/super-runtime/src/lib.rs`**
+
+```Rust
+// -- snip --
+use simple_event;
+
+// -- snip --
+impl simple_event::Trait for Runtime {
+  type Event = Event;
+}
+
+// -- snip --
+construct_runtime!(
+  pub enum Runtime where
+    Block = Block,
+    NodeBlock = opaque::Block,
+    UncheckedExtrinsic = UncheckedExtrinsic
+  {
+    // -- snip --
+    SingleValue: single_value::{Module, Call, Storage, Event<T>},
+  }
+);
+```
+
+Finally, you can see how the `simple-event` module is specified in `kitchen/modules/simple-event/src/lib.rs`.
+
+This is the general pattern used throughout these recipes. We first talk about a new piece of module code stored in `kitchen/modules/<module-name>/src/lib.rs`. The module is then included into the runtime by adding the module name and relative path in `kitchen/runtimes/super-runtime/Cargo.toml` (if not yet added) and updating `kitchen/runtimes/super-runtime/src/lib.rs`.
+
+## Learn More
+
+In fact, the Kitchen Node and runtime structure has been refactored to cater for the recipe purpose. If you are interested to learn more about how to include your own module in a node runtime, we recommend you to go through the following two tutorials.
+
+* [Writing a Runtime Module in its Own Crate Tutorial](https://substrate.dev/docs/en/tutorials/creating-a-runtime-module)
+* [Adding `Contract` Module to Your Runtime Tutorial](https://substrate.dev/docs/en/tutorials/adding-a-module-to-your-runtime)


### PR DESCRIPTION
Ch3 had a lot of content in one page. I'm going to break out into multiple pages, which should also provide more space to expand on certain things that are important, like instructions for *Interacting with the Node*.

This PR structures *Chapter 3: Getting Started* such that 
1. the main title page contains installation instructions and an overview of the kitchen structure
2. **Running a Node** contains instructions for running the kitchen node
3. **Interacting with a Node** contains instructions for interacting with the node
4. **Using the Kitchen** contains more information to configure modules into runtimes into nodes using the kitchen's structure

- [x] restructure (still open for feedback on this new structure)

I'm mainly doing this to make space for more content in the *Interacting with a Node* section as per #69 . Likewise, I'll probably do the the first of the following TODOs before merging this. The second will have adequate space because of this PR.
1. [x] address #69 with a link to type def configuration of Polkadot-js
2. [ ] could add an example of configuring a specific module's type defs (as discussed in #69 )