### PR TITLE
Add both runtimes and node to workspace

### DIFF
--- a/kitchen/Cargo.toml
+++ b/kitchen/Cargo.toml
@@ -27,7 +27,7 @@ members = [
   "modules/weights",
   "runtimes/super-runtime",
   "runtimes/super-genesis",
-  # "runtimes/weight-fee-runtime",
-  # "runtimes/weight-fee-genesis",
-  # "node",
+  "runtimes/weight-fee-runtime",
+  "runtimes/weight-fee-genesis",
+  "node",
 ]


### PR DESCRIPTION
This PR adds all the expected-working code to the kitchen's main cargo workspace. It fixes #83.

Previously not all packages were included as workspace members in `kitchen/Cargo.toml`. This was to reduce the load on our CircleCI configuration. As a side effect the node build did not work as described in #83 .

Since @4meta5 got github actions working in #95, CI is no longer holding us back, and this change should work.