### PR TITLE
Add tests to reservable currency pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4158,6 +4158,7 @@ version = "0.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
+ "pallet-balances",
  "parity-scale-codec",
  "sp-core",
  "sp-io",

--- a/pallets/reservable-currency/Cargo.toml
+++ b/pallets/reservable-currency/Cargo.toml
@@ -11,6 +11,7 @@ std = [
     'frame-support/std',
     'frame-system/std',
     'sp-runtime/std',
+    'balances/std',
 ]
 
 [dependencies.parity-scale-codec]
@@ -28,6 +29,11 @@ version = '2.0.0-alpha.5'
 
 [dependencies.sp-runtime]
 default_features = false
+version = '2.0.0-alpha.5'
+
+[dependencies.balances]
+default_features = false
+package = 'pallet-balances'
 version = '2.0.0-alpha.5'
 
 [dev-dependencies.sp-core]

--- a/pallets/reservable-currency/src/lib.rs
+++ b/pallets/reservable-currency/src/lib.rs
@@ -10,6 +10,9 @@ use frame_support::{
 };
 use frame_system::{self as system, ensure_signed};
 
+#[cfg(test)]
+mod tests;
+
 // balance type using reservable currency type
 type BalanceOf<T> = <<T as Trait>::Currency as Currency<<T as system::Trait>::AccountId>>::Balance;
 

--- a/pallets/reservable-currency/src/lib.rs
+++ b/pallets/reservable-currency/src/lib.rs
@@ -94,15 +94,13 @@ decl_module! {
 		) -> DispatchResult {
 			let _ = ensure_signed(origin)?; // dangerous because can be called with any signature (so dont do this in practice ever!)
 
-                        // Unreserved contains our overdraft, if collateral is bigger than
-                        // to_punish's reserved balance, what's left is put in unreserved.
-			let unreserved = T::Currency::unreserve(&to_punish, collateral);
-                        // Perhaps add an aditional check to see if we can susbtract unreserved
-                        // from free_balance and add it into the transfer below.
-			T::Currency::transfer(&to_punish, &dest, collateral - unreserved, AllowDeath)?;
+                        // If collateral is bigger than to_punish's reserved_balance, store what's left in overdraft.
+			let overdraft = T::Currency::unreserve(&to_punish, collateral);
+
+			T::Currency::transfer(&to_punish, &dest, collateral - overdraft, AllowDeath)?;
 
 			let now = <system::Module<T>>::block_number();
-			Self::deposit_event(RawEvent::TransferFunds(to_punish, dest, collateral - unreserved, now));
+			Self::deposit_event(RawEvent::TransferFunds(to_punish, dest, collateral - overdraft, now));
 
 			Ok(())
 		}

--- a/pallets/reservable-currency/src/lib.rs
+++ b/pallets/reservable-currency/src/lib.rs
@@ -94,11 +94,15 @@ decl_module! {
 		) -> DispatchResult {
 			let _ = ensure_signed(origin)?; // dangerous because can be called with any signature (so dont do this in practice ever!)
 
+                        // Unreserved contains our overdraft, if collateral is bigger than
+                        // to_punish's reserved balance, what's left is put in unreserved.
 			let unreserved = T::Currency::unreserve(&to_punish, collateral);
-			T::Currency::transfer(&to_punish, &dest, unreserved, AllowDeath)?;
+                        // Perhaps add an aditional check to see if we can susbtract unreserved
+                        // from free_balance and add it into the transfer below.
+			T::Currency::transfer(&to_punish, &dest, collateral - unreserved, AllowDeath)?;
 
 			let now = <system::Module<T>>::block_number();
-			Self::deposit_event(RawEvent::TransferFunds(to_punish, dest, unreserved, now));
+			Self::deposit_event(RawEvent::TransferFunds(to_punish, dest, collateral - unreserved, now));
 
 			Ok(())
 		}

