### PR TITLE
[WIP] rework list recipe to use more recent APIs and reduce confusion

### DIFF
--- a/text/storage/enumerated.md
+++ b/text/storage/enumerated.md
@@ -11,7 +11,7 @@ use support::{StorageValue, StorageMap};
 decl_storage! {
     trait Store for Module<T: Trait> as Example {
         TheList get(fn the_list): map u32 => T::AccountId;
-        TheCounter get(fn the_counter): u32;
+        LargestIndex get(fn the_counter): u32;
     }
 }
 ```
@@ -30,17 +30,19 @@ This recipe answers those questions with snippets from relevant code samples:
 
 ## Adding/Removing Elements in an Unbounded List <a name = "unbounded"></a>
 
-If the size of the list is not relevant, the implementation is straightforward. To add an `AccountId`, increment the `the_counter` and insert an `AccountId` at that index:
+If the contiguousness of the list is not relevant (i.e. you are willing to allow gaps and check for them at access time), the implementation is straightforward. To add an `AccountId`, increment the `LargestIndex` and insert an `AccountId` at that index:
 
 ```rust, ignore
-fn add_member(origin) -> Result {
+fn add_member(origin) -> DispatchResult {
     let who = ensure_signed(origin)?;
 
-    let new_count = <TheCounter<T>>::get() + 1;
-    // insert new member at next highest index
-    <TheList<T>>::insert(new_count, who.clone());
-    // increment counter
-    <TheCounter<T>>::put(new_count);
+    // Note: We use a 1-based (instead of 0-based) list here
+    // Note: Handle overflow here in production code!
+    let new_count = <LargestIndex>::get() + 1;
+    // insert new member past the end of the list
+    <TheList<T>>::insert(new_count, &who);
+    // store the incremented count
+    <LargestIndex>::put(new_count);
 
     Self::deposit_event(RawEvent::MemberAdded(who));
 
@@ -48,18 +50,16 @@ fn add_member(origin) -> Result {
 }
 ```
 
-To remove an `AccountId`, call the `remove` method for the `StorageMap` type at the relevant index. In this case, it isn't necessary to update the indices of other `proposal`s; order is not relevant.
+To remove an `AccountId`, call the `remove` (to drop it) or `take` (to use it) method for the `StorageMap` type at the relevant index. In this case, it isn't necessary to update the indices of other `member`s; contiguousness is not relevant.
 
 ```rust, ignore
-fn remove_member_unbounded(origin, index: u32) -> Result {
-    let who = ensure_signed(origin)?;
+fn remove_member_discontiguous(origin, index: u32) -> DispatchResult {
+    let _ = ensure_signed(origin)?;
 
     // verify existence
     ensure!(<TheList<T>>::exists(index), "an element doesn't exist at this index");
-    // for event emission
-    let removed_member = <TheList<T>>::get(index);
-    // remove member at provided index
-    <TheList<T>>::remove(index);
+    // use take for event emission, use remove to drop value
+    let removed_member = <TheList<T>>::take(index);
 
     Self::deposit_event(RawEvent::MemberRemoved(removed_member));
 
@@ -71,32 +71,29 @@ Because the code doesn't update the indices of other `AccountId`s in the map, it
 
 ## Swap and Pop for Ordered Lists <a name = "swappop"></a>
 
-To preserve storage so that the list doesn't continue growing even after removing elements, invoke the **swap and pop** algorithm:
+To preserve contiguousness so that the list does not contain gaps even after removing elements, invoke the **swap and pop** algorithm:
 1. swap the element to be removed with the element at the head of the *list* (the element with the highest index in the map)
 2. remove the element recently placed at the highest index
-3. decrement the `TheCount` value.
+3. decrement the `LargestIndex` value.
 
 Use the *swap and pop* algorithm to remove elements from the list.
 
 ```rust, ignore
-fn remove_member_bounded(origin, index: u32) -> Result {
+fn remove_member_contiguous(origin, index: u32) -> DispatchResult {
     let _ = ensure_signed(origin)?;
 
     ensure!(<TheList<T>>::exists(index), "an element doesn't exist at this index");
 
-    let largest_index = <TheCounter>::get();
-    let member_to_remove = <TheList<T>>::take(index);
+    let largest_index = <LargestIndex>::get();
     // swap
     if index != largest_index {
-        let temp = <TheList<T>>::take(largest_index);
-        <TheList<T>>::insert(index, temp);
-        <TheList<T>>::insert(largest_index, member_to_remove.clone());
+        <TheList<T>>::swap(index, largest_index);
     }
-    // pop
-    <TheList<T>>::remove(largest_index);
-    <TheCounter>::mutate(|count| *count - 1);
+    // pop, uses `take` to return the member in the event
+    let removed_member = <TheList<T>>::take(largest_index);
+    <LargestIndex>::mutate(|count| *count - 1);
 
-    Self::deposit_event(RawEvent::MemberRemoved(member_to_remove.clone()));
+    Self::deposit_event(RawEvent::MemberRemoved(removed_member));
 
     Ok(())
 }
@@ -104,40 +101,33 @@ fn remove_member_bounded(origin, index: u32) -> Result {
 
 ### Linked Map <a name = "linkedmap"></a>
 
-To trade performance for *relatively* simple code, use the `linked_map` data structure. By implementing [`StorageLinkedMap`](https://substrate.dev/rustdocs/master/frame_support/storage/trait.StorageLinkedMap.html) in addition to [`StorageMap`](https://substrate.dev/rustdocs/master/frame_support/storage/trait.StorageMap.html), `linked_map` provides a method `head` which yields the head of the *list*, thereby making it unnecessary to also store the `LargestIndex` (the *counters*). The `enumerate` method also returns an `Iterator` ordered according to when `(key, value)` pairs were inserted into the map.
+If you are willing to trade some storage overhead for *relatively* simple code, use the `linked_map` data structure. By implementing [`StorageLinkedMap`](https://substrate.dev/rustdocs/master/frame_support/storage/trait.StorageLinkedMap.html) in addition to [`StorageMap`](https://substrate.dev/rustdocs/master/frame_support/storage/trait.StorageMap.html), `linked_map` provides a method `head` which yields the head of the *list*, thereby making it unnecessary to also store the `LargestIndex`. The `enumerate` method also returns an `Iterator` ordered according to when `(key, value)` pairs were inserted into the map.
 
-To use `linked_map`, import `EnumerableStorageMap`. Here is the new declaration in the `decl_storage` block:
+To use `linked_map`, import `StorageLinkedMap`. Here is the new declaration in the `decl_storage` block:
 
 ```rust, ignore
-use support::{StorageMap, EnumerableStorageMap}; // no StorageValue necessary
+use frame_support::{StorageMap, StorageLinkedMap}; // no StorageValue necessary
 
 decl_storage! {
     trait Store for Module<T: Trait> as Example {
-        LinkedList get(fn linked_list): linked_map u32 => T::AccountId;
-        LinkedCounter get(fn linked_counter): u32;
+        TheLinkedList get(fn linked_list): linked_map u32 => T::AccountId;
     }
 }
 ```
 
-The method adding members is no different than the previously covered method, but the `remove_member_linked` method expresses swap and pop in a different way
+The method adding members is no different than the previously covered method, but the `remove_member_linked` method expresses shows that you don't need "swap and pop" any more:
 
 ```rust, ignore
-fn remove_member_linked(origin, index: u32) -> Result {
+fn remove_member_linked(origin, index: u32) -> DispatchResult {
     let _ = ensure_signed(origin)?;
 
-    ensure!(<LinkedList<T>>::exists(index), "A member does not exist at this index");
+    ensure!(<TheLinkedList<T>>::exists(index), "A member does not exist at this index");
+    let removed_member = <TheLinkedList<T>>::take(index);
 
-    let head_index = <LinkedList<T>>::head().unwrap();
-    // swap
-    let member_to_remove = <LinkedList<T>>::take(index);
-    let head_member = <LinkedList<T>>::take(head_index);
-    <LinkedList<T>>::insert(index, head_member);
-    <LinkedList<T>>::insert(head_index, member_to_remove);
-    // pop
-    <LinkedList<T>>::remove(head_index);
+    Self::deposit_event(RawEvent::MemberRemoved(removed_member));
 
     Ok(())
 }
 ```
 
-This implementation incurs some performance costs (vs solely using `StorageMap` and `StorageValue`) because `linked_map` heap allocates the entire map as an iterator in order to implement the [`enumerate` method](https://substrate.dev/rustdocs/master/frame_support/storage/trait.StorageLinkedMap.html#tymethod.enumerate).
+This implementation incurs some storage costs (vs solely using `StorageMap` and `StorageValue`) because `linked_map` stores `previous` and `next` key for every value.

--- a/text/storage/enumerated.md
+++ b/text/storage/enumerated.md
@@ -11,7 +11,7 @@ use support::{StorageValue, StorageMap};
 decl_storage! {
     trait Store for Module<T: Trait> as Example {
         TheList get(fn the_list): map u32 => T::AccountId;
-        LargestIndex get(fn the_counter): u32;
+        LargestIndex get(fn largest_index): u32;
     }
 }
 ```


### PR DESCRIPTION
The original list implemented on top of the `StorageMap` was not using the `swap` method now present as well as ignoring the bookkeeping that `StorageLinkedMap` does.

The text had/seemed to have inaccurate or outdated descriptions.

This is my WIP reworking of the recipe. Talking to @bkchr lead me to question the usefulness of trying to simulate a list on top of the regular `StorageMap`, though. So do we still want it? @JoshOrndorff 