### PR TITLE
Fix weights in all runtimes

### DIFF
--- a/runtimes/api-runtime/src/lib.rs
+++ b/runtimes/api-runtime/src/lib.rs
@@ -118,7 +118,7 @@ pub fn native_version() -> NativeVersion {
 
 parameter_types! {
 	pub const BlockHashCount: BlockNumber = 250;
-	pub const MaximumBlockWeight: Weight = 1_000_000;
+	pub const MaximumBlockWeight: Weight = 1_000_000_000;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;

--- a/runtimes/api-runtime/src/lib.rs
+++ b/runtimes/api-runtime/src/lib.rs
@@ -1,4 +1,4 @@
-//! A Runtime that demonstrates ca custom runtime API.
+//! A Runtime that demonstrates a custom runtime API.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.

--- a/runtimes/super-runtime/src/lib.rs
+++ b/runtimes/super-runtime/src/lib.rs
@@ -127,7 +127,7 @@ pub fn native_version() -> NativeVersion {
 
 parameter_types! {
 	pub const BlockHashCount: BlockNumber = 250;
-	pub const MaximumBlockWeight: Weight = 1_000_000;
+	pub const MaximumBlockWeight: Weight = 1_000_000_000;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;

--- a/runtimes/weight-fee-runtime/src/lib.rs
+++ b/runtimes/weight-fee-runtime/src/lib.rs
@@ -130,7 +130,7 @@ pub fn native_version() -> NativeVersion {
 
 parameter_types! {
 	pub const BlockHashCount: BlockNumber = 250;
-	pub const MaximumBlockWeight: Weight = 1_000_000;
+	pub const MaximumBlockWeight: Weight = 1_000_000_000;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;


### PR DESCRIPTION
This increases the maximum block weight in all runtimes so that balance transfer transactions fit in the block.

This cherry-pciks the commit from the branch that tracks substrate master where this change was already made. Hope there won't be merge conflicts in the future :crossed_fingers: 