### PR TITLE
Remove no-longer-correct type `weight: u32`.

### DIFF
--- a/runtimes/api-runtime/aggregate_types.js
+++ b/runtimes/api-runtime/aggregate_types.js
@@ -14,8 +14,7 @@ const pallets = [
 // These specifics are from https://polkadot.js.org/api/start/types.extend.html#impact-on-extrinsics
 const runtimeOwnTypes = {
   "Address": "AccountId",
-  "LookupSource": "AccountId",
-  "Weight": "u32"
+  "LookupSource": "AccountId"
 }
 
 // Loop through all pallets aggregating types

--- a/runtimes/api-runtime/types.json
+++ b/runtimes/api-runtime/types.json
@@ -1,5 +1,4 @@
 {
   "Address": "AccountId",
-  "LookupSource": "AccountId",
-  "Weight": "u32"
+  "LookupSource": "AccountId"
 }

--- a/runtimes/babe-grandpa-runtime/aggregate_types.js
+++ b/runtimes/babe-grandpa-runtime/aggregate_types.js
@@ -12,8 +12,7 @@ const pallets = []
 // These specifics are from https://polkadot.js.org/api/start/types.extend.html#impact-on-extrinsics
 const runtimeOwnTypes = {
   "Address": "AccountId",
-  "LookupSource": "AccountId",
-  "Weight": "u32"
+  "LookupSource": "AccountId"
 }
 
 // Loop through all pallets aggregating types

--- a/runtimes/babe-grandpa-runtime/types.json
+++ b/runtimes/babe-grandpa-runtime/types.json
@@ -1,28 +1,4 @@
 {
   "Address": "AccountId",
-  "LookupSource": "AccountId",
-  "Weight": "u32",
-  "ContinuousAccountData": {
-    "principal": "u64",
-    "deposit_date": "BlockNumber"
-  },
-  "GroupIndex": "u32",
-  "TaskId": "Vec<u8>",
-  "PriorityScore": "u32",
-  "RoundIndex": "u32",
-  "Task": {
-    "id": "TaskId",
-    "score": "PriorityScore",
-    "proposed_at": "BlockNumber"
-  },
-  "ValueStruct": {
-    "integer": "i32",
-    "boolean": "bool"
-  },
-  "BufferIndex": "u8",
-  "InnerThing": "InnerThingOf",
-  "SuperThing": {
-    "super_number": "u32",
-    "inner_thing": "InnerThing"
-  }
+  "LookupSource": "AccountId"
 }

--- a/runtimes/ocw-runtime/aggregate_types.js
+++ b/runtimes/ocw-runtime/aggregate_types.js
@@ -14,8 +14,7 @@ const pallets = [
 // These specifics are from https://polkadot.js.org/api/start/types.extend.html#impact-on-extrinsics
 const runtimeOwnTypes = {
 	"Address": "AccountId",
-	"LookupSource": "AccountId",
-  "Weight": "u32"
+	"LookupSource": "AccountId"
 }
 
 // Loop through all pallets aggregating types

--- a/runtimes/ocw-runtime/types.json
+++ b/runtimes/ocw-runtime/types.json
@@ -1,5 +1,4 @@
 {
   "Address": "AccountId",
-  "LookupSource": "AccountId",
-  "Weight": "u32"
+  "LookupSource": "AccountId"
 }

--- a/runtimes/super-runtime/aggregate_types.js
+++ b/runtimes/super-runtime/aggregate_types.js
@@ -36,8 +36,7 @@ const pallets = [
 // These specifics are from https://polkadot.js.org/api/start/types.extend.html#impact-on-extrinsics
 const runtimeOwnTypes = {
   "Address": "AccountId",
-  "LookupSource": "AccountId",
-  "Weight": "u32"
+  "LookupSource": "AccountId"
 }
 
 // Loop through all pallets aggregating types

--- a/runtimes/super-runtime/types.json
+++ b/runtimes/super-runtime/types.json
@@ -1,7 +1,6 @@
 {
   "Address": "AccountId",
   "LookupSource": "AccountId",
-  "Weight": "u32",
   "ContinuousAccountData": {
     "principal": "u64",
     "deposit_date": "BlockNumber"

--- a/runtimes/weight-fee-runtime/aggregate_types.js
+++ b/runtimes/weight-fee-runtime/aggregate_types.js
@@ -14,8 +14,7 @@ const pallets = [
 // These specifics are from https://polkadot.js.org/api/start/types.extend.html#impact-on-extrinsics
 const runtimeOwnTypes = {
   "Address": "AccountId",
-  "LookupSource": "AccountId",
-  "Weight": "u32"
+  "LookupSource": "AccountId"
 }
 
 // Loop through all pallets aggregating types

--- a/runtimes/weight-fee-runtime/types.json
+++ b/runtimes/weight-fee-runtime/types.json
@@ -1,5 +1,4 @@
 {
   "Address": "AccountId",
-  "LookupSource": "AccountId",
-  "Weight": "u32"
+  "LookupSource": "AccountId"
 }


### PR DESCRIPTION
This PR removes the explicit type `"Weight": "u32"` from all runtimes.

This type was necessary for nodes based on the older Substrate v2.0.0-alpha.6 to work with recent versions of Apps. Nodes in the develop branch, however, are updated to newer Substrate which works with Apps by default and thus those types are no longer necessary.