### PR TITLE
Kitchen node uses build-script-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,6 +1892,7 @@ dependencies = [
  "sp-runtime 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.3)",
  "sp-transaction-pool 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.3)",
  "structopt 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "substrate-build-script-utils 2.0.0-alpha.3 (git+https://github.com/paritytech/substrate.git?tag=v2.0.0-alpha.3)",
  "super-genesis 2.0.0",
  "super-runtime 2.0.0",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/nodes/kitchen-node/Cargo.toml
+++ b/nodes/kitchen-node/Cargo.toml
@@ -52,3 +52,8 @@ runtime-genesis = { package = "super-genesis", path = "../../runtimes/super-gene
 
 [build-dependencies]
 vergen = "3.0.4"
+
+[build-dependencies.build-script-utils]
+git = 'https://github.com/paritytech/substrate.git'
+package = 'substrate-build-script-utils'
+tag = 'v2.0.0-alpha.3'

--- a/nodes/kitchen-node/build.rs
+++ b/nodes/kitchen-node/build.rs
@@ -1,5 +1,3 @@
-use std::{env, path::PathBuf};
-
 use vergen::{ConstantsFlags, generate_cargo_keys};
 
 const ERROR_MSG: &str = "Failed to generate metadata files";
@@ -7,18 +5,5 @@ const ERROR_MSG: &str = "Failed to generate metadata files";
 fn main() {
 	generate_cargo_keys(ConstantsFlags::SHA_SHORT).expect(ERROR_MSG);
 
-	let mut manifest_dir = PathBuf::from(
-		env::var("CARGO_MANIFEST_DIR").expect("`CARGO_MANIFEST_DIR` is always set by cargo.")
-	);
-
-	while manifest_dir.parent().is_some() {
-		if manifest_dir.join(".git/HEAD").exists() {
-			println!("cargo:rerun-if-changed={}", manifest_dir.join(".git/HEAD").display());
-			return
-		}
-
-		manifest_dir.pop();
-	}
-
-	println!("cargo:warning=Could not find `.git/HEAD` from manifest dir!");
+	build_script_utils::rerun_if_git_head_changed();
 }


### PR DESCRIPTION
Update `nodes/kitchen-node/build.rs` to use the `substrate-build-script-utils` as introduced in https://github.com/paritytech/substrate/pull/4019

The rpc-node already uses these utils because it was started from a node-template released after the utils were introduced.