### PR TITLE
Testing Content Update

### DIFF
--- a/pallets/generic-event/src/lib.rs
+++ b/pallets/generic-event/src/lib.rs
@@ -4,6 +4,9 @@
 use support::{decl_event, decl_module, dispatch::DispatchResult};
 use system::ensure_signed;
 
+#[cfg(test)]
+mod tests;
+
 pub trait Trait: system::Trait {
     type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
 }
@@ -33,90 +36,3 @@ decl_event!(
         EmitInput(AccountId, u32),
     }
 );
-
-#[cfg(test)]
-mod tests {
-    use super::RawEvent;
-    use crate::{Module, Trait};
-    use primitives::H256;
-    use runtime_io;
-    use runtime_primitives::{
-        testing::Header,
-        traits::{BlakeTwo256, IdentityLookup},
-        Perbill,
-    };
-    use support::{assert_ok, impl_outer_event, impl_outer_origin, parameter_types};
-
-    impl_outer_origin! {
-        pub enum Origin for TestRuntime {}
-    }
-
-    // Workaround for https://github.com/rust-lang/rust/issues/26925 . Remove when sorted.
-    #[derive(Clone, PartialEq, Eq, Debug)]
-    pub struct TestRuntime;
-    parameter_types! {
-        pub const BlockHashCount: u64 = 250;
-        pub const MaximumBlockWeight: u32 = 1024;
-        pub const MaximumBlockLength: u32 = 2 * 1024;
-        pub const AvailableBlockRatio: Perbill = Perbill::one();
-    }
-    impl system::Trait for TestRuntime {
-        type Origin = Origin;
-        type Index = u64;
-        type Call = ();
-        type BlockNumber = u64;
-        type Hash = H256;
-        type Hashing = BlakeTwo256;
-        type AccountId = u64;
-        type Lookup = IdentityLookup<Self::AccountId>;
-        type Header = Header;
-        type Event = TestEvent;
-        type BlockHashCount = BlockHashCount;
-        type MaximumBlockWeight = MaximumBlockWeight;
-        type MaximumBlockLength = MaximumBlockLength;
-        type AvailableBlockRatio = AvailableBlockRatio;
-        type Version = ();
-        type ModuleToIndex = ();
-    }
-
-    mod generic_event {
-        pub use crate::Event;
-    }
-
-    impl_outer_event! {
-        pub enum TestEvent for TestRuntime {
-            generic_event<T>,
-        }
-    }
-
-    impl Trait for TestRuntime {
-        type Event = TestEvent;
-    }
-
-    pub type System = system::Module<TestRuntime>;
-    pub type GenericEvent = Module<TestRuntime>;
-
-    pub struct ExtBuilder;
-
-    impl ExtBuilder {
-        pub fn build() -> runtime_io::TestExternalities {
-            let storage = system::GenesisConfig::default()
-                .build_storage::<TestRuntime>()
-                .unwrap();
-            runtime_io::TestExternalities::from(storage)
-        }
-    }
-
-    #[test]
-    fn test() {
-        ExtBuilder::build().execute_with(|| {
-            assert_ok!(GenericEvent::do_something(Origin::signed(1), 32));
-
-            // construct event that should be emitted in the method call directly above
-            let expected_event = TestEvent::generic_event(RawEvent::EmitInput(1, 32));
-
-            // iterate through array of `EventRecord`s
-            assert!(System::events().iter().any(|a| a.event == expected_event));
-        })
-    }
-}

