### PR TITLE
Update Scale codec dependencies to 1.3.0

### DIFF
--- a/nodes/basic-pow/Cargo.toml
+++ b/nodes/basic-pow/Cargo.toml
@@ -14,7 +14,7 @@ path = 'src/main.rs'
 futures = '0.3.1'
 log = '0.4.8'
 structopt = '0.3.8'
-parity-scale-codec = '1.0.0'
+parity-scale-codec = '1.3.0'
 sha3 = "0.8"
 rand = { version = "0.7", features = ["small_rng"] }
 sc-consensus-pow = { version = '0.8.0-alpha.5' }

--- a/pallets/adding-machine/Cargo.toml
+++ b/pallets/adding-machine/Cargo.toml
@@ -14,7 +14,7 @@ std = [
 ]
 
 [dependencies]
-parity-scale-codec = { version = "1.1.0", features = ["derive"], default-features = false }
+parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
 frame-support = { package = "frame-support", version = '2.0.0-alpha.5', default_features = false }
 system = { package = "frame-system", version = '2.0.0-alpha.5', default_features = false }
 sp-runtime = { version = '2.0.0-alpha.5', default_features = false }

--- a/pallets/basic-token/Cargo.toml
+++ b/pallets/basic-token/Cargo.toml
@@ -13,7 +13,7 @@ std = [
 ]
 
 [dependencies]
-parity-scale-codec = { version = "1.1.0", features = ["derive"], default-features = false }
+parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
 frame-support = { version = '2.0.0-alpha.5', default_features = false }
 frame-system = { version = '2.0.0-alpha.5', default_features = false }
 

