### PR TITLE
Update Contributing Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,9 +38,8 @@ It is time  to tag a new release when either, enough new features have been cont
 1. Create a release branch off of `develop`.
 2. Update dependencies to crates.io.
 3. Update version of each Recipes crate.
-4. Update version listed in the main `README.md`.
-5. Make a pull request against `master`.
-6. Tag the new release version in the history of `master` only after the release branch is merged.
+4. Make a pull request against `master`.
+5. Tag the new release version in the history of `master` only after the release branch is merged.
 
 ## Proposing Changes and Additions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ If you would like to make a change or addition to the recipes, you do not need a
 
 ### What to Contribute
 
-Anything you think will make the Recipes better, is worth proposing. Here are some ideas to get you started.
+Anything you think will make the Recipes better, is worth proposing. Here are some ideas to get you started. All of these ideas and more are listed in our [issue queue](https://github.com/substrate-developer-hub/recipes/issues)
 
 * **Test Coverage** - Not all code is covered, and not all covered code is covered well, but we would like more and better coverage.
 * **New recipes** - If you know how to do something useful in Substrate that is not yet covered in the Recipes, please contribute.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ The Substrate Recipes strive to identify and extract useful patterns and example
 The Recipes are part of the Substrate Developer Hub, so inter-linking between the Recipes and other DevHub facets is common. In particular, the Recipes frequently links to:
 * The [Reference Docs](https://substrate.dev/rustdocs/master/)
 * The [Tutorials](https://substrate.io/tutorials/)
-* The [Knowledge Base](https://substrate.dev/docs)
+* The [Knowledge Base](https://substrate.io/kb/learn-substrate)
 
 ## Reporting Bugs
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,6 @@ Prefer listing dependencies under a single `[dependencies]` header in lieu of us
 No standards for language style are enforced aside from the common English spelling/grammar rules. @4meta5 has a few *preferences*:
 * Avoid using "we", "our", "you" because it often is conducive to unnecessary language
 * Prefer active voice ("you may want to use active voice" `=>` "use active voice")
-* Link as often as possible to outside content and useful resources including other recipes, knowledgebase,
+* Link as often as possible to outside content and useful resources including other recipes, knowledge base,
 tutorials, Wikipedia, and 3rd party content. It is not necessary to re-link the same external resource on subsequent
 mentions in a single document.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,57 +1,74 @@
 # Contributing Guidelines
 
-The **purpose** of [Substrate Recipes](https://substrate.dev/recipes/) is to identify best practices and extract useful patterns for developing on Substrate, and to present those patterns in an approachable and fun format.
+The Substrate Recipes strive to identify and extract useful patterns and examples of developing on Substrate, and to present those patterns in an approachable and fun format. **Your help is Welcome!**
 
-The recipes onboards aspiring blockchain developers by focusing first on **FRAME pallet development** patterns before reusing these patterns in the context of **runtime configurations**, and finally installing those runtimes in full substrate-based nodes.
+The Recipes are part of the Substrate Developer Hub, so inter-linking between the Recipes and other DevHub facets is common. In particular, the Recipes frequently links to:
+* The [Reference Docs](https://substrate.dev/rustdocs/master/)
+* The [Tutorials](https://substrate.io/tutorials/)
+* The [Knowledge Base](https://substrate.dev/docs)
 
-The recipes supplements existing resources by providing usage examples, demonstrating best practices in context, and extending simple samples/tutorials. Likewise, it is necessary to **frequently link to/from [reference docs](https://substrate.dev/rustdocs/master/), [tutorials](https://substrate.dev/tutorials/), and [high-level docs](https://substrate.dev/docs)**.
+## Reporting Bugs
 
-## Chef's Workflow
+One way to contribute to the Recipes, is to report issues you find when using the Recipes. You may report new issues at https://github.com/substrate-developer-hub/recipes/issues. When reporting an issue, please inlcude the following information.
 
-1. Isolate useful pattern(s) from the main [Substrate](https://github.com/paritytech/substrate) repository and other code that builds on Substrate.
+* **Short summary of the issue encountered** - In a sentence or two explain what the issue is at a high level.
+* **What recipe has the issue** - You may specify the recipe by name (eg. )"Basic PoW Node"), directory (eg. `/nodes/basic-pow`), or GitHub link (eg. https://github.com/substrate-developer-hub/recipes/tree/master/nodes/basic-pow). Other unambiguous ways of specifying the particular recipe are also acceptable (eg. crates.io link, or rendered text link).
+* **Steps to reproduce** - What actions did you take to notice the issue? Did you submit a particular extrinsic? Did you compile the code a particular way? What command did you run the node with?
+* **Expected Behavior** - What were you expecting to happen when you encountered the bug?
+* **Observed Behavior** - What actually happened when you encountered the bug?
+* **Additional Relevant Information** - What error message did you receive? What OS and rust compiler are you using?
 
-2. Open an [issue](https://github.com/substrate-developer-hub/recipes/issues/new) describing how the pattern can be condensed into a recipe.
+## Git Workflow
 
-3. Fork the [recipes](https://github.com/substrate-developer-hub/recipes). Before making any changes, checkout another branch.
+The recipes follows closely to [gitflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow). That means there are two main branches in the repository, `master`, and `develop` as well as any number of topic branches. If you aren't familiar with gitflow, it is worth reading that article and studying the diagrams. One of the diagrams is included below.
 
-4. Write complete working code in one of the `pallets`, `runtimes`, or `nodes` directories, and add it the the workspace in `Cargo.toml`.
+![gitflow](https://wac-cdn.atlassian.com/dam/jcr:a9cea7b7-23c3-41a7-a4e0-affa053d9ea7/04%20(1).svg?cdnVersion=1017)
 
-5. Write the companion text in the `text` directory, referencing the code you wrote.
+### Master Branch
 
-6. Stage your changes locally (see below).
+The `master` branch contains stable, published code and is where release versions are tagged. Released versions will always be in the history of the `master` branch. The code on `master` uses published dependencies from `crates.io` and uses git dependencies only where absolutely necessary because relevant crates are not published on crates.
 
-7. Open a new pull request. Thanks for you contributions <3.
+### Develop Branch
+The `develop` branch is where active development happens. It is where new recipes, restructures, revisions, CI updates, and most other changes are merged. In order to keep up with the latest Substrate development, the `develop` branch allows dependencies from git.
 
-### Testing and Staging Locally
-```bash
-# Test code
-cargo test --all
+### Cutting a Release
 
-# Install mdbook
-cargo install mdbook
+It is time  to tag a new release when either, enough new features have been contributed that releasing makes sense, or, more likely, Substrate itself has tagged a new release. The release process also follows gitflow. The process of creating a new release is usually undertaken by the project maintainer, but the steps are outlined here nonetheless.
 
-#Build and open rendered book in default browser
-mdbook build --open
-```
+1. Create a release branch off of `develop`.
+2. Update dependencies to crates.io.
+3. Update version of each Recipes crate.
+4. Update version listed in the main `README.md`.
+5. Make a pull request against `master`.
+6. Tag the new release version in the history of `master` only after the release branch is merged.
+
+## Proposing Changes and Additions
+
+If you would like to make a change or addition to the recipes, you do not need anyone's permission to get started. You may simply open a Pull Request against the `develop` branch. Of course, not all changes will be accepted, and changes should either be in line with the existing Recipes structure or refactor that structure for a good reason. If you would like to get preliminary input from the Recipes' maintainers before beginning, you may [open an issue](https://github.com/substrate-developer-hub/recipes/issues) discussing your idea first. Either approach (PR or issue) is welcome.
+
+### What to Contribute
+
+Anything you think will make the Recipes better, is worth proposing. Here are some ideas to get you started.
+
+* **Test Coverage** - Not all code is covered, and not all covered code is covered well, but we would like more and better coverage.
+* **New recipes** - If you know how to do something useful in Substrate that is not yet covered in the Recipes, please contribute.
+* **UX improvements** - Any way to make it easier and less confusing to get new users on boarded is welcome.
+* **CI Improvements** - The more tests we have automated, the higher quality the Recipes will be.
 
 ## Style
 
 ### Rust Code
 There is not yet strict enforcement of the [Rust in Substrate coding style](https://wiki.parity.io/Substrate-Style-Guide), but it is highly encouraged to wrap lines at 120 characters a line (or less) for improving reviewer experience on github.
 
-Graciously invoke `cargo fmt` on any Rust code -- this should soon be enforced by CI!
+Graciously invoke `cargo fmt` and `cargo clippy` on any Rust code; This should soon be enforced by CI.
 
 ### Cargo.toml
-Prefer listing dependencies under a single `[dependencies]` header in lieu of using a `[dependencies.some_import]` for every `some_import` module imported. This preference is not enforced. See [`adding-machine/Cargo.toml`](https://github.com/substrate-developer-hub/recipes/blob/master/pallets/adding-machine/Cargo.toml) for an example of the recommended less verbose `Cargo.toml` syntax.
+Prefer listing dependencies under a single `[dependencies]` header in lieu of using a `[dependencies.some_import]` for every `some_import` module imported.
 
 ### English
 No standards for language style are enforced aside from the common English spelling/grammar rules. @4meta5 has a few *preferences*:
 * Avoid using "we", "our", "you" because it often is conducive to unnecessary language
-* Prefer active voice (instead of "you may want to use active voice" `=>` "use active voice")
-* Link as often as possible to outside content and useful resources including other recipes, docs,
-tutorials, and code. It is not necessary to re-link the same external resource on subsequent
+* Prefer active voice ("you may want to use active voice" `=>` "use active voice")
+* Link as often as possible to outside content and useful resources including other recipes, knowledgebase,
+tutorials, Wikipedia, and 3rd party content. It is not necessary to re-link the same external resource on subsequent
 mentions in a single document.
-
-## Test Coverage
-Not all code is covered, and not all covered code is covered well, but we have a good start and will continue to improve. Your help is warmly welcomed.
-Run the tests with `cargo test -- all`.

--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ The Substrate Recipes are [GPL 3.0 Licensed](LICENSE) It is open source and [ope
 
 ## Using Recipes in External Projects
 
-The pallets and runtimes provided here are tested and ready to be used in other Substrate-based blockchains. The big caveat is that you must use the same upstream Substrate version throughout the project. The recipes currently use Substrate@`7e9a2ae`.
+The pallets and runtimes provided here are tested and ready to be used in other Substrate-based blockchains. The big caveat is that you must use the same upstream Substrate version throughout the project.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ _A Hands-On Cookbook for Aspiring Blockchain Chefs_
 Ready to roll up your sleeves and cook some blockchain? Read the book online at [substrate.dev/recipes](https://substrate.dev/recipes)
 
 ## Repository Structure
-There are four primary directories in this repository:
+There are five primary directories in this repository:
 
 * **Text**: Source of [the book](https://substrate.dev/recipes) written in markdown. This text describes the code in the other three directories.
-* **Pallets**: Complete pallets for use in FRAME-based runtimes.
-* **Runtimes**: Complete runtimes for use in Substrate nodes.
+* **Pallets**: Pallets for use in FRAME-based runtimes.
+* **Runtimes**: Runtimes for use in Substrate nodes.
+* **Consensus**: Consensus engines for use in Substrate nodes.
 * **Nodes**: Complete Substrate nodes ready to run.
 
 The book is built with [mdbook](https://rust-lang-nursery.github.io/mdBook/) and deployed via [github pages](https://pages.github.com/).
@@ -22,4 +23,4 @@ The Substrate Recipes are [GPL 3.0 Licensed](LICENSE) It is open source and [ope
 
 ## Using Recipes in External Projects
 
-The pallets and runtimes provided here are tested and ready to be used in other Substrate-based blockchains. The big caveat is that you must use the same upstream Substrate version throughout the project. The recipes currently use Substrate@`v2.0.0-alpha.7`.
+The pallets and runtimes provided here are tested and ready to be used in other Substrate-based blockchains. The big caveat is that you must use the same upstream Substrate version throughout the project. The recipes currently use Substrate@`7e9a2ae`.


### PR DESCRIPTION
This PR updates the contributing guidelines (and readme) to reflect the current state of the Recipes, and the decision to follow gitflow.