### PR TITLE
Demonstrate colelcting fees in seperate asset.

### DIFF
--- a/kitchen/Cargo.lock
+++ b/kitchen/Cargo.lock
@@ -529,7 +529,6 @@ version = "0.1.0"
 dependencies = [
  "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
  "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
- "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
  "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-core 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
  "sp-io 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
@@ -2708,6 +2707,19 @@ dependencies = [
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
  "sp-inherents 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
+ "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
+ "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
+]
+
+[[package]]
+name = "pallet-generic-asset"
+version = "2.0.0"
+source = "git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54#3e651110aa06aa835790df63410a29676243fc54"
+dependencies = [
+ "frame-support 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
+ "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
+ "parity-scale-codec 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "sp-runtime 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
  "sp-std 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
 ]
@@ -5883,6 +5895,7 @@ dependencies = [
  "frame-system 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
  "pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
  "pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
+ "pallet-generic-asset 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
  "pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
  "pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
  "pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)",
@@ -6302,6 +6315,7 @@ dependencies = [
 "checksum pallet-babe 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)" = "<none>"
 "checksum pallet-balances 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)" = "<none>"
 "checksum pallet-finality-tracker 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)" = "<none>"
+"checksum pallet-generic-asset 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)" = "<none>"
 "checksum pallet-grandpa 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)" = "<none>"
 "checksum pallet-indices 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)" = "<none>"
 "checksum pallet-randomness-collective-flip 2.0.0 (git+https://github.com/paritytech/substrate.git?rev=3e651110aa06aa835790df63410a29676243fc54)" = "<none>"

--- a/kitchen/runtimes/weight-fee-genesis/src/lib.rs
+++ b/kitchen/runtimes/weight-fee-genesis/src/lib.rs
@@ -1,6 +1,6 @@
 use runtime::{
 	AccountId, BabeConfig, BalancesConfig, GenesisConfig, GrandpaConfig,
-	SudoConfig, IndicesConfig, SystemConfig, WASM_BINARY,
+	SudoConfig, IndicesConfig, SystemConfig, GenericAssetConfig, WASM_BINARY,
 };
 use babe_primitives::{AuthorityId as BabeId};
 use grandpa_primitives::{AuthorityId as GrandpaId};
@@ -20,6 +20,17 @@ pub fn testnet_genesis(initial_authorities: Vec<(AccountId, AccountId, GrandpaId
 		balances: Some(BalancesConfig {
 			balances: endowed_accounts.iter().cloned().map(|k|(k, 1 << 60)).collect(),
 			vesting: vec![],
+		}),
+		generic_asset: Some(GenericAssetConfig {
+			assets: vec![
+				13,
+				1,
+			],
+			initial_balance: 10u128.pow(18 + 9), // 1 billion token with 18 decimals
+			endowed_accounts: endowed_accounts.clone().into_iter().map(Into::into).collect(),
+			next_asset_id: 100,
+			staking_asset_id: 1,
+			spending_asset_id: 1,
 		}),
 		sudo: Some(SudoConfig {
 			key: root_key,

--- a/kitchen/runtimes/weight-fee-runtime/Cargo.toml
+++ b/kitchen/runtimes/weight-fee-runtime/Cargo.toml
@@ -56,6 +56,12 @@ git = 'https://github.com/paritytech/substrate.git'
 package = 'pallet-balances'
 rev = '3e651110aa06aa835790df63410a29676243fc54'
 
+[dependencies.generic-asset]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+package = 'pallet-generic-asset'
+rev = '3e651110aa06aa835790df63410a29676243fc54'
+
 [dependencies.transaction-payment]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
@@ -162,6 +168,7 @@ std = [
 	"balances/std",
 	"block-builder-api/std",
 	"executive/std",
+	"generic-asset/std",
 	"grandpa/std",
 	"indices/std",
 	"inherents/std",

--- a/kitchen/runtimes/weight-fee-runtime/src/lib.rs
+++ b/kitchen/runtimes/weight-fee-runtime/src/lib.rs
@@ -32,7 +32,7 @@ use version::NativeVersion;
 #[allow(unused_imports)]
 use sp_runtime::traits::ConvertInto;
 #[allow(unused_imports)]
-use generic_asset::SpendingAssetCurrency;
+use generic_asset::{SpendingAssetCurrency, AssetCurrency, AssetIdProvider};
 
 // A few exports that help ease life for downstream crates.
 #[cfg(any(feature = "std", test))]
@@ -289,33 +289,40 @@ impl<C0, C1, C2> Convert<Weight, Balance> for QuadraticWeightToFee<C0, C1, C2>
 }
 
 // --------------------- An Option to Currency to Collect Fees -----------------------
-//TODO
-// struct FixedGenericAsset;
+type FixedGenericAsset<T> = AssetCurrency<T, FixedAssetId>;
+
+pub struct FixedAssetId;
+impl AssetIdProvider for FixedAssetId {
+	type AssetId = u32;
+	fn asset_id() -> Self::AssetId {
+		13
+	}
+}
 
 parameter_types! {
-	// Used with LinearWeightToFee conversion.
+	// Used with LinearWeightToFee conversion. Leaving this constant in tact when using other
+	// conversion techniques is harmless.
 	pub const FeeWeightRatio: u128 = 1_000;
 
-	// Used with QuadraticWeightToFee conversion. Leaving this constant in tact when using other
+	// Used with QuadraticWeightToFee conversion. Leaving these constants in tact when using other
 	// conversion techniques is harmless.
 	pub const WeightFeeConstant: u128 = 1_000;
 	pub const WeightFeeLinear: u128 = 100;
 	pub const WeightFeeQuadratic : u128 = 10;
 
-	// Establish the base- and byte-fees. These are used regardless of which WeightFee conversion
-	// is being used.
+	// Establish the base- and byte-fees. These are used in all configurations.
 	pub const TransactionBaseFee: u128 = 0;
 	pub const TransactionByteFee: u128 = 1;
 }
 
 impl transaction_payment::Trait for Runtime {
 
-    // The asset in which fees will be collected.
-    // Enable exactly one of the following options.
-	//type Currency = Balances; // The balances pallet (The most common choice)
-	// type Currency = FixedGenericAsset... // A generic asset whose ID is hard-coded above.
-	type Currency = SpendingAssetCurrency<Self>; // A generic asset whose ID is stored in the
-	                                             // generic_asset pallet's runtime storage
+	// The asset in which fees will be collected.
+	// Enable exactly one of the following options.
+	type Currency = Balances; // The balances pallet (The most common choice)
+	//type Currency = FixedGenericAsset<Self>; // A generic asset whose ID is hard-coded above.
+	//type Currency = SpendingAssetCurrency<Self>; // A generic asset whose ID is stored in the
+	                                               // generic_asset pallet's runtime storage
 
 	// What to do when fees are paid. () means take no additional actions.
 	type OnTransactionPayment = ();

--- a/kitchen/runtimes/weight-fee-runtime/src/lib.rs
+++ b/kitchen/runtimes/weight-fee-runtime/src/lib.rs
@@ -27,10 +27,12 @@ use version::RuntimeVersion;
 #[cfg(feature = "std")]
 use version::NativeVersion;
 
-// Don't throw a warning when importing ConvertInto. It is used in one of the commented-by-default
-// weight-fee conversions.
+// These structs are used in one of the commented-by-default implementations of
+// transaction_payment::Trait. Don't warn when they are unused.
 #[allow(unused_imports)]
 use sp_runtime::traits::ConvertInto;
+#[allow(unused_imports)]
+use generic_asset::SpendingAssetCurrency;
 
 // A few exports that help ease life for downstream crates.
 #[cfg(any(feature = "std", test))]
@@ -231,6 +233,13 @@ impl balances::Trait for Runtime {
 	type CreationFee = CreationFee;
 }
 
+impl generic_asset::Trait for Runtime {
+    /// The type for recording an account's balance.
+    type Balance = Balance;
+    type AssetId = u32;
+    type Event = Event;
+}
+
 impl sudo::Trait for Runtime {
 	type Event = Event;
 	type Proposal = Call;
@@ -279,31 +288,39 @@ impl<C0, C1, C2> Convert<Weight, Balance> for QuadraticWeightToFee<C0, C1, C2>
 	}
 }
 
+// --------------------- An Option to Currency to Collect Fees -----------------------
+//TODO
+// struct FixedGenericAsset;
 
-
-// Enable only when WeightToFee = LinearWeightToFee
-// parameter_types!{
-// 	pub const FeeWeightRatio: u128 = 1_000;
-// }
-
-// Enable only when WeightToFee = QuadraticWeightToFee
 parameter_types! {
+	// Used with LinearWeightToFee conversion.
+	pub const FeeWeightRatio: u128 = 1_000;
+
+	// Used with QuadraticWeightToFee conversion. Leaving this constant in tact when using other
+	// conversion techniques is harmless.
 	pub const WeightFeeConstant: u128 = 1_000;
 	pub const WeightFeeLinear: u128 = 100;
 	pub const WeightFeeQuadratic : u128 = 10;
-}
 
-// Always necessary
-parameter_types! {
+	// Establish the base- and byte-fees. These are used regardless of which WeightFee conversion
+	// is being used.
 	pub const TransactionBaseFee: u128 = 0;
 	pub const TransactionByteFee: u128 = 1;
 }
 
 impl transaction_payment::Trait for Runtime {
-	type Currency = balances::Module<Runtime>;
+
+    // The asset in which fees will be collected.
+    // Enable exactly one of the following options.
+	//type Currency = Balances; // The balances pallet (The most common choice)
+	// type Currency = FixedGenericAsset... // A generic asset whose ID is hard-coded above.
+	type Currency = SpendingAssetCurrency<Self>; // A generic asset whose ID is stored in the
+	                                             // generic_asset pallet's runtime storage
+
+	// What to do when fees are paid. () means take no additional actions.
 	type OnTransactionPayment = ();
 
-	// Base fee is applied to every single transaction
+	// Base fee is a fixed amount applied to every transaction
 	type TransactionBaseFee = TransactionBaseFee;
 
 	// Byte fee is multiplied by the length of the
@@ -311,7 +328,7 @@ impl transaction_payment::Trait for Runtime {
 	type TransactionByteFee = TransactionByteFee;
 
 	// Function to convert dispatch weight to a chargeable fee.
-	// Enable exactly one of the following examples.
+	// Enable exactly one of the following options.
 	//type WeightToFee = ConvertInto;
 	//type WeightToFee = LinearWeightToFee<FeeWeightRatio>;
 	type WeightToFee = QuadraticWeightToFee<WeightFeeConstant, WeightFeeLinear, WeightFeeQuadratic>;
@@ -335,6 +352,7 @@ construct_runtime!(
 		Grandpa: grandpa::{Module, Call, Storage, Config, Event},
 		Indices: indices,
 		Balances: balances,
+		GenericAsset: generic_asset,
 		RandomnessCollectiveFlip: randomness_collective_flip::{Module, Call, Storage},
 		Sudo: sudo,
 		TransactionPayment: transaction_payment::{Module, Storage},

--- a/src/README.md
+++ b/src/README.md
@@ -19,6 +19,7 @@
     - [Configurable Constants](./storage/constants.md)
 - [Types and Traits](./traits/README.md)
     - [Currency Types](./traits/currency.md)
+    - [Weights for Resource Accounting](./traits/weights.md)
     - [Transaction Fees for Economic Security](./traits/fees.md)
     - [Instantiable Pallets](./storage/instantiable.md)
 - [Declarative Syntax](./declarative/README.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -19,6 +19,7 @@
     - [Configurable Constants](./storage/constants.md)
 - [Types and Traits](./traits/README.md)
     - [Currency Types](./traits/currency.md)
+    - [Weights for Resource Accounting](./traits/weights.md)
     - [Transaction Fees for Economic Security](./traits/fees.md)
     - [Instantiable Pallets](./storage/instantiable.md)
 - [Declarative Syntax](./declarative/README.md)

--- a/src/traits/fees.md
+++ b/src/traits/fees.md
@@ -1,75 +1,38 @@
-# Economic Security in Substrate <a name = "sec"></a>
+# Transaction Fees
+*[kitchen/runtimes/weight-fee-runtime](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/runtimes/weight-fee-runtime)*
 
-An algorithm is considered to be *efficient* if its running time is polynomial in the size of the input, and *highly efficient* if its running time is linear in the size of the input. **It is important for all on-chain algorithms to be highly efficient, because they must scale linearly as the size of the Polkadot network grows**. In contrast, off-chain algorithms are only required to be efficient. - [Web3 Research](https://research.web3.foundation/en/latest/polkadot/NPoS/index.html)
+Substrate provides the [`transaction_payment` pallet](https://substrate.dev/rustdocs/master/pallet_transaction_payment/index.html) for calculating and collecting fees for executing transactions. Fees are broken down into several components:
 
-Any resources used by a transaction must explicitly be paid for, and it is a pallet author's job to ensure that appropriate fees are required. Maintaining the balance between **resources used** and **price paid** is an important design activity for runtime security.
+* Base fee - A fixed fee applied to each transaction. A parameter in the `transaction_payment` pallet.
+* Length fee - A fee proportional to the transaction's length in bytes. The proportionality constant is a parameter in the `transaction_payment` pallet.
+* Weight fee - A fee calculated from the transaction's weight. Weights are intended to capture the actual resources consumed by the transaction. Learn more in the [recipe on weights](./weights.md). It doesn't need to be linear, although it often is. The same conversion function is applied across all transactions from all pallets in the runtime.
+* Fee Multiplier - A multiplier for the computed fee, that can change as the chain progresses. This topic is not (yet) covered further in the recipes.
 
-*Indeed, mispriced EVM operations have shown how operations that underestimate cost can open economic DOS attack vectors: [Onwards; Underpriced EVM Operations](https://www.parity.io/onwards/), [Under-Priced DOS Attacks on Ethereum](https://www4.comp.polyu.edu.hk/~csxluo/DoSEVM.pdf)*
+`total_fee = base_fee + transaction_length * length_fee + weight_to_fee(total_weight)`
 
+## Setting the Constants
 
+Each of the parameters described above is set in the `transaction_payment` pallet's configuration trait. For example, the `super-runtime` sets these parameters as follows.
 
-Substrate provides several ways to affect the fees charges for executing a transaction. Substrate developer hub contains full details about [fees](https://substrate.dev/docs/en/next/development/module/fees) and [weights](https://substrate.dev/docs/en/next/conceptual/runtime/weight).
+```rust,ignore
+parameter_types! {
+    pub const TransactionBaseFee: u128 = 0;
+    pub const TransactionByteFee: u128 = 1;
+}
 
-* Base fee - Applies a fixed fee to each and every transaction. A parameter in the `transaction_payment` pallet.
-
-* Length fee - Applies a fee proportional to the transaction's length in bytes. The constant is a parameter in the `transaction_payment` pallet.
-
-* Transaction weight - Each transaction can declare a weight, either fixed, or calculated from its parameters. This is exemplified briefly below and more thoroughly in the kitchen.
-
-* Weight to Fee - A function to convert weight to fee. It doesn't need to be linear, although it often is. The same conversion function is applied across all transactions from all pallets in the runtime. This is exemplified briefly below and more thoroughly in the kitchen.
-
-## Assigning Transaction Weights
-
-For simple transactions a fixed weight will do.
-```rust, ignore
-decl_module! {
-	pub struct Module<T: Trait> for enum Call {
-
-		#[weight = SimpleDispatchInfo::FixedNormal(100)]
-		fn store_value(_origin, entry: u32) -> Result {
-			// --snip--
-		}
-```
-
-For more complex transactions, custom weight calculations can be performed.
-```rust, ignore
-pub struct Conditional(u32);
-
-impl WeighData<(&bool, &u32)> for Conditional {
-	fn weigh_data(&self, (switch, val): (&bool, &u32)) -> Weight {
-
-		if *switch {
-			val.saturating_mul(self.0)
-		}
-		else {
-			self.0
-		}
-	}
+impl transaction_payment::Trait for Runtime {
+    type Currency = balances::Module<Runtime>;
+    type OnTransactionPayment = ();
+    type TransactionBaseFee = TransactionBaseFee;
+    type TransactionByteFee = TransactionByteFee;
+    type WeightToFee = ConvertInto;
+    type FeeMultiplierUpdate = ();
 }
 ```
-
-In addition to the [`WeightData`
-Trait](https://substrate.dev/rustdocs/master/frame_support/weights/trait.WeighData.html), shown
-above, types that are used to calculate transaction weights, must also implement
-[`ClassifyDispatch`](https://substrate.dev/rustdocs/master/frame_support/weights/trait.ClassifyDispatch.html),
-and [`PaysFee`](https://substrate.dev/rustdocs/master/frame_support/weights/trait.PaysFee.html).
-These examples and several others can be compiled in the kitchen.
-
-While you can make reasonable estimates of resource consumption at
-design time, it is always best to actually measure the resources
-required of your functions through an empirical process. Failure to
-perform such rigorous measurement may result in an economically
-insecure chain.
 
 ## Converting Weight To Fees
 
-In many cases converting weight to fees 1:1 will suffice and be accomplished with [`ConvertInto`](https://substrate.dev/rustdocs/master/sp_runtime/traits/struct.ConvertInto.html). This approach is taken in the [node template](https://github.com/substrate-developer-hub/substrate-node-template/blob/43ee95347b6626580b1d9d554c3c8b77dc85bc01/runtime/src/lib.rs#L230) as well as the kitchen's own super runtime.
-```rust, ignore
-impl transaction_payment::Trait for Runtime {
-	// --snip--
-	type WeightToFee = ConvertInto;
-}
-```
+In many cases converting weight to fees 1:1, as shown above, will suffice and can be accomplished with [`ConvertInto`](https://substrate.dev/rustdocs/master/sp_runtime/traits/struct.ConvertInto.html). This approach is also taken in the [node template](https://github.com/substrate-developer-hub/substrate-node-template/blob/43ee95347b6626580b1d9d554c3c8b77dc85bc01/runtime/src/lib.rs#L230). It is also possible to provide a type that makes a more complex calculation. Any type that implements `Convert<Weight, Balance>` will suffice.
 
 This example uses a quadratic conversion and supports custom coefficients
 ```rust, ignore
@@ -90,4 +53,20 @@ impl<C0, C1, C2> Convert<Weight, Balance> for QuadraticWeightToFee<C0, C1, C2>
 }
 ```
 
-These examples, and several others can be compiled in the kitchen.
+This examples, and several others can be compiled in the kitchen's [weight-fee-runtime](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/runtimes/weight-fee-runtime)
+
+## Collecting Fees
+
+Having calculated the amount of fees due, runtime authors must decide which asset the fees should be paid in. A common choice is the use the [`Ballances` pallet](https://substrate.dev/rustdocs/master/pallet_balances/index.html), but any type that implements the [`Currency` trait](https://substrate.dev/rustdocs/master/frame_support/traits/trait.Currency.html) can be used. The weight-fee-runtime demonstrates how to use an asset provided by the [`Generic Asset` pallet](https://substrate.dev/rustdocs/master/pallet_generic_asset/index.html).
+
+```rust,ignore
+impl transaction_payment::Trait for Runtime {
+
+	// A generic asset whose ID is stored in the generic_asset pallet's runtime storage
+	//type Currency = SpendingAssetCurrency<Self>;
+
+	// --snip--
+}
+```
+
+This examples, and several others can be compiled in the kitchen's [weight-fee-runtime](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/runtimes/weight-fee-runtime)

--- a/src/traits/fees.md
+++ b/src/traits/fees.md
@@ -63,7 +63,7 @@ Having calculated the amount of fees due, runtime authors must decide which asse
 impl transaction_payment::Trait for Runtime {
 
 	// A generic asset whose ID is stored in the generic_asset pallet's runtime storage
-	//type Currency = SpendingAssetCurrency<Self>;
+	type Currency = SpendingAssetCurrency<Self>;
 
 	// --snip--
 }

--- a/src/traits/weights.md
+++ b/src/traits/weights.md
@@ -1,0 +1,84 @@
+# Computational Resources and Weights
+*[`kitchen/pallets/weights`](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/pallets/weights)*
+
+Any computational resources used by a transaction must be accounted for so that appropriate fees can be applied, and it is a pallet author's job to ensure that this accounting happens. Substrate provides a mechanism known as transaction weighting to quantify the resources consumed while executing a transaction.
+
+*Indeed, mispriced EVM operations have shown how operations that underestimate cost can open economic DOS attack vectors: [Onwards; Underpriced EVM Operations](https://www.parity.io/onwards/), [Under-Priced DOS Attacks on Ethereum](https://www4.comp.polyu.edu.hk/~csxluo/DoSEVM.pdf)*
+
+
+## Assigning Transaction Weights
+Pallet authors can annotate their dispatchable function with a weight using syntax like this,
+```rust, ignore
+#[weight = <Some Weighting Instance>]
+fn some_call(...) -> Result {
+	// --snip--
+}
+```
+
+For simple transactions a fixed weight will do. Substrate provides the [`SimpleDispatchInfo` enum](https://substrate.dev/rustdocs/master/frame_support/weights/enum.SimpleDispatchInfo.html) for situations like this.
+```rust, ignore
+decl_module! {
+	pub struct Module<T: Trait> for enum Call {
+
+		#[weight = SimpleDispatchInfo::FixedNormal(100)]
+		fn store_value(_origin, entry: u32) -> Result {
+			// --snip--
+		}
+```
+
+For more complex transactions, custom weight calculations can be performed that consider the parameters passed to the call. This snippet shows a weighting struct that weighs transactions where the first parameter
+is a `boo`l. If the first parameter is `true`, then the weight is linear in the second parameter. Otherwise the weight is constant. A transaction where this weighting scheme makes sense is demonstrated in the kitchen.
+```rust, ignore
+pub struct Conditional(u32);
+
+impl WeighData<(&bool, &u32)> for Conditional {
+	fn weigh_data(&self, (switch, val): (&bool, &u32)) -> Weight {
+
+		if *switch {
+			val.saturating_mul(self.0)
+		}
+		else {
+			self.0
+		}
+	}
+}
+```
+
+In addition to the [`WeightData`
+Trait](https://substrate.dev/rustdocs/master/frame_support/weights/trait.WeighData.html), shown
+above, types that are used to calculate transaction weights, must also implement
+[`ClassifyDispatch`](https://substrate.dev/rustdocs/master/frame_support/weights/trait.ClassifyDispatch.html),
+and [`PaysFee`](https://substrate.dev/rustdocs/master/frame_support/weights/trait.PaysFee.html).
+
+
+```rust,ignore
+impl<T> ClassifyDispatch<T> for Conditional {
+    fn classify_dispatch(&self, _: T) -> DispatchClass {
+        // Classify all calls as Normal (which is the default)
+        Default::default()
+    }
+}
+```
+
+```rust,ignore
+impl PaysFee for Conditional {
+    fn pays_fee(&self) -> bool {
+        true
+    }
+}
+```
+
+The complete code for this example as well as several others can be found in the kitchen.
+
+## Cautions
+
+While you can make reasonable estimates of resource consumption at
+design time, it is always best to actually measure the resources
+required of your functions through an empirical process. Failure to
+perform such rigorous measurement may result in an economically
+insecure chain.
+
+While it isn't enforced, calculating a transaction's weight should itself be a cheap operation. If the weight calculation itself is expensive, your chain will be insecure.
+
+## What About Fees?
+Weights are used only to describe the computational resources consumed by a transaction, and enable accounting of these resources. To learn how to turn these weights into actual fees charged to transactors, continue to the recipe on [Fees](./fees.md).


### PR DESCRIPTION
This PR adds content to the recipes' coverage of transaction weights and fees. In particular it:

* Demonstrates collecting fees with the generic_asset pallet's `SpendingAssetCurrency`
* Demonstrates collecting fees with a generic_asset with a fixed id.
* Splits recipe about weights and fees into two (one about weights and one about fees)
* Cleans up the code of the weight-fee-runtime