--- a/pallets/generic-event/src/tests.rs
+++ b/pallets/generic-event/src/tests.rs
@@ -1,0 +1,82 @@
+use crate::{Module, Trait, RawEvent};
+use primitives::H256;
+use runtime_io;
+use runtime_primitives::{
+    testing::Header,
+    traits::{BlakeTwo256, IdentityLookup},
+    Perbill,
+};
+use support::{assert_ok, impl_outer_event, impl_outer_origin, parameter_types};
+
+impl_outer_origin! {
+    pub enum Origin for TestRuntime {}
+}
+
+// Workaround for https://github.com/rust-lang/rust/issues/26925 . Remove when sorted.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct TestRuntime;
+parameter_types! {
+    pub const BlockHashCount: u64 = 250;
+    pub const MaximumBlockWeight: u32 = 1024;
+    pub const MaximumBlockLength: u32 = 2 * 1024;
+    pub const AvailableBlockRatio: Perbill = Perbill::one();
+}
+impl system::Trait for TestRuntime {
+    type Origin = Origin;
+    type Index = u64;
+    type Call = ();
+    type BlockNumber = u64;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = u64;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = TestEvent;
+    type BlockHashCount = BlockHashCount;
+    type MaximumBlockWeight = MaximumBlockWeight;
+    type MaximumBlockLength = MaximumBlockLength;
+    type AvailableBlockRatio = AvailableBlockRatio;
+    type Version = ();
+    type ModuleToIndex = ();
+}
+
+mod generic_event {
+    pub use crate::Event;
+}
+
+impl_outer_event! {
+    pub enum TestEvent for TestRuntime {
+        generic_event<T>,
+    }
+}
+
+impl Trait for TestRuntime {
+    type Event = TestEvent;
+}
+
+pub type System = system::Module<TestRuntime>;
+pub type GenericEvent = Module<TestRuntime>;
+
+pub struct ExtBuilder;
+
+impl ExtBuilder {
+    pub fn build() -> runtime_io::TestExternalities {
+        let storage = system::GenesisConfig::default()
+            .build_storage::<TestRuntime>()
+            .unwrap();
+        runtime_io::TestExternalities::from(storage)
+    }
+}
+
+#[test]
+fn test() {
+    ExtBuilder::build().execute_with(|| {
+        assert_ok!(GenericEvent::do_something(Origin::signed(1), 32));
+
+        // construct event that should be emitted in the method call directly above
+        let expected_event = TestEvent::generic_event(RawEvent::EmitInput(1, 32));
+
+        // iterate through array of `EventRecord`s
+        assert!(System::events().iter().any(|a| a.event == expected_event));
+    })
+}

--- a/pallets/simple-event/src/lib.rs
+++ b/pallets/simple-event/src/lib.rs
@@ -4,120 +4,33 @@
 use support::{decl_event, decl_module, dispatch::DispatchResult};
 use system::ensure_signed;
 
+#[cfg(test)]
+mod tests;
+
 pub trait Trait: system::Trait {
-    type Event: From<Event> + Into<<Self as system::Trait>::Event>;
-}
-
-decl_module! {
-    pub struct Module<T: Trait> for enum Call where origin: T::Origin {
-        fn deposit_event() = default;
-
-        fn do_something(origin, input: u32) -> DispatchResult {
-            let _ = ensure_signed(origin)?;
-
-            // could do something with the input here instead
-            let new_number = input;
-
-            // emit event
-            Self::deposit_event(Event::EmitInput(new_number));
-            Ok(())
-        }
-    }
+	type Event: From<Event> + Into<<Self as system::Trait>::Event>;
 }
 
 // uses u32 and not types from Trait so does not require `<T>`
 decl_event!(
-    pub enum Event {
-        EmitInput(u32),
-    }
+	pub enum Event {
+		EmitInput(u32),
+	}
 );
 
