### PR TITLE
Update runtimes to match upstream

### DIFF
--- a/kitchen/node/src/cli.rs
+++ b/kitchen/node/src/cli.rs
@@ -38,7 +38,7 @@ pub fn run<I, T, E>(args: I, exit: E, version: VersionInfo) -> error::Result<()>
 				),
 			}.map_err(|e| format!("{:?}", e))
 		}),
-		ParseAndPrepare::BuildSpec(cmd) => cmd.run(load_spec),
+		ParseAndPrepare::BuildSpec(cmd) => cmd.run::<NoCustom, _, _, _>(load_spec),
 		ParseAndPrepare::ExportBlocks(cmd) => cmd.run_with_builder(|config: Config<_>|
 			Ok(new_full_start!(config).0), load_spec, exit),
 		ParseAndPrepare::ImportBlocks(cmd) => cmd.run_with_builder(|config: Config<_>|

--- a/kitchen/node/src/service.rs
+++ b/kitchen/node/src/service.rs
@@ -48,7 +48,7 @@ macro_rules! new_full_start {
 				let select_chain = select_chain.take()
 					.ok_or_else(|| substrate_service::Error::SelectChainRequired)?;
 				let (grandpa_block_import, grandpa_link) =
-					grandpa::block_import::<_, _, _, runtime::RuntimeApi, _, _>(
+					grandpa::block_import::<_, _, _, runtime::RuntimeApi, _>(
 						client.clone(), &*client, select_chain
 					)?;
 				let justification_import = grandpa_block_import.clone();
@@ -136,7 +136,9 @@ pub fn new_full<C: Send + Default + 'static>(config: Configuration<C, GenesisCon
 		gossip_duration: Duration::from_millis(333),
 		justification_period: 512,
 		name: Some(name),
+		observer_enabled: true,
 		keystore: Some(service.keystore()),
+		is_authority,
 	};
 
 	match (is_authority, disable_grandpa) {
@@ -194,8 +196,8 @@ pub fn new_light<C: Send + Default + 'static>(config: Configuration<C, GenesisCo
 			let fetch_checker = fetcher
 				.map(|fetcher| fetcher.checker().clone())
 				.ok_or_else(|| "Trying to start light import queue without active fetch checker")?;
-			let grandpa_block_import = grandpa::light_block_import::<_, _, _, RuntimeApi, _>(
-				client.clone(), backend, Arc::new(fetch_checker), client.clone()
+			let grandpa_block_import = grandpa::light_block_import::<_, _, _, RuntimeApi>(
+				client.clone(), backend, &*client.clone(), Arc::new(fetch_checker)
 			)?;
 
 			let finality_proof_import = grandpa_block_import.clone();

--- a/kitchen/runtimes/super-runtime/Cargo.toml
+++ b/kitchen/runtimes/super-runtime/Cargo.toml
@@ -136,10 +136,27 @@ git = 'https://github.com/paritytech/substrate.git'
 package = 'sr-primitives'
 branch = 'master'
 
-[dependencies.client]
+[dependencies.sr-api]
 default_features = false
 git = 'https://github.com/paritytech/substrate.git'
-package = 'substrate-client'
+branch = 'master'
+
+[dependencies.block-builder-api]
+default_features = false
+git = 'https://github.com/paritytech/substrate.git'
+package = 'substrate-block-builder-runtime-api'
+branch = 'master'
+
+[dependencies.tx-pool-api]
+default_features = false
+git = 'https://github.com/paritytech/substrate.git'
+package = 'substrate-transaction-pool-runtime-api'
+branch = 'master'
+
+[dependencies.inherents]
+default_features = false
+git = 'https://github.com/paritytech/substrate.git'
+package = 'substrate-inherents'
 branch = 'master'
 
 [dependencies.offchain-primitives]
@@ -156,7 +173,7 @@ wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.
 default = ["std"]
 std = [
 	"parity-scale-codec/std",
-	"client/std",
+	"sr-api/std",
 	"rstd/std",
 	"runtime-io/std",
 	"support/std",
@@ -191,5 +208,8 @@ std = [
 	"basic-token/std",
 	"check-membership/std",
 	"schedule-on-finalize/std",
-	"transaction-payment/std"
+	"transaction-payment/std",
+	"block-builder-api/std",
+	"tx-pool-api/std",
+	"inherents/std",
 ]

--- a/kitchen/runtimes/super-runtime/src/lib.rs
+++ b/kitchen/runtimes/super-runtime/src/lib.rs
@@ -18,12 +18,9 @@ use sr_primitives::{
 use sr_primitives::traits::{NumberFor, BlakeTwo256, Block as BlockT, StaticLookup, Verify, ConvertInto};
 use sr_primitives::weights::Weight;
 use babe::{AuthorityId as BabeId, SameAuthoritiesForever};
-use grandpa::{AuthorityId as GrandpaId, AuthorityWeight as GrandpaWeight};
+use grandpa::AuthorityList as GrandpaAuthorityList;
 use grandpa::fg_primitives;
-use client::{
-	block_builder::api::{CheckInherentsResult, InherentData, self as block_builder_api},
-	runtime_api as client_api, impl_runtime_apis
-};
+use sr_api::impl_runtime_apis;
 use version::RuntimeVersion;
 #[cfg(feature = "std")]
 use version::NativeVersion;
@@ -98,10 +95,8 @@ pub mod opaque {
 
 	impl_opaque_keys! {
 		pub struct SessionKeys {
-			#[id(key_types::GRANDPA)]
-			pub grandpa: GrandpaId,
-			#[id(key_types::BABE)]
-			pub babe: BabeId,
+			pub grandpa: Grandpa,
+			pub babe: Babe,
 		}
 	}
 }
@@ -395,7 +390,7 @@ pub type CheckedExtrinsic = generic::CheckedExtrinsic<AccountId, Call, SignedExt
 pub type Executive = executive::Executive<Runtime, Block, system::ChainContext<Runtime>, Runtime, AllModules>;
 
 impl_runtime_apis! {
-	impl client_api::Core<Block> for Runtime {
+	impl sr_api::Core<Block> for Runtime {
 		fn version() -> RuntimeVersion {
 			VERSION
 		}
@@ -409,7 +404,7 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl client_api::Metadata<Block> for Runtime {
+	impl sr_api::Metadata<Block> for Runtime {
 		fn metadata() -> OpaqueMetadata {
 			Runtime::metadata().into()
 		}
@@ -424,11 +419,14 @@ impl_runtime_apis! {
 			Executive::finalize_block()
 		}
 
-		fn inherent_extrinsics(data: InherentData) -> Vec<<Block as BlockT>::Extrinsic> {
+		fn inherent_extrinsics(data: inherents::InherentData) -> Vec<<Block as BlockT>::Extrinsic> {
 			data.create_extrinsics()
 		}
 
-		fn check_inherents(block: Block, data: InherentData) -> CheckInherentsResult {
+		fn check_inherents(
+			block: Block,
+			data: inherents::InherentData
+		) -> inherents::CheckInherentsResult {
 			data.check_extrinsics(&block)
 		}
 
@@ -437,7 +435,7 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl client_api::TaggedTransactionQueue<Block> for Runtime {
+	impl tx_pool_api::TaggedTransactionQueue<Block> for Runtime {
 		fn validate_transaction(tx: <Block as BlockT>::Extrinsic) -> TransactionValidity {
 			Executive::validate_transaction(tx)
 		}
@@ -450,7 +448,7 @@ impl_runtime_apis! {
 	}
 
 	impl fg_primitives::GrandpaApi<Block> for Runtime {
-		fn grandpa_authorities() -> Vec<(GrandpaId, GrandpaWeight)> {
+		fn grandpa_authorities() -> GrandpaAuthorityList {
 			Grandpa::grandpa_authorities()
 		}
 	}
@@ -475,7 +473,6 @@ impl_runtime_apis! {
 
 	impl substrate_session::SessionKeys<Block> for Runtime {
 		fn generate_session_keys(seed: Option<Vec<u8>>) -> Vec<u8> {
-			let seed = seed.as_ref().map(|s| rstd::str::from_utf8(&s).expect("Seed is an utf8 string"));
 			opaque::SessionKeys::generate(seed)
 		}
 	}

--- a/kitchen/runtimes/weight-fee-runtime/Cargo.toml
+++ b/kitchen/runtimes/weight-fee-runtime/Cargo.toml
@@ -122,10 +122,27 @@ git = 'https://github.com/paritytech/substrate.git'
 package = 'sr-primitives'
 branch = 'master'
 
-[dependencies.client]
+[dependencies.sr-api]
 default_features = false
 git = 'https://github.com/paritytech/substrate.git'
-package = 'substrate-client'
+branch = 'master'
+
+[dependencies.block-builder-api]
+default_features = false
+git = 'https://github.com/paritytech/substrate.git'
+package = 'substrate-block-builder-runtime-api'
+branch = 'master'
+
+[dependencies.tx-pool-api]
+default_features = false
+git = 'https://github.com/paritytech/substrate.git'
+package = 'substrate-transaction-pool-runtime-api'
+branch = 'master'
+
+[dependencies.inherents]
+default_features = false
+git = 'https://github.com/paritytech/substrate.git'
+package = 'substrate-inherents'
 branch = 'master'
 
 [dependencies.offchain-primitives]
@@ -142,7 +159,7 @@ wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.
 default = ["std"]
 std = [
 	"parity-scale-codec/std",
-	"client/std",
+	"sr-api/std",
 	"rstd/std",
 	"runtime-io/std",
 	"support/std",
@@ -164,5 +181,8 @@ std = [
 	"offchain-primitives/std",
 	"substrate-session/std",
 	"transaction-payment/std",
+	"block-builder-api/std",
+	"tx-pool-api/std",
+	"inherents/std",
 	"weights/std",
 ]


### PR DESCRIPTION
Upstream Substrate APIs have had some breaking changes recently including:
* https://github.com/paritytech/substrate/pull/4086
* https://github.com/paritytech/substrate/pull/3985

This PR updates the recipe runtimes to build against the new APIs
- [x] Super Runtime
- [x] Weight Fee Runtime

This solves #79 as reported by @dhruvinparikh