--- a/pallets/reservable-currency/src/tests.rs
+++ b/pallets/reservable-currency/src/tests.rs
@@ -1,0 +1,175 @@
+use crate::*;
+use balances;
+use frame_support::{assert_err, assert_ok, impl_outer_event, impl_outer_origin, parameter_types};
+use frame_system::{self as system};
+use sp_core::H256;
+use sp_io;
+use sp_runtime::{
+    testing::Header,
+    traits::{BlakeTwo256, IdentityLookup},
+    Perbill,
+};
+
+impl_outer_origin! {
+    pub enum Origin for TestRuntime {}
+}
+
+// Workaround for https://github.com/rust-lang/rust/issues/26925 . Remove when sorted.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct TestRuntime;
+parameter_types! {
+    pub const BlockHashCount: u64 = 250;
+    pub const MaximumBlockWeight: u32 = 1024;
+    pub const MaximumBlockLength: u32 = 2 * 1024;
+    pub const AvailableBlockRatio: Perbill = Perbill::one();
+
+    pub const ExistentialDeposit: u64 = 1;
+    pub const TransferFee: u64 = 0;
+    pub const CreationFee: u64 = 0;
+}
+impl system::Trait for TestRuntime {
+    type Origin = Origin;
+    type Index = u64;
+    type Call = ();
+    type BlockNumber = u64;
+    type Hash = H256;
+    type Hashing = BlakeTwo256;
+    type AccountId = u64;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Header = Header;
+    type Event = TestEvent;
+    type BlockHashCount = BlockHashCount;
+    type MaximumBlockWeight = MaximumBlockWeight;
+    type MaximumBlockLength = MaximumBlockLength;
+    type AvailableBlockRatio = AvailableBlockRatio;
+    type Version = ();
+    type ModuleToIndex = ();
+    type AccountData = balances::AccountData<u64>;
+    type OnNewAccount = ();
+    type OnKilledAccount = ();
+}
+
+impl balances::Trait for TestRuntime {
+    type Balance = u64;
+    type Event = TestEvent;
+    type DustRemoval = ();
+    type ExistentialDeposit = ExistentialDeposit;
+    type AccountStore = system::Module<TestRuntime>;
+}
+
+mod reservable_currency {
+    pub use crate::Event;
+}
+
+impl_outer_event! {
+    pub enum TestEvent for TestRuntime {
+        system<T>,
+        reservable_currency<T>,
+        balances<T>,
+    }
+}
+
+impl Trait for TestRuntime {
+    type Event = TestEvent;
+    type Currency = balances::Module<Self>;
+}
+
+pub type System = system::Module<TestRuntime>;
+pub type Balances = balances::Module<TestRuntime>;
+pub type ReservableCurrency = Module<TestRuntime>;
+
+// An alternative to `ExtBuilder` which includes custom configuration
+pub fn new_test_ext() -> sp_io::TestExternalities {
+    let mut t = system::GenesisConfig::default()
+        .build_storage::<TestRuntime>()
+        .unwrap();
+    balances::GenesisConfig::<TestRuntime> {
+        // Provide some initial balances
+        balances: vec![(1, 10000), (2, 11000), (3, 12000), (4, 13000), (5, 14000)],
+    }
+    .assimilate_storage(&mut t)
+    .unwrap();
+    t.into()
+}
+
+/// Verifying correct behavior of boilerplate
+#[test]
+fn new_test_ext_behaves() {
+    new_test_ext().execute_with(|| {
+        assert_eq!(Balances::free_balance(&1), 10000);
+    })
+}
+
+#[test]
+fn new_test_ext_reserve_funds() {
+    new_test_ext().execute_with(|| {
+        // Lock half of 1's balance : (1, 10000) -> (1, 5000)
+        assert_ok!(ReservableCurrency::reserve_funds(Origin::signed(1), 5000));
+        // Test and see if we received a LockFunds event
+        let expected_event = TestEvent::reservable_currency(RawEvent::LockFunds(1, 5000, 1));
+        assert!(System::events().iter().any(|a| a.event == expected_event));
+        // Test and see if (1, 5000) holds
+        assert_eq!(Balances::free_balance(&1), 5000);
+        // Make sure that our 5000 is actually reserved
+        assert_eq!(Balances::reserved_balance(&1), 5000);
+    })
+}
+
+#[test]
+fn new_test_ext_unreserve_funds() {
+    new_test_ext().execute_with(|| {
+        // Lock balance, test lock event, test free balance
+        assert_ok!(ReservableCurrency::reserve_funds(Origin::signed(1), 5000));
+        let lock_event = TestEvent::reservable_currency(RawEvent::LockFunds(1, 5000, 1));
+        assert!(System::events().iter().any(|a| a.event == lock_event));
+        assert_eq!(Balances::free_balance(&1), 5000);
+
+        // Unlock balance, test event, test free balance
+        assert_ok!(ReservableCurrency::unreserve_funds(Origin::signed(1), 5000));
+        let unlock_event = TestEvent::reservable_currency(RawEvent::UnlockFunds(1, 5000, 1));
+        assert!(System::events().iter().any(|a| a.event == unlock_event));
+        assert_eq!(Balances::free_balance(&1), 10000);
+    })
+}
+
+#[test]
+fn new_test_ext_transfer_funds() {
+    new_test_ext().execute_with(|| {
+        // Transfer 4000 funds -> check for TransferFunds event -> check for (1, 6000) / (2, 15000)
+        assert_ok!(ReservableCurrency::transfer_funds(
+            Origin::signed(1),
+            2,
+            4000
+        ));
+        let transfer_event = TestEvent::reservable_currency(RawEvent::TransferFunds(1, 2, 4000, 1));
+        assert!(System::events().iter().any(|a| a.event == transfer_event));
+        assert_eq!(Balances::free_balance(&1), 6000);
+        assert_eq!(Balances::free_balance(&2), 15000);
+    })
+}
+
+#[test]
+fn new_test_ext_unreserve_and_transfer() {
+    new_test_ext().execute_with(|| {
+        // Reserve 4000 -> check for (1, 6000) -> check for reserved::(1, 4000)
+        assert_ok!(ReservableCurrency::reserve_funds(Origin::signed(1), 4000));
+        assert_eq!(Balances::free_balance(&1), 6000);
+        assert_eq!(Balances::reserved_balance(&1), 4000);
+        let reserve_event = TestEvent::reservable_currency(RawEvent::LockFunds(1, 4000, 1));
+        assert!(System::events().iter().any(|a| a.event == reserve_event));
+
+        // Punish one, pass 6000 collateral. One pays 2000 since 4000 goes unreserved.
+        assert_ok!(ReservableCurrency::unreserve_and_transfer(
+            Origin::signed(1),
+            1,
+            2,
+            6000
+        ));
+        let transfer_event = TestEvent::reservable_currency(RawEvent::TransferFunds(1, 2, 2000, 1));
+        assert!(System::events().iter().any(|a| a.event == transfer_event));
+        //Test if reserved::(1, 0) -> test if (1, 8000) -> test if (2, 13000)
+        assert_eq!(Balances::reserved_balance(&1), 0);
+        assert_eq!(Balances::free_balance(&1), 8000);
+        assert_eq!(Balances::free_balance(&2), 13000);
+    })
+}

