### PR TITLE
fix signature of Currency::transfer method in two modules

### DIFF
--- a/kitchen/modules/reservable-currency/src/lib.rs
+++ b/kitchen/modules/reservable-currency/src/lib.rs
@@ -1,7 +1,7 @@
 //! borrows collateral locking logic from treasury/lib.rs
 // demonstrates https://crates.parity.io/srml_support/traits/trait.ReservableCurrency.html
 use support::traits::{
-	Currency, OnUnbalanced, ReservableCurrency,
+	Currency, ReservableCurrency, ExistenceRequirement::AllowDeath
 };
 use support::{decl_event, decl_module, dispatch::Result};
 use system::ensure_signed;
@@ -23,7 +23,7 @@ decl_event!(
         AccountId = <T as system::Trait>::AccountId,
         Balance = BalanceOf<T>,
         BlockNumber = <T as system::Trait>::BlockNumber,
-    {   
+    {
         LockFunds(AccountId, Balance, BlockNumber),
         UnlockFunds(AccountId, Balance, BlockNumber),
         // sender, dest, amount, block number
@@ -63,7 +63,7 @@ decl_module! {
         pub fn transfer_funds(origin, dest: T::AccountId, amount: BalanceOf<T>) -> Result {
             let sender = ensure_signed(origin)?;
 
-            T::Currency::transfer(&sender, &dest, amount)?;
+            T::Currency::transfer(&sender, &dest, amount, AllowDeath)?;
 
             let now = <system::Module<T>>::block_number();
 
@@ -73,15 +73,15 @@ decl_module! {
 
         // might be useful in closed economic systems
         pub fn unreserve_and_transfer(
-            origin, 
-            to_punish: T::AccountId, 
-            dest: T::AccountId, 
+            origin,
+            to_punish: T::AccountId,
+            dest: T::AccountId,
             collateral: BalanceOf<T>
         ) -> Result {
             let _ = ensure_signed(origin)?; // dangerous because can be called with any signature (so dont do this in practice ever!)
 
             let unreserved = T::Currency::unreserve(&to_punish, collateral);
-            T::Currency::transfer(&to_punish, &dest, unreserved)?;
+            T::Currency::transfer(&to_punish, &dest, unreserved, AllowDeath)?;
 
             let now = <system::Module<T>>::block_number();
             Self::deposit_event(RawEvent::TransferFunds(to_punish, dest, unreserved, now));

--- a/kitchen/modules/smpl-treasury/src/lib.rs
+++ b/kitchen/modules/smpl-treasury/src/lib.rs
@@ -3,7 +3,7 @@
 
 use runtime_primitives::traits::{AccountIdConversion, Zero};
 use runtime_primitives::ModuleId;
-use support::traits::{Currency, Get};
+use support::traits::{Currency, Get, ExistenceRequirement::AllowDeath};
 use support::{decl_event, decl_module, decl_storage, dispatch::Result, StorageValue};
 use system::{self, ensure_signed};
 use rstd::prelude::*;
@@ -29,7 +29,7 @@ decl_module! {
         fn proxy_transfer(origin, dest: T::AccountId, amount: BalanceOf<T>) -> Result {
             let sender = ensure_signed(origin)?;
 
-            let _ = T::Currency::transfer(&sender, &Self::account_id(), amount)?;
+            let _ = T::Currency::transfer(&sender, &Self::account_id(), amount, AllowDeath)?;
             <SpendQ<T>>::mutate(|requests| requests.push((dest.clone(), amount)));
             Self::deposit_event(RawEvent::ProxyTransfer(dest, amount));
             Ok(())
@@ -83,7 +83,7 @@ impl<T: Trait> Module<T> {
         <SpendQ<T>>::get().into_iter().for_each(|request| {
             if request.1 <= budget_remaining {
                 budget_remaining -= request.1;
-                let _ = T::Currency::transfer(&Self::account_id(), &request.0, request.1);
+                let _ = T::Currency::transfer(&Self::account_id(), &request.0, request.1, AllowDeath);
             }
         });
     }

--- a/kitchen/modules/smpl-treasury/src/lib.rs
+++ b/kitchen/modules/smpl-treasury/src/lib.rs
@@ -51,16 +51,16 @@ decl_storage! {
 }
 
 decl_event!(
-	pub enum Event<T>
-	where
-		Balance = BalanceOf<T>,
-		<T as system::Trait>::AccountId
-	{
-		/// New spend requets.
-		ProxyTransfer(AccountId, Balance),
+    pub enum Event<T>
+    where
+        Balance = BalanceOf<T>,
+        <T as system::Trait>::AccountId
+    {
+        /// New spend requets.
+        ProxyTransfer(AccountId, Balance),
         /// New spend execution
         SpendExecute(AccountId, Balance),
-	}
+    }
 );
 
 impl<T: Trait> Module<T> {

--- a/kitchen/modules/smpl-treasury/src/lib.rs
+++ b/kitchen/modules/smpl-treasury/src/lib.rs
@@ -3,7 +3,7 @@
 
 use runtime_primitives::traits::{AccountIdConversion, Zero};
 use runtime_primitives::ModuleId;
-use support::traits::{Currency, Get, ReservableCurrency};
+use support::traits::{Currency, Get};
 use support::{decl_event, decl_module, decl_storage, dispatch::Result, StorageValue};
 use system::{self, ensure_signed};
 use rstd::prelude::*;
@@ -16,7 +16,7 @@ pub trait Trait: system::Trait {
     /// The overarching event type.
     type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
     /// The staking balance.
-    type Currency: Currency<Self::AccountId> + ReservableCurrency<Self::AccountId>;
+    type Currency: Currency<Self::AccountId>;
     /// Period between successive spends.
     type SpendPeriod: Get<Self::BlockNumber>;
 }

--- a/kitchen/runtimes/super-genesis/Cargo.toml
+++ b/kitchen/runtimes/super-genesis/Cargo.toml
@@ -9,5 +9,5 @@ package = 'super-runtime'
 path = '../super-runtime'
 
 [dependencies]
-babe-primitives = { package = "substrate-consensus-babe-primitives", git = "https://github.com/paritytech/substrate", branch = "master" }
-grandpa-primitives = { package = "substrate-finality-grandpa-primitives", git = "https://github.com/paritytech/substrate", branch = "master" }
+babe-primitives = { package = "substrate-consensus-babe-primitives", git = "https://github.com/paritytech/substrate", rev = '6ae3b6c4ddc03d4cdb10bd1d417b95d20f4c1b6e' }
+grandpa-primitives = { package = "substrate-finality-grandpa-primitives", git = "https://github.com/paritytech/substrate", rev = '6ae3b6c4ddc03d4cdb10bd1d417b95d20f4c1b6e' }

--- a/kitchen/runtimes/weight-fee-genesis/Cargo.toml
+++ b/kitchen/runtimes/weight-fee-genesis/Cargo.toml
@@ -9,5 +9,5 @@ package = 'weight-fee-runtime'
 path = '../weight-fee-runtime'
 
 [dependencies]
-babe-primitives = { package = "substrate-consensus-babe-primitives", git = "https://github.com/paritytech/substrate", branch = "master" }
-grandpa-primitives = { package = "substrate-finality-grandpa-primitives", git = "https://github.com/paritytech/substrate", branch = "master" }
+babe-primitives = { package = "substrate-consensus-babe-primitives", git = "https://github.com/paritytech/substrate", rev = '6ae3b6c4ddc03d4cdb10bd1d417b95d20f4c1b6e' }
+grandpa-primitives = { package = "substrate-finality-grandpa-primitives", git = "https://github.com/paritytech/substrate", rev = '6ae3b6c4ddc03d4cdb10bd1d417b95d20f4c1b6e' }


### PR DESCRIPTION
This fixes the build issues about incorrect number of parameters in calls to `transfer`.

This was hard to diagnose because I was relying on the docs at https://crates.parity.io/srml_support/traits/trait.Currency.html#tymethod.transfer which still describe a three-parameter signature even though there are 4 parameters.