### PR TITLE
Update decl_storage! calls to use fn in getter declaration

### DIFF
--- a/kitchen/modules/check-membership/src/lib.rs
+++ b/kitchen/modules/check-membership/src/lib.rs
@@ -13,9 +13,9 @@ pub trait Trait: system::Trait {
 
 decl_storage! {
     trait Store for Module<T: Trait> as PGeneric {
-        Owner get(owner): T::AccountId;
+        Owner get(fn owner): T::AccountId;
 
-        Members get(members): Vec<T::AccountId>;
+        Members get(fn members): Vec<T::AccountId>;
     }
 }
 

--- a/kitchen/modules/double-map/src/lib.rs
+++ b/kitchen/modules/double-map/src/lib.rs
@@ -2,10 +2,10 @@
 
 // Double Map Example w/ remove_prefix
 // https://crates.parity.io/srml_support/storage/trait.StorageDoubleMap.html
-// `double_map` maps two keys to a single value. 
+// `double_map` maps two keys to a single value.
 // the first key might be a group identifier
 // the second key might be a unique identifier
-// `remove_prefix` enables clean removal of all values with the group identifier 
+// `remove_prefix` enables clean removal of all values with the group identifier
 
 use support::{
     ensure, decl_module, decl_storage, decl_event,
@@ -26,9 +26,9 @@ decl_storage! {
         // member score (double map)
         MemberScore: double_map GroupIndex, twox_128(T::AccountId) => u32;
         // get group ID for member
-        GroupMembership get(group_membership): map T::AccountId => GroupIndex;
+        GroupMembership get(fn group_membership): map T::AccountId => GroupIndex;
         // for fast membership checks, see check-membership recipe for more details
-        AllMembers get(all_members): Vec<T::AccountId>;
+        AllMembers get(fn all_members): Vec<T::AccountId>;
 	}
 }
 

--- a/kitchen/modules/gen-random/src/lib.rs
+++ b/kitchen/modules/gen-random/src/lib.rs
@@ -17,7 +17,7 @@ pub trait Trait: system::Trait {
 
 decl_storage! {
     trait Store for Module<T: Trait> as PGeneric {
-        Nonce get(nonce): u32;
+        Nonce get(fn nonce): u32;
     }
 }
 
@@ -54,6 +54,6 @@ decl_event!(
 
 decl_storage! {
     trait Store for Module<T: Trait> as RNG {
-        Nonce get(nonce): u64;
+        Nonce get(fn nonce): u64;
     }
-} 
+}

--- a/kitchen/modules/hello-substrate/src/lib.rs
+++ b/kitchen/modules/hello-substrate/src/lib.rs
@@ -16,8 +16,8 @@ decl_event!{
 
 decl_storage! {
 	trait Store for Module<T: Trait> as HelloWorld {
-		pub LastValue get(last_value): u64; 
-		pub UserValue get(user_value): map T::AccountId => u64;
+		pub LastValue get(fn last_value): u64;
+		pub UserValue get(fn user_value): map T::AccountId => u64;
 	}
 }
 

--- a/kitchen/modules/linked-map/src/lib.rs
+++ b/kitchen/modules/linked-map/src/lib.rs
@@ -1,10 +1,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 /// List via Maps
-/// Substrate does not natively support a list type since it may encourage 
-/// dangerous habits. Unless explicitly guarded against, a list will add 
-/// unbounded `O(n)` complexity to an operation that will only charge `O(1)` 
-/// fees ([Big O notation refresher](https://rob-bell.net/2009/06/a-beginners-guide-to-big-o-notation/)). 
+/// Substrate does not natively support a list type since it may encourage
+/// dangerous habits. Unless explicitly guarded against, a list will add
+/// unbounded `O(n)` complexity to an operation that will only charge `O(1)`
+/// fees ([Big O notation refresher](https://rob-bell.net/2009/06/a-beginners-guide-to-big-o-notation/)).
 /// This opens an economic attack vector on your chain.
 
 use support::{ensure, decl_module, decl_storage, decl_event, StorageValue, StorageMap, StorageLinkedMap, dispatch::Result};
@@ -16,11 +16,11 @@ pub trait Trait: system::Trait {
 
 decl_storage! {
 	trait Store for Module<T: Trait> as List {
-		TheList get(the_list): map u32 => T::AccountId;
-		TheCounter get(the_counter): u32;
+		TheList get(fn the_list): map u32 => T::AccountId;
+		TheCounter get(fn the_counter): u32;
 
-		LinkedList get(linked_list): linked_map u32 => T::AccountId;
-		LinkedCounter get(linked_counter): u32;
+		LinkedList get(fn linked_list): linked_map u32 => T::AccountId;
+		LinkedCounter get(fn linked_counter): u32;
 	}
 }
 
@@ -57,7 +57,7 @@ decl_module! {
 			Self::deposit_event(RawEvent::MemberAdded(who));
 
 			Ok(())
-		} 
+		}
 
 		// worst option
 		// -- only works if the list is *unbounded*

--- a/kitchen/modules/module-constant-config/src/lib.rs
+++ b/kitchen/modules/module-constant-config/src/lib.rs
@@ -18,7 +18,7 @@ pub trait Trait: system::Trait {
 
 decl_storage! {
 	trait Store for Module<T: Trait> as Example {
-        SingleValue get(single_value): u32;
+        SingleValue get(fn single_value): u32;
 	}
 }
 

--- a/kitchen/modules/schedule-on-finalize/src/lib.rs
+++ b/kitchen/modules/schedule-on-finalize/src/lib.rs
@@ -46,9 +46,9 @@ decl_event!(
 decl_storage! {
     trait Store for Module<T: Trait> as EventLoop {
         /// Outstanding tasks getter
-        Tasks get(tasks): map T::Hash => Option<Task<T::BlockNumber>>;
+        Tasks get(fn tasks): map T::Hash => Option<Task<T::BlockNumber>>;
         /// Dispatch Queue for tasks
-        TaskQ get(task_q): Vec<T::Hash>;
+        TaskQ get(fn task_q): Vec<T::Hash>;
     }
 }
 

--- a/kitchen/modules/simple-map/src/lib.rs
+++ b/kitchen/modules/simple-map/src/lib.rs
@@ -11,7 +11,7 @@ pub trait Trait: system::Trait {
 
 decl_storage! {
 	trait Store for Module<T: Trait> as SimpleMap {
-		SimpleMap get(simple_map): map T::AccountId => u32;
+		SimpleMap get(fn simple_map): map T::AccountId => u32;
 	}
 }
 

--- a/kitchen/modules/smpl-treasury/src/lib.rs
+++ b/kitchen/modules/smpl-treasury/src/lib.rs
@@ -46,7 +46,7 @@ decl_module! {
 decl_storage! {
     trait Store for Module<T: Trait> as STreasury {
         /// the amount, the address to which it is sent
-        SpendQ get(spend_q): Vec<(T::AccountId, BalanceOf<T>)>;
+        SpendQ get(fn spend_q): Vec<(T::AccountId, BalanceOf<T>)>;
     }
 }
 

--- a/kitchen/modules/social-network/src/lib.rs
+++ b/kitchen/modules/social-network/src/lib.rs
@@ -14,10 +14,10 @@ pub trait Trait: system::Trait {
 
 decl_storage! {
     trait Store for Module<T: Trait> as SocialNetwork {
-        MyFriend get(my_friend): map (T::AccountId, u32) => T::AccountId;
-        FriendsCount get(friends_count): map T::AccountId => u32;
-        AllFriends get(all_friends): map T::AccountId => Vec<T::AccountId>;
-        Blocked get(blocked): map T::AccountId => Vec<T::AccountId>;
+        MyFriend get(fn my_friend): map (T::AccountId, u32) => T::AccountId;
+        FriendsCount get(fn friends_count): map T::AccountId => u32;
+        AllFriends get(fn all_friends): map T::AccountId => Vec<T::AccountId>;
+        Blocked get(fn blocked): map T::AccountId => Vec<T::AccountId>;
     }
 }
 

--- a/kitchen/modules/storage-cache/src/lib.rs
+++ b/kitchen/modules/storage-cache/src/lib.rs
@@ -13,11 +13,11 @@ pub trait Trait: system::Trait {
 decl_storage! {
     trait Store for Module<T: Trait> as StorageCache {
         // copy type
-        SomeCopyValue get(some_copy_value): u32;
+        SomeCopyValue get(fn some_copy_value): u32;
 
         // clone type
-        KingMember get(king_member): T::AccountId;
-        GroupMembers get(group_members): Vec<T::AccountId>;
+        KingMember get(fn king_member): T::AccountId;
+        GroupMembers get(fn group_members): Vec<T::AccountId>;
     }
 }
 
@@ -56,7 +56,7 @@ decl_module! {
             Self::deposit_event(RawEvent::InefficientValueChange(another_calculation, now));
             Ok(())
         }
-        
+
         // (Copy) more efficient value change
         fn swap_value_w_copy(origin, some_val: u32) -> Result {
             let _ = ensure_signed(origin)?;
@@ -71,14 +71,14 @@ decl_module! {
         }
 
         //  (Clone) inefficient implementation
-        // swaps the king account if 
-        // (1) other account is member && 
+        // swaps the king account if
+        // (1) other account is member &&
         // (2) existing king isn't
         fn swap_king_no_cache(origin) -> Result {
             let new_king = ensure_signed(origin)?;
             let existing_king = <KingMember<T>>::get();
 
-            // only places a new account if 
+            // only places a new account if
             // (1) the existing account is not a member &&
             // (2) the new account is a member
             ensure!(!Self::is_member(existing_king), "is a member so maintains priority");
@@ -94,8 +94,8 @@ decl_module! {
         }
 
         //  (Clone) better implementation
-        // swaps the king account if 
-        // (1) other account is member && 
+        // swaps the king account if
+        // (1) other account is member &&
         // (2) existing king isn't
         fn swap_king_with_cache(origin) -> Result {
             let new_king = ensure_signed(origin)?;
@@ -103,7 +103,7 @@ decl_module! {
             // prefer to clone previous call rather than repeat call unnecessarily
             let old_king = existing_king.clone();
 
-            // only places a new account if 
+            // only places a new account if
             // (1) the existing account is not a member &&
             // (2) the new account is a member
             ensure!(!Self::is_member(existing_king), "is a member so maintains priority");

--- a/kitchen/modules/struct-storage/src/lib.rs
+++ b/kitchen/modules/struct-storage/src/lib.rs
@@ -23,8 +23,8 @@ pub struct SuperThing<Hash, Balance> {
 
 decl_storage! {
     trait Store for Module<T: Trait> as NestedStructs {
-        Value get(value): map u32 => Thing<T::Hash, T::Balance>;
-        SuperValue get(super_value): map u32 => SuperThing<T::Hash, T::Balance>;
+        Value get(fn value): map u32 => Thing<T::Hash, T::Balance>;
+        SuperValue get(fn super_value): map u32 => SuperThing<T::Hash, T::Balance>;
     }
 }
 

--- a/kitchen/modules/vec-set/src/lib.rs
+++ b/kitchen/modules/vec-set/src/lib.rs
@@ -12,9 +12,9 @@ pub trait Trait: system::Trait {
 
 decl_storage! {
 	trait Store for Module<T: Trait> as VecMap {
-        Members get(members): Vec<T::AccountId>;
-	    CurrentValues get(current_values): Vec<u32>;
-        NewValues get(new_values): Vec<u32>;
+        Members get(fn members): Vec<T::AccountId>;
+	    CurrentValues get(fn current_values): Vec<u32>;
+        NewValues get(fn new_values): Vec<u32>;
 	}
 }
 
@@ -53,7 +53,7 @@ decl_module! {
             current_values.append(&mut Self::new_values());
             Self::deposit_event(RawEvent::AppendVec(user));
             Ok(())
-        } // more examples in srml/elections-phragmen   
+        } // more examples in srml/elections-phragmen
 
         fn add_member(origin) -> Result {
             let new_member = ensure_signed(origin)?;

--- a/kitchen/modules/weights/src/lib.rs
+++ b/kitchen/modules/weights/src/lib.rs
@@ -9,7 +9,7 @@ pub trait Trait: system::Trait {}
 
 decl_storage! {
 	trait Store for Module<T: Trait> as SimpleMap {
-		StoredValue get(stored_value): u32;
+		StoredValue get(fn stored_value): u32;
 	}
 }
 

--- a/src/basics/README.md
+++ b/src/basics/README.md
@@ -13,13 +13,13 @@ use support::{decl_module, decl_event, decl_storage, StorageValue, StorageMap};
 use system::ensure_signed;
 ```
 
-The blockchain's runtime storage is configured in [`decl_storage`](https://crates.parity.io/srml_support/macro.decl_storage.html). 
+The blockchain's runtime storage is configured in [`decl_storage`](https://crates.parity.io/srml_support/macro.decl_storage.html).
 
 ```rust
 decl_storage! {
 	trait Store for Module<T: Trait> as HelloWorld {
-		pub LastValue get(last_value): u64; 
-		pub UserValue get(user_value): map T::AccountId => u64;
+		pub LastValue get(fn last_value): u64;
+		pub UserValue get(fn user_value): map T::AccountId => u64;
 	}
 }
 ```

--- a/src/dao/treasury.md
+++ b/src/dao/treasury.md
@@ -37,7 +37,7 @@ In [srml/treasury](https://github.com/paritytech/substrate/blob/master/srml/trea
 decl_storage! {
 	trait Store for Module<T: Trait> as STreasury {
 		/// the amount, the address to which it is sent
-		SpendQ get(spend_q): Vec<(T::AccountId, BalanceOf<T>)>;
+		SpendQ get(fn spend_q): Vec<(T::AccountId, BalanceOf<T>)>;
 	}
 }
 ```

--- a/src/declarative/ensure.md
+++ b/src/declarative/ensure.md
@@ -9,7 +9,7 @@ In the [set storage and iteration](../storage/iterate.md), a vector was stored i
 ```rust
 decl_storage! {
 	trait Store for Module<T: Trait> as VecMap {
-        Members get(members): Vec<T::AccountId>;
+        Members get(fn members): Vec<T::AccountId>;
 	}
 }
 ...

--- a/src/identity/social.md
+++ b/src/identity/social.md
@@ -23,7 +23,7 @@ MyFriend get(my_friend): map (T::AccountId, u32) => T::AccountId;
 FriendsCount get(friends_count): map T::AccountId => u32;
 ```
 
-Patterns that use mappings to emulate higher order data structures are common when managing runtime storage on Substrate. 
+Patterns that use mappings to emulate higher order data structures are common when managing runtime storage on Substrate.
 
 ## Social Network
 
@@ -42,15 +42,15 @@ decl_event!(
 );
 ```
 
-Our storage items contain a higher order array represented by the items described previously. 
+Our storage items contain a higher order array represented by the items described previously.
 
 ```rust
 decl_storage! {
   trait Store for Module<T: Trait> as SocialNetwork {
-    MyFriend get(my_friend): map (T::AccountId, u32) => T::AccountId;
-    FriendsCount get(friends_count): map T::AccountId => u32;
-    AllFriends get(all_friends): map T::AccountId => Vec<T::AccountId>;
-    Blocked get(blocked): map T::AccountId => Vec<T::AccountId>;
+    MyFriend get(fn my_friend): map (T::AccountId, u32) => T::AccountId;
+    FriendsCount get(fn friends_count): map T::AccountId => u32;
+    AllFriends get(fn all_friends): map T::AccountId => Vec<T::AccountId>;
+    Blocked get(fn blocked): map T::AccountId => Vec<T::AccountId>;
   }
 }
 ```

--- a/src/storage/cache.md
+++ b/src/storage/cache.md
@@ -1,17 +1,17 @@
 # Cache Multiple Calls
 *[`kitchen/modules/storage-cache`](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/modules/storage-cache)*
 
-Calls to runtime storage have an associated cost. With this in mind, multiple calls to storage values should be avoided when possible. 
+Calls to runtime storage have an associated cost. With this in mind, multiple calls to storage values should be avoided when possible.
 
 ```rust
 decl_storage! {
     trait Store for Module<T: Trait> as StorageCache {
         // copy type
-        SomeCopyValue get(some_copy_value): u32;
+        SomeCopyValue get(fn some_copy_value): u32;
 
         // clone type
-        KingMember get(king_member): T::AccountId;
-        GroupMembers get(group_members): Vec<T::AccountId>;
+        KingMember get(fn king_member): T::AccountId;
+        GroupMembers get(fn group_members): Vec<T::AccountId>;
     }
 }
 ```
@@ -58,13 +58,13 @@ decl_storage! {
     trait Store for Module<T: Trait> as StorageCache {
         // ...<copy type here>...
         // clone type
-        KingMember get(king_member): T::AccountId;
-        GroupMembers get(group_members): Vec<T::AccountId>;
+        KingMember get(fn king_member): T::AccountId;
+        GroupMembers get(fn group_members): Vec<T::AccountId>;
     }
 }
 ```
 
-The runtime methods enable the calling account to swap the `T::AccountId` value in storage if 
+The runtime methods enable the calling account to swap the `T::AccountId` value in storage if
 1. the existing storage value is not in `GroupMembers` AND
 2. the calling account is in `Group Members
 
@@ -74,7 +74,7 @@ fn swap_king_no_cache(origin) -> Result {
     let new_king = ensure_signed(origin)?;
     let existing_king = <KingMember<T>>::get();
 
-    // only places a new account if 
+    // only places a new account if
     // (1) the existing account is not a member &&
     // (2) the new account is a member
     ensure!(!Self::is_member(existing_king), "is a member so maintains priority");
@@ -129,7 +129,7 @@ fn swap_king_with_cache(origin) -> Result {
     // <no (unnecessary) storage call here>
     // place new king
     <KingMember<T>>::put(new_king.clone());
-    
+
     // use cached old_king value here
     Self::deposit_event(RawEvent::BetterKingSwap(old_king, new_king));
     Ok(())

--- a/src/storage/constants.md
+++ b/src/storage/constants.md
@@ -36,12 +36,12 @@ decl_module! {
 }
 ```
 
-This example manipulates a single value in storage declared as `SingleValue`. 
+This example manipulates a single value in storage declared as `SingleValue`.
 
 ```rust
 decl_storage! {
 	trait Store for Module<T: Trait> as Example {
-        SingleValue get(single_value): u32;
+        SingleValue get(fn single_value): u32;
 	}
 }
 ```

--- a/src/storage/double.md
+++ b/src/storage/double.md
@@ -11,14 +11,14 @@ decl_storage! {
         // member score (double map)
         MemberScore: double_map GroupIndex, twox_128(T::AccountId) => u32;
         // get group ID for member
-        GroupMembership get(group_membership): map T::AccountId => GroupIndex;
+        GroupMembership get(fn group_membership): map T::AccountId => GroupIndex;
         // for fast membership checks, see check-membership recipe for more details
-        AllMembers get(all_members): Vec<T::AccountId>;
+        AllMembers get(fn all_members): Vec<T::AccountId>;
 	}
 }
 ```
 
-For the purposes of this example,  store the scores of each members in a map that associates this `u32` value with two keys: (1) the hash of the member's `AccountId` and (2) a `GroupIndex` identifier. This allows for efficient removal of all values associated with a specific `GroupIndex` identifier. 
+For the purposes of this example,  store the scores of each members in a map that associates this `u32` value with two keys: (1) the hash of the member's `AccountId` and (2) a `GroupIndex` identifier. This allows for efficient removal of all values associated with a specific `GroupIndex` identifier.
 
 ```rust
 fn remove_group_score(origin, group: GroupIndex) -> Result {

--- a/src/storage/enumerated.md
+++ b/src/storage/enumerated.md
@@ -10,8 +10,8 @@ use support::{StorageValue, StorageMap};
 
 decl_storage! {
     trait Store for Module<T: Trait> as Example {
-        TheList get(the_list): map u32 => T::AccountId;
-        TheCounter get(the_counter): u32;
+        TheList get(fn the_list): map u32 => T::AccountId;
+        TheCounter get(fn the_counter): u32;
     }
 }
 ```
@@ -45,7 +45,7 @@ fn add_member(origin) -> Result {
     Self::deposit_event(RawEvent::MemberAdded(who));
 
     Ok(())
-} 
+}
 ```
 
 To remove an `AccountId`, call the `remove` method for the `StorageMap` type at the relevant index. In this case, it isn't necessary to update the indices of other `proposal`s; order is not relevant.
@@ -74,7 +74,7 @@ Because the code doesn't update the indices of other `AccountId`s in the map, it
 To preserve storage so that the list doesn't continue growing even after removing elements, invoke the **swap and pop** algorithm:
 1. swap the element to be removed with the element at the head of the *list* (the element with the highest index in the map)
 2. remove the element recently placed at the highest index
-3. decrement the `TheCount` value. 
+3. decrement the `TheCount` value.
 
 Use the *swap and pop* algorithm to remove elements from the list.
 
@@ -113,8 +113,8 @@ use support::{StorageMap, EnumerableStorageMap}; // no StorageValue necessary
 
 decl_storage! {
     trait Store for Module<T: Trait> as Example {
-        LinkedList get(linked_list): linked_map u32 => T::AccountId;
-        LinkedCounter get(linked_counter): u32;
+        LinkedList get(fn linked_list): linked_map u32 => T::AccountId;
+        LinkedCounter get(fn linked_counter): u32;
     }
 }
 ```

--- a/src/storage/iterate.md
+++ b/src/storage/iterate.md
@@ -14,7 +14,7 @@ To maintain a set of `AccountId` to establish group ownership of decisions, it i
 ```rust
 decl_storage! {
 	trait Store for Module<T: Trait> as VecMap {
-        Members get(members): Vec<T::AccountId>;
+        Members get(fn members): Vec<T::AccountId>;
 	}
 }
 ```
@@ -50,8 +50,8 @@ In this example, the helper method facilitates isolation of runtime storage acce
 ```rust
 decl_storage! {
 	trait Store for Module<T: Trait> as VecMap {
-	    CurrentValues get(current_values): Vec<u32>;
-        NewValues get(new_values): Vec<u32>;
+	    CurrentValues get(fn current_values): Vec<u32>;
+        NewValues get(fn new_values): Vec<u32>;
 	}
 }
 ```

--- a/src/storage/structs.md
+++ b/src/storage/structs.md
@@ -21,7 +21,7 @@ To use the `Encode` and `Decode` traits, it is necessary to import them from `su
 use support::codec::{Encode, Decode};
 ```
 
-By storing types in `MyStruct` as generics, it is possible to access custom Substrate types like `AccountId`, `Balance`, and `Hash`. 
+By storing types in `MyStruct` as generics, it is possible to access custom Substrate types like `AccountId`, `Balance`, and `Hash`.
 
 For example, to store a mapping from `AccountId` to `MyStruct` with `some_generic` as the `Balance` type and `some_other_generic` as the `Hash` type:
 
@@ -79,9 +79,9 @@ pub struct SuperThing <Hash, Balance> {
 decl_module! {
     pub struct Module<T: Trait> for enum Call where origin: T::Origin {
         fn set_mapping(_origin, key: u32, num: u32, hash: T::Hash, balance: T::Balance) -> Result {
-            let thing = Thing { 
-                            my_num: num, 
-                            my_hash: hash, 
+            let thing = Thing {
+                            my_num: num,
+                            my_hash: hash,
                             my_balance: balance
                         };
             <Value<T>>::insert(key, thing);
@@ -90,8 +90,8 @@ decl_module! {
 
         fn set_super_mapping(_origin, key: u32, super_num: u32, thing_key: u32) -> Result {
             let thing = Self::value(thing_key);
-            let super_thing = SuperThing { 
-                            my_super_num: super_num, 
+            let super_thing = SuperThing {
+                            my_super_num: super_num,
                             my_thing: thing
                         };
             <SuperValue<T>>::insert(key, super_thing);
@@ -102,8 +102,8 @@ decl_module! {
 
 decl_storage! {
     trait Store for Module<T: Trait> as RuntimeExampleStorage {
-        Value get(value): map u32 => Thing<T::Hash, T::Balance>;
-        SuperValue get(super_value): map u32 => SuperThing<T::Hash, T::Balance>;
+        Value get(fn value): map u32 => Thing<T::Hash, T::Balance>;
+        SuperValue get(fn super_value): map u32 => SuperThing<T::Hash, T::Balance>;
     }
 }
 ```

--- a/src/token/token.md
+++ b/src/token/token.md
@@ -10,11 +10,11 @@ To implement a simple token transfer with Substrate,
 ```rust
 decl_storage! {
   trait Store for Module<T: Trait> as TokenTransfer {
-    pub TotalSupply get(total_supply): u64 = 21000000; // (1)
+    pub TotalSupply get(fn total_supply): u64 = 21000000; // (1)
 
-    pub GetBalance get(get_balance): map T::AccountId => u64; // (3)
+    pub GetBalance get(fn get_balance): map T::AccountId => u64; // (3)
 
-    Init get(is_init): bool; // (2)
+    Init get(fn is_init): bool; // (2)
   }
 }
 ```
@@ -60,7 +60,7 @@ decl_module! {
       let updated_from_balance = sender_balance.checked_sub(value).ok_or("overflow in calculating balance")?;
       let receiver_balance = Self::get_balance(to.clone());
       let updated_to_balance = receiver_balance.checked_add(value).ok_or("overflow in calculating balance")?;
-      
+
       // reduce sender's balance
       <GetBalance<T>>::insert(sender.clone(), updated_from_balance);
 
@@ -68,7 +68,7 @@ decl_module! {
       <GetBalance<T>>::insert(to.clone(), updated_to_balance);
 
       Self::deposit_event(RawEvent::Transfer(sender, to, value));
-      
+
       Ok(())
     }
   }

--- a/src/tour/treasury.md
+++ b/src/tour/treasury.md
@@ -36,7 +36,7 @@ In [srml/treasury](https://github.com/paritytech/substrate/blob/master/srml/trea
 decl_storage! {
 	trait Store for Module<T: Trait> as STreasury {
 		/// the amount, the address to which it is sent
-		SpendQ get(spend_q): Vec<(T::AccountId, BalanceOf<T>)>;
+		SpendQ get(fn spend_q): Vec<(T::AccountId, BalanceOf<T>)>;
 	}
 }
 ```


### PR DESCRIPTION
Fixes #75 

This is my first pass at adding all the missing `fn`s. Please take a look that I didn't miss any.

I noticed a few additional oddities while doing this such as gen-random having two `decl_storage!`s. But I'd prefer to not let those things block this PR.