### PR TITLE
Update CI to support gitflow

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -4,9 +4,10 @@ on:
   pull_request:
     branches:
     - master
+    - develop
 
 jobs:
-  build:
+  build-book:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/build-deploy-book.yml
+++ b/.github/workflows/build-deploy-book.yml
@@ -6,7 +6,7 @@ on:
     - master
 
 jobs:
-  build-deploy:
+  build-deploy-book:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -1,15 +1,17 @@
-name: Test
+name: Test Code
 
 on:
   pull_request:
     branches:
     - master
+    - develop
   push:
     branches:
     - master
+    -develop
 
 jobs:
-  build:
+  test-code:
     runs-on: ubuntu-18.04
 
     steps:

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -8,7 +8,7 @@ on:
   push:
     branches:
     - master
-    -develop
+    - develop
 
 jobs:
   test-code:


### PR DESCRIPTION
This PR modifies the CI to support the [gitflow]() workflow we recently adopted in the Recipes.

In particular it:
* Builds the book on PRs and pushes to both `master` _and `develop`_
* `check`s and `test`s the code on PRs and pushes to both `master` _and `develop`_
* Gives the jobs more descriptive names which will pay off when failed jobs prevent merging.