### PR TITLE
Fix broken links

### DIFF
--- a/src/base/rust.md
+++ b/src/base/rust.md
@@ -5,7 +5,7 @@ To be productive with [substrate](https://github.com/substrate) requires some fa
 ## API Design
 
 To become more familiar with commmon design patterns in Rust, the following links might be helpful:
-* [Official Rust API Guidelines](https://rust-lang-nursery.github.io/api-guidelines/about.html)
+* [Official Rust API Guidelines](https://rust-lang.github.io/api-guidelines/about.html)
 * [Rust Unofficial Design Patterns](https://github.com/rust-unofficial/patterns)
 * [Elegant Library API Guidelines](https://deterministic.space/elegant-apis-in-rust.html)
 
@@ -14,9 +14,9 @@ To become more familiar with commmon design patterns in Rust, the following link
 To optimize runtime performance, Substrate developers should make use of iterators, traits, and Rust's other "*zero cost* abstractions":
 * [Abstraction without overhead: traits in Rust](https://blog.rust-lang.org/2015/05/11/traits.html), [related conference talk](https://www.youtube.com/watch?v=Sn3JklPAVLk)
 * [Effectively Using Iterators in Rust](https://hermanradtke.com/2015/06/22/effectively-using-iterators-in-rust.html)
-* [Achieving Warp Speed with Rust](http://troubles.md/posts/rust-optimization/) 
+* [Achieving Warp Speed with Rust](http://troubles.md/posts/rust-optimization/)
 
-It is not (immediately) necessary to become familiar with multithreading because the runtime operates in a [single-threaded context](https://www.tutorialspoint.com/single-threaded-and-multi-threaded-processes). Even so, an optimized [substrate node](https://github.com/paritytech/substrate/tree/master/node) architecture will use a custom RPC interface. Moreover, the runtime might take advantage of the [offchain workers API](https://substrate.dev/docs/en/next/overview/off-chain-workers) to minimize the computation executed on-chain. Effectively using these features requires increased familiarity with advanced Rust. 
+It is not (immediately) necessary to become familiar with multithreading because the runtime operates in a [single-threaded context](https://www.tutorialspoint.com/single-threaded-and-multi-threaded-processes). Even so, the runtime might take advantage of the [offchain workers API](https://substrate.dev/docs/en/next/overview/off-chain-workers) to minimize the computation executed on-chain. Effectively using these features requires increased familiarity with advanced Rust.
 
 For a high-level overview of concurrency in Rust, Stjepan Glavina provides the following descriptions in [Lock-free Rust: Crossbeam in 2019](https://stjepang.github.io/2019/01/29/lock-free-rust-crossbeam-in-2019.html):
 * **[Rayon](https://github.com/rayon-rs/rayon)** splits your data into distinct pieces, gives each piece to a thread to do some kind of computation on it, and finally aggregates results. Its goal is to distribute CPU-intensive tasks onto a thread pool.
@@ -28,7 +28,7 @@ For a high-level overview of concurrency in Rust, Stjepan Glavina provides the f
 
 **Conceptual**
 * [Introduction to Async/Await Programming (withoutboats/wakers-i)](https://boats.gitlab.io/blog/post/wakers-i/)
-* [Futures (by Aaron Turon)](http://aturon.github.io/2016/08/11/futures/)
+* [Futures (by Aaron Turon)](https://aturon.github.io/tech/2016/08/11/futures/)
 * [RustLatam 2019 - Without Boats: Zero-Cost Async IO](https://www.youtube.com/watch?v=skos4B5x7qE)
 
 **Projects**

--- a/src/base/setup.md
+++ b/src/base/setup.md
@@ -11,7 +11,7 @@ curl https://getsubstrate.io -sSf | bash
 
 ### For Windows
 
-Refer to our [Substrate Installation on Windows](https://substrate.dev/docs/en/next/getting-started#getting-started-on-windows).
+Refer to our [Substrate Installation on Windows](https://substrate.dev/docs/en/overview/getting-started#getting-started-on-windows).
 
 ## Kitchen Overview
 

--- a/src/declarative/README.md
+++ b/src/declarative/README.md
@@ -12,6 +12,6 @@ Each of the recipes in this section are oriented around increasing
 
 ## Pallet Development Criteria <a name = "criteria"></a>
 
-1. Pallets should be relatively independent pieces of code; if your pallet is tied to many other pallets, it should be a smart contract. See the [substrate-contracts-workshop](https://github.com/shawntabrizi/substrate-contracts-workshop) for more details with respect to smart contract programming on Substrate. Also, *use traits for abstracting shared behavior*. 
+1. Pallets should be relatively independent pieces of code; if your pallet is tied to many other pallets, it should be a smart contract. See the [substrate-contracts-workshop](https://github.com/shawntabrizi/substrate-contracts-workshop) for more details with respect to smart contract programming on Substrate. Also, *use traits for abstracting shared behavior*.
 
-2. It should not be possible for your code to panic after storage changes. Poor error handling in Substrate can *brick* the blockchain, rendering it useless thereafter. With this in mind, it is very important to structure code according to declarative, condition-oriented design patterns. *See more in the [declarative programming](./cop.md) section.*
+2. It should not be possible for your code to panic after storage changes. Poor error handling in Substrate can *brick* the blockchain, rendering it useless thereafter. With this in mind, it is very important to structure code according to declarative, condition-oriented design patterns.

--- a/src/declarative/ensure.md
+++ b/src/declarative/ensure.md
@@ -34,10 +34,9 @@ fn member_action(origin) -> Result {
 
 Indeed, this pattern of extracting runtime checks into separate functions and invoking the `ensure` macro in their place is useful. It produces readable code and encourages targeted testing to more easily identify the source of logic errors.
 
-*This [github comment](https://github.com/shawntabrizi/substrate-collectables-workshop/pull/55#discussion_r258147961) might help when visualizing declarative patterns in practice.*
-TODO: Ellaborate github comment as it is no longer accessible.
+*This [github comment](https://github.com/substrate-developer-hub/substrate-collectables-workshop/pull/55#discussion_r258147961) might help when visualizing declarative patterns in practice.*
+TODO: Ellaborate github comment
 
 **Bonus Reading**
 * [Design for Testability](https://blog.nelhage.com/2016/03/design-for-testability/)
 * [Condition-Oriented Programming](https://www.parity.io/condition-oriented-programming/)
-* [Declarative Smart Contracts](https://www.tokendaily.co/blog/declarative-smart-contracts)

--- a/src/declarative/ensure.md
+++ b/src/declarative/ensure.md
@@ -35,7 +35,6 @@ fn member_action(origin) -> Result {
 Indeed, this pattern of extracting runtime checks into separate functions and invoking the `ensure` macro in their place is useful. It produces readable code and encourages targeted testing to more easily identify the source of logic errors.
 
 *This [github comment](https://github.com/substrate-developer-hub/substrate-collectables-workshop/pull/55#discussion_r258147961) might help when visualizing declarative patterns in practice.*
-TODO: Ellaborate github comment
 
 **Bonus Reading**
 * [Design for Testability](https://blog.nelhage.com/2016/03/design-for-testability/)

--- a/src/storage/childtries.md
+++ b/src/storage/childtries.md
@@ -51,7 +51,7 @@ fn kv_put(index: ObjectCount, who: &T::AccountId, value_type: &ValueType) {
 }
 ```
 
-The code in [`kitchen/pallets/child-trie`](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/pallets/child-trie) demonstrates a minimal way of organizing the basic child-trie api methods (as done in [`polkadot/runtime/crowdfund`](https://github.com/paritytech/polkadot/blob/master/runtime/src/crowdfund.rs)). It separates out the generation of the child trie id from the index with a runtime method `id_from_index`.
+The code in [`kitchen/pallets/child-trie`](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/pallets/child-trie) demonstrates a minimal way of organizing the basic child-trie api methods (as done in [`polkadot/runtime/crowdfund`](https://github.com/paritytech/polkadot/blob/c003d73c65cdcc0367340db09522c91d1d3851fc/runtime/common/src/crowdfund.rs)). It separates out the generation of the child trie id from the index with a runtime method `id_from_index`.
 
 ```rust, ignore
 pub fn id_from_index(index: ObjectCount) -> Vec<u8> {

--- a/src/storage/constants.md
+++ b/src/storage/constants.md
@@ -46,7 +46,7 @@ decl_storage! {
 }
 ```
 
-`SingleValue` is set to `0` every `ClearFrequency` number of blocks. *This logic is in the `on_finalize` block and is covered in deeper detail in the [Blockchain Event Loop](../tour/schedule.md) recipe.*
+`SingleValue` is set to `0` every `ClearFrequency` number of blocks in the `on_finalize` function that runs at the end of blocks execution.
 
 ```rust, ignore
 fn on_finalize(n: T::BlockNumber) {

--- a/src/storage/enumerated.md
+++ b/src/storage/enumerated.md
@@ -26,7 +26,7 @@ This recipe answers those questions with snippets from relevant code samples:
 * [Swap and Pop for Ordered Lists](#swappop)
 * [Linked Map for Simplified Enumeration](#linkedmap)
 
-**Note**: it is important to properly handle overflow/underflow](../declarative/safemath.md) and verify [other relevant conditions](../declarative) for safety
+**Note**: it is important to properly handle [overflow/underflow](../declarative/safemath.md) and verify [other relevant conditions](../declarative) for safety
 
 ## Adding/Removing Elements in an Unbounded List <a name = "unbounded"></a>
 

--- a/src/storage/enumerated.md
+++ b/src/storage/enumerated.md
@@ -26,7 +26,7 @@ This recipe answers those questions with snippets from relevant code samples:
 * [Swap and Pop for Ordered Lists](#swappop)
 * [Linked Map for Simplified Enumeration](#linkedmap)
 
-**Note**: it is important to properly handle overflow/underflow](../declarative/safemath.md) and verify [other relevant conditions](../declarative/README.md) for safety
+**Note**: it is important to properly handle overflow/underflow](../declarative/safemath.md) and verify [other relevant conditions](../declarative) for safety
 
 ## Adding/Removing Elements in an Unbounded List <a name = "unbounded"></a>
 

--- a/src/storage/enumerated.md
+++ b/src/storage/enumerated.md
@@ -26,7 +26,7 @@ This recipe answers those questions with snippets from relevant code samples:
 * [Swap and Pop for Ordered Lists](#swappop)
 * [Linked Map for Simplified Enumeration](#linkedmap)
 
-**Note**: it is important to properly handle [overflow/underflow](../declarative/overunder.md) and verify [other relevant conditions](../declarative/README.md) for safety
+**Note**: it is important to properly handle overflow/underflow](../declarative/safemath.md) and verify [other relevant conditions](../declarative/README.md) for safety
 
 ## Adding/Removing Elements in an Unbounded List <a name = "unbounded"></a>
 

--- a/src/testing/externalities.md
+++ b/src/testing/externalities.md
@@ -137,6 +137,6 @@ fn fake_test2() {
 }
 ```
 
-The test environment mocked above is actually used for the cursory and incomplete test `eras_change_correctly`. This test guided the structure of the if condition in `on_initialize` to periodically reset the `SignalBank` and increment the `Era`. *If interested in learning more about this pallet's TDD, read [more here](https://github.com/substrate-developer-hub/recipes/blob/master/src/testing/schedule.md).*
+The test environment mocked above is actually used for the cursory and incomplete test `eras_change_correctly`. This test guided the structure of the if condition in `on_initialize` to periodically reset the `SignalBank` and increment the `Era`.
 
 For more examples of the mock runtime scaffolding pattern used in [`execution-schedule`](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/pallets/execution-schedule), see `balances/mock.rs` and `contract/tests.rs`.

--- a/src/traits/README.md
+++ b/src/traits/README.md
@@ -2,7 +2,7 @@
 
 Pallets may access their own associated types as well as the associated types of other pallets in the runtime. This is seen in most pallets when they access `frame_system`'s associated `AccountId` type. All pallets are tightly coupled to `frame_system` through this syntax, and thus have access to its types. You may optionally couple to additional pallets in this way.
 
-> Another option to loosely couple to other pallets is discussed further later.
+> Another option, loosely coupling to other pallets, is discussed further later.
 
 ```rust, ignore
 pub trait Trait: system::Trait {}
@@ -14,7 +14,6 @@ This provides access to `Hash`, `AccountId`, and `BlockNumber` anywhere that spe
 
 - [Currency Types](./currency.md)
 - [Transaction Fees](./fees.md)
-- [Mock Runtime for Unit Testing](./mock.md)
 
 ## support::traits
 

--- a/src/traits/fees.md
+++ b/src/traits/fees.md
@@ -1,6 +1,6 @@
 # Economic Security in Substrate <a name = "sec"></a>
 
-An algorithm is considered to be *efficient* if its running time is polynomial in the size of the input, and *highly efficient* if its running time is linear in the size of the input. **It is important for all on-chain algorithms to be highly efficient, because they must scale linearly as the size of the Polkadot network grows**. In contrast, off-chain algorithms are only required to be efficient. - [Web3 Research](http://research.web3.foundation/en/latest/polkadot/NPoS/1.intro/)
+An algorithm is considered to be *efficient* if its running time is polynomial in the size of the input, and *highly efficient* if its running time is linear in the size of the input. **It is important for all on-chain algorithms to be highly efficient, because they must scale linearly as the size of the Polkadot network grows**. In contrast, off-chain algorithms are only required to be efficient. - [Web3 Research](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html)
 
 Any resources used by a transaction must explicitly be paid for, and it is a pallet author's job to ensure that appropriate fees are required. Maintaining the balance between **resources used** and **price paid** is an important design activity for runtime security.
 


### PR DESCRIPTION
Thanks @jimmychu0807 for pointing me to drlinkcheck.com . It turns out there were several broken links hiding in the recipes.

This PR is a stop-gap fix to remove the broken links. Where possible they are pointed to the correct current location. When linked external content is removed or unavailable, the links are removed. Some internal links are also removed.

As with #117, this has led me to realize that a larger reorganization of the recipes is in order. My intent atm is to do that reorganization along with the update for Substrate 2.0