-#[cfg(test)]
-mod tests {
-    use crate::{Module, Trait};
-    use primitives::H256;
-    use runtime_io;
-    use runtime_primitives::{
-        testing::Header,
-        traits::{BlakeTwo256, IdentityLookup},
-        Perbill,
-    };
-    use support::{assert_ok, impl_outer_event, impl_outer_origin, parameter_types};
-    use system::{EventRecord, Phase};
+decl_module! {
+	pub struct Module<T: Trait> for enum Call where origin: T::Origin {
+		fn deposit_event() = default;
 
-    impl_outer_origin! {
-        pub enum Origin for TestRuntime {}
-    }
+		fn do_something(origin, input: u32) -> DispatchResult {
+			let _ = ensure_signed(origin)?;
 
-    // Workaround for https://github.com/rust-lang/rust/issues/26925 . Remove when sorted.
-    #[derive(Clone, PartialEq, Eq, Debug)]
-    pub struct TestRuntime;
-    parameter_types! {
-        pub const BlockHashCount: u64 = 250;
-        pub const MaximumBlockWeight: u32 = 1024;
-        pub const MaximumBlockLength: u32 = 2 * 1024;
-        pub const AvailableBlockRatio: Perbill = Perbill::one();
-    }
-    impl system::Trait for TestRuntime {
-        type Origin = Origin;
-        type Index = u64;
-        type Call = ();
-        type BlockNumber = u64;
-        type Hash = H256;
-        type Hashing = BlakeTwo256;
-        type AccountId = u64;
-        type Lookup = IdentityLookup<Self::AccountId>;
-        type Header = Header;
-        type Event = TestEvent;
-        type BlockHashCount = BlockHashCount;
-        type MaximumBlockWeight = MaximumBlockWeight;
-        type MaximumBlockLength = MaximumBlockLength;
-        type AvailableBlockRatio = AvailableBlockRatio;
-        type Version = ();
-        type ModuleToIndex = ();
-    }
+			// could do something with the input here instead
+			let new_number = input;
 
-    mod simple_event {
-        pub use crate::Event;
-    }
-
-    impl_outer_event! {
-        pub enum TestEvent for TestRuntime {
-            simple_event,
-        }
-    }
-
-    impl Trait for TestRuntime {
-        type Event = TestEvent;
-    }
-
-    pub type System = system::Module<TestRuntime>;
-    pub type SimpleEvent = Module<TestRuntime>;
-
-    pub struct ExtBuilder;
-
-    impl ExtBuilder {
-        pub fn build() -> runtime_io::TestExternalities {
-            let storage = system::GenesisConfig::default()
-                .build_storage::<TestRuntime>()
-                .unwrap();
-            runtime_io::TestExternalities::from(storage)
-        }
-    }
-
-    #[test]
-    fn test() {
-        ExtBuilder::build().execute_with(|| {
-            assert_ok!(SimpleEvent::do_something(Origin::signed(1), 32));
-
-            assert_eq!(
-                System::events(),
-                vec![EventRecord {
-                    phase: Phase::ApplyExtrinsic(0),
-                    event: TestEvent::simple_event(crate::Event::EmitInput(32)),
-                    topics: vec![],
-                }]
-            );
-        })
-    }
+			// emit event
+			Self::deposit_event(Event::EmitInput(new_number));
+			Ok(())
+		}
+	}
 }

--- a/pallets/simple-event/src/tests.rs
+++ b/pallets/simple-event/src/tests.rs
@@ -1,0 +1,91 @@
+use crate::{Module, Trait};
+use primitives::H256;
+use runtime_io;
+use runtime_primitives::{
+	testing::Header,
+	traits::{BlakeTwo256, IdentityLookup},
+	Perbill,
+};
+use support::{assert_ok, impl_outer_event, impl_outer_origin, parameter_types};
+use system::{EventRecord, Phase};
+
+// Implement the outer environment: Origin, TestEvent
+impl_outer_origin! {
+	pub enum Origin for TestRuntime {}
+}
+
+mod simple_event {
+	pub use crate::Event;
+}
+
+impl_outer_event! {
+	pub enum TestEvent for TestRuntime {
+		simple_event,
+	}
+}
+
+// Workaround for https://github.com/rust-lang/rust/issues/26925 . Remove when sorted.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct TestRuntime;
+
+parameter_types! {
+	pub const BlockHashCount: u64 = 250;
+	pub const MaximumBlockWeight: u32 = 1024;
+	pub const MaximumBlockLength: u32 = 2 * 1024;
+	pub const AvailableBlockRatio: Perbill = Perbill::one();
+}
+
+// The TestRuntime implements two pallet/frame traits: system, and simple_event
+impl system::Trait for TestRuntime {
+	type Origin = Origin;
+	type Index = u64;
+	type Call = ();
+	type BlockNumber = u64;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = u64;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type Header = Header;
+	type Event = TestEvent;
+	type BlockHashCount = BlockHashCount;
+	type MaximumBlockWeight = MaximumBlockWeight;
+	type MaximumBlockLength = MaximumBlockLength;
+	type AvailableBlockRatio = AvailableBlockRatio;
+	type Version = ();
+	type ModuleToIndex = ();
+}
+
+impl Trait for TestRuntime {
+	type Event = TestEvent;
+}
+
+// Hook up modules so we can make dispatched calls later
+pub type System = system::Module<TestRuntime>;
+pub type SimpleEvent = Module<TestRuntime>;
+
+pub struct ExtBuilder;
+
+impl ExtBuilder {
+	pub fn build() -> runtime_io::TestExternalities {
+		let storage = system::GenesisConfig::default()
+			.build_storage::<TestRuntime>()
+			.unwrap();
+		runtime_io::TestExternalities::from(storage)
+	}
+}
+
+#[test]
+fn test() {
+	ExtBuilder::build().execute_with(|| {
+		assert_ok!(SimpleEvent::do_something(Origin::signed(1), 32));
+
+		assert_eq!(
+			System::events(),
+			vec![EventRecord {
+				phase: Phase::ApplyExtrinsic(0),
+				event: TestEvent::simple_event(crate::Event::EmitInput(32)),
+				topics: vec![],
+			}]
+		);
+	})
+}

--- a/text/appetizers/events.md
+++ b/text/appetizers/events.md
@@ -27,7 +27,7 @@ Self::deposit_event(Event::EmitInput(new_number));
 
 ## Events with Generic Types
 
-[Sometimes](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/generic-event) events might contin types from the pallet's Configuration Trait. In this case, it is necessary to specify additional syntax
+[Sometimes](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/generic-event) events might contain types from the pallet's Configuration Trait. In this case, it is necessary to specify additional syntax
 
 ```rust, ignore
 decl_event!(

--- a/text/testing/mock.md
+++ b/text/testing/mock.md
@@ -36,14 +36,14 @@ impl Trait for TestRuntime {
 Next, we create a new type that wraps the mock `TestRuntime` in the pallet's `Module`.
 
 ```rust, ignore
-pub type HelloSubstrate = Module<TestRuntime>;
+pub type TestPallet = Module<TestRuntime>;
 ```
 
 It may be helpful to read this as type aliasing our configured mock runtime to work with the pallet's `Module`, which is what is ultimately being tested.
 
 ## `impl system::Trait`
 
-In many cases, the pallet's `Trait` inherits `system::Trait` like
+In many cases, the pallet's `Trait` inherits `system::Trait` like:
 
 ```rust, ignore
 pub trait Trait: system::Trait {
@@ -51,12 +51,41 @@ pub trait Trait: system::Trait {
 }
 ```
 
-The mock runtime must inherit and define the `system::Trait` associated types (*[remember](https://substrate.dev/recipes/traits/index.html)*). To do so, `impl` the `system::Trait` for `TestRuntime` with a few types imported from other crates,
+Before we can create a mock runtime that take our pallet to run tests, we first need to create the
+outer environment for the runtime, as follows:
 
 ```rust, ignore
 use support::{impl_outer_event, impl_outer_origin, parameter_types};
 use runtime_primitives::{Perbill, traits::{IdentityLookup, BlakeTwo256}, testing::Header};
+use runtime_io;
+use primitives::{H256};
 
+// We define the outer `Origin` enum, and `Event` enums.
+// You may not aware these enums are created when writing the pallet, it is because
+//   they are created through the macro `decl_event`, `decl_module` that we use.
+// Also these are not standard Rust but the syntax expected when parsed inside these macros.
+impl_outer_origin! {
+	pub enum Origin for TestRuntime {}
+}
+
+// -- If you want to test events, add the following. Otherwise, please ignore --
+mod test_events {
+	pub use crate::Event;
+}
+
+impl_outer_event! {
+	pub enum TestEvent for TestRuntime {
+		test_events,
+	}
+}
+// -- End: Code setup for testing events --
+```
+
+The mock runtime must inherit and define the `system::Trait` associated types
+(*[remember](https://substrate.dev/recipes/traits/index.html)*). To do so, `impl` the `system::Trait`
+for `TestRuntime` with types created previously and imported from other crates.
+
+```rust, ignore
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct TestRuntime;
 parameter_types! {
@@ -70,19 +99,24 @@ impl system::Trait for TestRuntime {
 	type Index = u64;
 	type Call = ();
 	type BlockNumber = u64;
-	type Hash = BlakeTwo256;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
 	type AccountId = u64;
 	type Lookup = IdentityLookup<Self::AccountId>;
 	type Header = Header;
+	// To test events, use `TestEvent`. Otherwise, use the commented line
 	type Event = TestEvent;
+	// type Event = ();
 	type BlockHashCount = BlockHashCount;
 	type MaximumBlockWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();
+	type ModuleToIndex = ();
 }
 
 pub type System = system::Module<TestRuntime>;
+pub type TestPallet = Module<TestRuntime>;
 ```
 
 With this, it is possible to use this type in the unit tests. For example, the block number can be set with [`set_block_number`](https://substrate.dev/rustdocs/master/frame_system/struct.Module.html#method.set_block_number)
@@ -247,8 +281,8 @@ NOTE: the input to `Origin::signed` is the `system::Trait`'s `AccountId` type wh
 
 ```rust, ignore
 pub trait Trait: 'static + Eq + Clone {
-    //...
-    type AccountId: Parameter + Member + MaybeSerializeDeserialize + Debug + MaybeDisplay + Ord + Default;
+	//...
+	type AccountId: Parameter + Member + MaybeSerializeDeserialize + Debug + MaybeDisplay + Ord + Default;
 	//...
 }
 ```

--- a/text/testing/mock.md
+++ b/text/testing/mock.md
@@ -1,6 +1,6 @@
 # Mock Runtime for Unit Testing
 
-*see [root](./index.md) for list of kitchen pallets with unit test coverage*
+*See [Testing](./index.md) page for list of kitchen pallets with unit test coverage.*
 
 There are two main patterns on writing tests for pallets. We can put the tests:
 
@@ -38,8 +38,8 @@ use runtime_io;
 use primitives::{H256};
 
 // We define the outer `Origin` enum and `Event` enum.
-// You may not aware these enums are created when writing the runtime/pallet, it is
-//   because they are created through the `construct_runtime!` macro.
+// You may not be aware that these enums are created when writing the runtime/pallet;
+//   it is because they are created through the `construct_runtime!` macro.
 // Also, these are not standard Rust but the syntax expected when parsed inside
 //   these macros.
 impl_outer_origin! {
@@ -109,7 +109,7 @@ parameter_types! {
 	pub const AvailableBlockRatio: Perbill = Perbill::one();
 }
 
-// First, implement the system pallet trait for test runtime
+// First, implement the system pallet's configuration trait for `TestRuntime`
 impl system::Trait for TestRuntime {
 	type Origin = Origin;
 	type Index = u64;
@@ -131,7 +131,7 @@ impl system::Trait for TestRuntime {
 	type ModuleToIndex = ();
 }
 
-// Then implement our own pallet trait for test runtime
+// Then implement our own pallet's configuration trait for `TestRuntime`
 impl Trait for TestRuntime {
 	type Event = TestEvent;
 }


### PR DESCRIPTION
This PR updates the content of the testing section.

* Makes in-text code work with 3e65111
* Adds detail about testing events
* Splits `simple-event` tests into separate file
* Splits `generic-event` tests into separate file