--- a/pallets/charity/Cargo.toml
+++ b/pallets/charity/Cargo.toml
@@ -16,11 +16,7 @@ std = [
 
 [dependencies]
 serde = "1.0.102"
-
-[dependencies.parity-scale-codec]
-default-features = false
-features = ['derive']
-version = '1.1.0'
+parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
 
 [dependencies.frame-support]
 default_features = false

--- a/pallets/check-membership/Cargo.toml
+++ b/pallets/check-membership/Cargo.toml
@@ -15,7 +15,7 @@ std = [
 ]
 
 [dependencies]
-parity-scale-codec = { version = "1.1.0", features = ["derive"], default-features = false }
+parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
 frame-support = { version = '2.0.0-alpha.5', default_features = false }
 frame-system = { version = '2.0.0-alpha.5', default_features = false}
 sp-runtime = { version = '2.0.0-alpha.5', default_features = false }

--- a/pallets/child-trie/Cargo.toml
+++ b/pallets/child-trie/Cargo.toml
@@ -17,7 +17,7 @@ std = [
 [dependencies.parity-scale-codec]
 default-features = false
 features = ['derive']
-version = '1.0.6'
+version = '1.3.0'
 
 [dependencies.frame-support]
 default_features = false

--- a/pallets/compounding-interest/Cargo.toml
+++ b/pallets/compounding-interest/Cargo.toml
@@ -22,7 +22,7 @@ tag = "v0.5.4+sub_v0.1"
 [dependencies.parity-scale-codec]
 default-features = false
 features = ['derive']
-version = '1.0.6'
+version = '1.3.0'
 
 [dependencies.frame-support]
 default_features = false

--- a/pallets/constant-config/Cargo.toml
+++ b/pallets/constant-config/Cargo.toml
@@ -16,7 +16,7 @@ std = [
 [dependencies.parity-scale-codec]
 default-features = false
 features = ['derive']
-version = '1.0.6'
+version = '1.3.0'
 
 [dependencies.frame-support]
 default_features = false

--- a/pallets/currency-imbalances/Cargo.toml
+++ b/pallets/currency-imbalances/Cargo.toml
@@ -16,7 +16,7 @@ std = [
 [dependencies.parity-scale-codec]
 default-features = false
 features = ['derive']
-version = '1.0.6'
+version = '1.3.0'
 
 [dependencies.frame-support]
 default_features = false

--- a/pallets/double-map/Cargo.toml
+++ b/pallets/double-map/Cargo.toml
@@ -17,7 +17,7 @@ std = [
 [dependencies.parity-scale-codec]
 default-features = false
 features = ['derive']
-version = '1.1.0'
+version = '1.3.0'
 
 [dependencies.frame-support]
 default_features = false

--- a/pallets/execution-schedule/Cargo.toml
+++ b/pallets/execution-schedule/Cargo.toml
@@ -17,7 +17,7 @@ std = [
 [dependencies.parity-scale-codec]
 default-features = false
 features = ['derive']
-version = '1.1.0'
+version = '1.3.0'
 
 [dependencies.frame-support]
 default_features = false

--- a/pallets/fixed-point/Cargo.toml
+++ b/pallets/fixed-point/Cargo.toml
@@ -22,7 +22,7 @@ tag = "v0.5.4+sub_v0.1"
 [dependencies.parity-scale-codec]
 default-features = false
 features = ['derive']
-version = '1.0.6'
+version = '1.3.0'
 
 [dependencies.frame-support]
 default_features = false

--- a/pallets/generic-event/Cargo.toml
+++ b/pallets/generic-event/Cargo.toml
@@ -14,7 +14,7 @@ std = [
 ]
 
 [dependencies]
-parity-scale-codec = { version = "1.1.0", features = ["derive"], default-features = false }
+parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
 frame-support = { package = "frame-support", version = '2.0.0-alpha.5', default_features = false }
 system = { package = "frame-system", version = '2.0.0-alpha.5', default_features = false }
 sp-runtime = { version = '2.0.0-alpha.5', default_features = false }

--- a/pallets/hello-substrate/Cargo.toml
+++ b/pallets/hello-substrate/Cargo.toml
@@ -14,7 +14,7 @@ std = [
 ]
 
 [dependencies]
-parity-scale-codec = { version = '1.0.6', features = ['derive'], default-features = false}
+parity-scale-codec = { version = '1.3.0', features = ['derive'], default-features = false}
 frame-support = { version = '2.0.0-alpha.5', default-features = false }
 frame-system = { version = '2.0.0-alpha.5', default-features = false }
 sp-runtime = { version = '2.0.0-alpha.5', default-features = false }

--- a/pallets/lockable-currency/Cargo.toml
+++ b/pallets/lockable-currency/Cargo.toml
@@ -16,7 +16,7 @@ std = [
 [dependencies.parity-scale-codec]
 default-features = false
 features = ['derive']
-version = '1.0.6'
+version = '1.3.0'
 
 [dependencies.frame-support]
 default_features = false

--- a/pallets/offchain-demo/Cargo.toml
+++ b/pallets/offchain-demo/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/substrate-developer-hub/recipes/"
 
 [dependencies]
 # external dependencies
-codec = { package = "parity-scale-codec", version = "1.0.6", default-features = false }
+codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false }
 parking_lot = "0.10.0"
 serde = { version = "1.0.101", optional = true }
 serde_json = { version = "1.0.46", default-features = false, features = ["alloc"] }

--- a/pallets/randomness/Cargo.toml
+++ b/pallets/randomness/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 # external dependencies
-parity-scale-codec = { default-features = false, features = ['derive'], version = '1.1.0' }
+parity-scale-codec = { default-features = false, features = ['derive'], version = '1.3.0' }
 
 # Substrate pallet/frame dependencies
 frame-support = { version = '2.0.0-alpha.5', default_features = false }

--- a/pallets/reservable-currency/Cargo.toml
+++ b/pallets/reservable-currency/Cargo.toml
@@ -16,7 +16,7 @@ std = [
 [dependencies.parity-scale-codec]
 default-features = false
 features = ['derive']
-version = '1.0.6'
+version = '1.3.0'
 
 [dependencies.frame-support]
 default_features = false

--- a/pallets/ringbuffer-queue/Cargo.toml
+++ b/pallets/ringbuffer-queue/Cargo.toml
@@ -13,7 +13,7 @@ std = [
 ]
 
 [dependencies]
-codec = { package = 'parity-scale-codec', default-features = false, features = ['derive'], version = '1.1.0' }
+codec = { package = 'parity-scale-codec', default-features = false, features = ['derive'], version = '1.3.0' }
 frame-support = { default_features = false, version = '2.0.0-alpha.5' }
 frame-system = { default_features = false, version = '2.0.0-alpha.5' }
 sp-std = { default_features = false, version = '2.0.0-alpha.5' }

--- a/pallets/simple-crowdfund/Cargo.toml
+++ b/pallets/simple-crowdfund/Cargo.toml
@@ -20,7 +20,7 @@ std = [
 [dependencies.parity-scale-codec]
 default-features = false
 features = ['derive']
-version = '1.0.6'
+version = '1.3.0'
 
 [dependencies.support]
 default_features = false

--- a/pallets/simple-event/Cargo.toml
+++ b/pallets/simple-event/Cargo.toml
@@ -14,7 +14,7 @@ std = [
 ]
 
 [dependencies]
-parity-scale-codec = { version = "1.1.0", features = ["derive"], default-features = false }
+parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
 frame-support = { package = "frame-support", version = '2.0.0-alpha.5', default_features = false }
 system = { package = "frame-system", version = '2.0.0-alpha.5', default_features = false }
 sp-runtime = { version = '2.0.0-alpha.5', default_features = false }

--- a/pallets/simple-map/Cargo.toml
+++ b/pallets/simple-map/Cargo.toml
@@ -13,7 +13,7 @@ std = [
 ]
 
 [dependencies]
-parity-scale-codec = { default-features = false, features = ['derive'], version = '1.1.0' }
+parity-scale-codec = { default-features = false, features = ['derive'], version = '1.3.0' }
 frame-support = { default_features = false, version = '2.0.0-alpha.5' }
 frame-system = { default_features = false, version = '2.0.0-alpha.5' }
 

--- a/pallets/single-value/Cargo.toml
+++ b/pallets/single-value/Cargo.toml
@@ -14,7 +14,7 @@ std = [
 ]
 
 [dependencies]
-parity-scale-codec = { default-features = false, features = ['derive'], version = '1.0.6' }
+parity-scale-codec = { default-features = false, features = ['derive'], version = '1.3.0' }
 frame-support = { version = '2.0.0-alpha.5',  default_features = false }
 frame-system  = { version = '2.0.0-alpha.5',  default_features = false }
 sp-runtime = { version = '2.0.0-alpha.5',  default_features = false }

--- a/pallets/storage-cache/Cargo.toml
+++ b/pallets/storage-cache/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 # external dependencies
-parity-scale-codec = { default-features = false, features = ['derive'], version = '1.1.0' }
+parity-scale-codec = { default-features = false, features = ['derive'], version = '1.3.0' }
 
 # Substrate pallet/frame dependencies
 frame-support = { package = 'frame-support', version = '2.0.0-alpha.5', default_features = false }

--- a/pallets/struct-storage/Cargo.toml
+++ b/pallets/struct-storage/Cargo.toml
@@ -17,7 +17,7 @@ std = [
 [dependencies.parity-scale-codec]
 default-features = false
 features = ['derive']
-version = '1.1.0'
+version = '1.3.0'
 
 [dependencies.frame-support]
 default_features = false

--- a/pallets/sum-storage/Cargo.toml
+++ b/pallets/sum-storage/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Joshy Orndorff"]
 edition = "2018"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0", default-features = false, features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
 sp-std = { version = '2.0.0-alpha.5', default_features = false}
 sp-runtime = { version = '2.0.0-alpha.5', default_features = false}
 frame-support = { version = '2.0.0-alpha.5', default_features = false}

--- a/pallets/sum-storage/rpc/Cargo.toml
+++ b/pallets/sum-storage/rpc/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["JoshyOrndorff"]
 edition = "2018"
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "1.0.0" }
+codec = { package = "parity-scale-codec", version = "1.3.0" }
 jsonrpc-core = "14.0.3"
 jsonrpc-core-client = "14.0.3"
 jsonrpc-derive = "14.0.3"

--- a/pallets/vec-set/Cargo.toml
+++ b/pallets/vec-set/Cargo.toml
@@ -16,7 +16,7 @@ std = [
 [dependencies.parity-scale-codec]
 default-features = false
 features = ['derive']
-version = '1.1.0'
+version = '1.3.0'
 
 [dependencies.frame-support]
 default_features = false

--- a/pallets/weights/Cargo.toml
+++ b/pallets/weights/Cargo.toml
@@ -16,7 +16,7 @@ std = [
 [dependencies.parity-scale-codec]
 default-features = false
 features = ['derive']
-version = '1.0.6'
+version = '1.3.0'
 
 [dependencies.frame-support]
 default-features = false

--- a/runtimes/api-runtime/Cargo.toml
+++ b/runtimes/api-runtime/Cargo.toml
@@ -16,7 +16,7 @@ timestamp = { package = "pallet-timestamp", version = '2.0.0-alpha.5', default_f
 transaction-payment = { package = "pallet-transaction-payment", version = '2.0.0-alpha.5', default_features = false}
 randomness-collective-flip = { package = "pallet-randomness-collective-flip", version = '2.0.0-alpha.5', default_features = false}
 
-parity-scale-codec = { version = "1.0.0", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.0", default-features = false, features = ["derive"] }
 frame-executive = { version = '2.0.0-alpha.5', default_features = false}
 safe-mix = { version = "1.0.0", default-features = false }
 serde = { version = "1.0.101", optional = true, features = ["derive"] }

--- a/runtimes/ocw-runtime/Cargo.toml
+++ b/runtimes/ocw-runtime/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 serde = { version = "1.0", optional = true, features = ["derive"] }
 safe-mix = { version = "1.0", default-features = false }
-parity-scale-codec = { version = "1.0.6", features = ["derive"], default-features = false }
+parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
 
 # Substrate pallets & dependencies
 frame-executive = { version = '2.0.0-alpha.5', default-features = false }

--- a/runtimes/pow-runtime/Cargo.toml
+++ b/runtimes/pow-runtime/Cargo.toml
@@ -8,11 +8,7 @@ edition = "2018"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 safe-mix = { version = "1.0", default-features = false }
 weights = { path = "../../pallets/weights", default-features = false }
-
-[dependencies.parity-scale-codec]
-default-features = false
-features = ['derive']
-version = '1.0.6'
+parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
 
 [dependencies.rstd]
 default-features = false
@@ -67,13 +63,13 @@ version = '2.0.0-alpha.5'
 
 # [dependencies.babe]
 # default-features = false
-# 
+#
 # package = 'pallet-babe'
 # version = '2.0.0-alpha.5'
 #
 # [dependencies.sp-consensus-babe]
 # default-features = false
-# 
+#
 # version = '2.0.0-alpha.5'
 
 [dependencies.executive]

--- a/runtimes/super-runtime/Cargo.toml
+++ b/runtimes/super-runtime/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Joshy Orndorff"]
 edition = "2018"
 
 [dependencies]
-parity-scale-codec = { version = "1.0.0", default-features = false, features = ["derive"] }
+parity-scale-codec = { version = "1.3.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 safe-mix = { version = "1.0", default-features = false }
 # Substrate Pallets

--- a/runtimes/weight-fee-runtime/Cargo.toml
+++ b/runtimes/weight-fee-runtime/Cargo.toml
@@ -8,11 +8,7 @@ edition = "2018"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 safe-mix = { version = "1.0", default-features = false }
 weights = { path = "../../pallets/weights", default-features = false }
-
-[dependencies.parity-scale-codec]
-default-features = false
-features = ['derive']
-version = '1.0.6'
+parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
 
 [dependencies.rstd]
 default-features = false

--- a/text/3-entrees/storage-api/index.md
+++ b/text/3-entrees/storage-api/index.md
@@ -6,7 +6,7 @@ For crypto*currencies*, storage might consist of a mapping between account keys 
 
 More generally, blockchains provide an interface to store and interact with data in a verifiable and globally irreversible way. In this context, data is stored in a series of snapshots, each of which may be accessed at a later point in time, but, once created, snapshots are considered irreversible.
 
-Arbitrary data may be stored, as long as its data type is serializable in Substrate i.e. implements [`Encode`](https://docs.rs/parity-scale-codec/1.0.6/parity_scale_codec/#encode) and [`Decode`](https://docs.rs/parity-scale-codec/1.0.6/parity_scale_codec/#decode) traits.
+Arbitrary data may be stored, as long as its data type is serializable in Substrate i.e. implements [`Encode`](https://docs.rs/parity-scale-codec/1.3.0/parity_scale_codec/#encode) and [`Decode`](https://docs.rs/parity-scale-codec/1.3.0/parity_scale_codec/#decode) traits.
 
 The previous *[single-value storage recipe](../../2-appetizers/2-storage-values.md)* showed how a single value can be stored in runtime storage. In this section, we cover
 - [caching values rather than calling to storage multiple times](./cache.md)

--- a/text/3-entrees/storage-api/ringbuffer.md
+++ b/text/3-entrees/storage-api/ringbuffer.md
@@ -62,7 +62,7 @@ where
 
 The bounds `B` will be a `StorageValue` storing a tuple of indices `(Index, Index)`. The item storage will be a `StorageMap` mapping from our `Index` type to the `Item` type. We specify the associated `Query` type for both of them to help with type inference (because the value returned can be different from the stored representation).
 
-The [`Codec`](https://docs.rs/parity-scale-codec/1.2.0/parity_scale_codec/trait.Codec.html) and [`EncodeLike`](https://docs.rs/parity-scale-codec/1.2.0/parity_scale_codec/trait.EncodeLike.html) type constraints make sure that both items and indices can be stored in storage.
+The [`Codec`](https://docs.rs/parity-scale-codec/1.3.0/parity_scale_codec/trait.Codec.html) and [`EncodeLike`](https://docs.rs/parity-scale-codec/1.3.0/parity_scale_codec/trait.EncodeLike.html) type constraints make sure that both items and indices can be stored in storage.
 
 We need the [`PhantomData`](https://doc.rust-lang.org/std/marker/struct.PhantomData.html) in order to "hold on to" the types during the lifetime of the transient object.
 


### PR DESCRIPTION
Closes #178

Updates all (:crossed_fingers:) dependencies on `parity-scale-codec` to the latest (`1.3.0`).