--- a/pallets/reservable-currency/src/tests.rs
+++ b/pallets/reservable-currency/src/tests.rs
@@ -158,18 +158,19 @@ fn new_test_ext_unreserve_and_transfer() {
         let reserve_event = TestEvent::reservable_currency(RawEvent::LockFunds(1, 4000, 1));
         assert!(System::events().iter().any(|a| a.event == reserve_event));
 
-        // Punish one, pass 6000 collateral. One pays 2000 since 4000 goes unreserved.
+        // Punish one, for a value of 6000 collateral. Because one only has 4000 collateral reserved
+        // al of it is unreserved and transferred
         assert_ok!(ReservableCurrency::unreserve_and_transfer(
             Origin::signed(1),
             1,
             2,
             6000
         ));
-        let transfer_event = TestEvent::reservable_currency(RawEvent::TransferFunds(1, 2, 2000, 1));
+        let transfer_event = TestEvent::reservable_currency(RawEvent::TransferFunds(1, 2, 4000, 1));
         assert!(System::events().iter().any(|a| a.event == transfer_event));
         //Test if reserved::(1, 0) -> test if (1, 8000) -> test if (2, 13000)
         assert_eq!(Balances::reserved_balance(&1), 0);
-        assert_eq!(Balances::free_balance(&1), 8000);
-        assert_eq!(Balances::free_balance(&2), 13000);
+        assert_eq!(Balances::free_balance(&1), 6000);
+        assert_eq!(Balances::free_balance(&2), 15000);
     })
 }

--- a/pallets/reservable-currency/src/tests.rs
+++ b/pallets/reservable-currency/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::*;
 use balances;
-use frame_support::{assert_err, assert_ok, impl_outer_event, impl_outer_origin, parameter_types};
+use frame_support::{assert_ok, impl_outer_event, impl_outer_origin, parameter_types};
 use frame_system::{self as system};
 use sp_core::H256;
 use sp_io;
@@ -159,7 +159,7 @@ fn new_test_ext_unreserve_and_transfer() {
         assert!(System::events().iter().any(|a| a.event == reserve_event));
 
         // Punish one, for a value of 6000 collateral. Because one only has 4000 collateral reserved
-        // al of it is unreserved and transferred
+        // all of it is unreserved and transferred
         assert_ok!(ReservableCurrency::unreserve_and_transfer(
             Origin::signed(1),
             1,


### PR DESCRIPTION
Solves #209. Adds test coverage to the reservable currency recipe.

Sorry for the last one (#220), I have no idea how it went wrong that horribly. 