### PR TITLE
Clean cargo.toml files

### DIFF
--- a/pallets/adding-machine/Cargo.toml
+++ b/pallets/adding-machine/Cargo.toml
@@ -10,14 +10,14 @@ default = ['std']
 std = [
     'parity-scale-codec/std',
     'frame-support/std',
-    'system/std',
+    'frame-system/std',
     'sp-runtime/std',
 ]
 
 [dependencies]
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { package = "frame-support", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
-system = { package = "frame-system", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+frame-support = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+frame-system = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
 sp-runtime = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
 
 [dev-dependencies]

--- a/pallets/adding-machine/Cargo.toml
+++ b/pallets/adding-machine/Cargo.toml
@@ -16,10 +16,10 @@ std = [
 
 [dependencies]
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { package = "frame-support", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
-system = { package = "frame-system", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
-sp-runtime = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
+frame-support = { package = "frame-support", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+system = { package = "frame-system", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+sp-runtime = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
 
 [dev-dependencies]
-sp-core = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
-sp-io = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
+sp-core = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+sp-io = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }

--- a/pallets/adding-machine/src/lib.rs
+++ b/pallets/adding-machine/src/lib.rs
@@ -5,7 +5,7 @@
 //! A simple adding machine which checks for overflow and unlucky numbers.
 //! Throws errors accordingly
 use frame_support::{decl_error, decl_module, decl_storage, dispatch::DispatchResult, ensure};
-use system::ensure_signed;
+use frame_system::{self as system, ensure_signed};
 
 #[cfg(test)]
 mod tests;

--- a/pallets/adding-machine/src/tests.rs
+++ b/pallets/adding-machine/src/tests.rs
@@ -1,5 +1,6 @@
 use crate::{Error, Module, Trait};
 use frame_support::{assert_noop, assert_ok, impl_outer_origin, parameter_types};
+use frame_system as system;
 use sp_core::H256;
 use sp_io::TestExternalities;
 use sp_runtime::{

--- a/pallets/basic-token/Cargo.toml
+++ b/pallets/basic-token/Cargo.toml
@@ -15,10 +15,10 @@ std = [
 
 [dependencies]
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
-frame-system = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
+frame-support = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+frame-system = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
 
 [dev-dependencies]
-sp-core = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
-sp-io = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
-sp-runtime = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
+sp-core = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+sp-io = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+sp-runtime = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }

--- a/pallets/check-membership/Cargo.toml
+++ b/pallets/check-membership/Cargo.toml
@@ -17,8 +17,8 @@ std = [
 
 [dependencies]
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
-frame-system = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-sp-runtime = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
-sp-core = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
-sp-std = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
+frame-support = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+frame-system = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+sp-runtime = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+sp-core = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+sp-std = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }

--- a/pallets/generic-event/Cargo.toml
+++ b/pallets/generic-event/Cargo.toml
@@ -10,14 +10,14 @@ default = ['std']
 std = [
     'parity-scale-codec/std',
     'frame-support/std',
-    'system/std',
+    'frame-system/std',
     'sp-runtime/std',
 ]
 
 [dependencies]
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { package = "frame-support", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
-system = { package = "frame-system", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+frame-support = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+frame-system = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
 sp-runtime = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
 
 [dev-dependencies]

--- a/pallets/generic-event/Cargo.toml
+++ b/pallets/generic-event/Cargo.toml
@@ -16,10 +16,10 @@ std = [
 
 [dependencies]
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { package = "frame-support", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
-system = { package = "frame-system", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
-sp-runtime = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
+frame-support = { package = "frame-support", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+system = { package = "frame-system", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+sp-runtime = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
 
 [dev-dependencies]
-sp-core = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
-sp-io = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
+sp-core = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+sp-io = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }

--- a/pallets/generic-event/src/lib.rs
+++ b/pallets/generic-event/src/lib.rs
@@ -3,7 +3,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use frame_support::{decl_event, decl_module, dispatch::DispatchResult};
-use system::ensure_signed;
+use frame_system::{self as system, ensure_signed};
 
 #[cfg(test)]
 mod tests;

--- a/pallets/generic-event/src/tests.rs
+++ b/pallets/generic-event/src/tests.rs
@@ -1,5 +1,6 @@
 use crate::{Module, RawEvent, Trait};
 use frame_support::{assert_ok, impl_outer_event, impl_outer_origin, parameter_types};
+use frame_system as system;
 use sp_core::H256;
 use sp_io::TestExternalities;
 use sp_runtime::{

--- a/pallets/randomness/Cargo.toml
+++ b/pallets/randomness/Cargo.toml
@@ -10,11 +10,11 @@ license = "GPL-3.0-or-later"
 parity-scale-codec = { default-features = false, features = ['derive'], version = '1.3.0' }
 
 # Substrate pallet/frame dependencies
-frame-support = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
-frame-system = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
-sp-runtime = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
-sp-std = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
-sp-core = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
+frame-support = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+frame-system = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+sp-runtime = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+sp-std = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+sp-core = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
 
 [dev-dependencies]
 sp-io = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }

--- a/pallets/simple-event/Cargo.toml
+++ b/pallets/simple-event/Cargo.toml
@@ -16,10 +16,10 @@ std = [
 
 [dependencies]
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { package = "frame-support", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
-system = { package = "frame-system", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
-sp-runtime = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
+frame-support = { package = "frame-support", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+system = { package = "frame-system", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+sp-runtime = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
 
 [dev-dependencies]
-sp-core = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
-sp-io = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
+sp-core = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+sp-io = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }

--- a/pallets/single-value/Cargo.toml
+++ b/pallets/single-value/Cargo.toml
@@ -16,10 +16,10 @@ std = [
 
 [dependencies]
 parity-scale-codec = { default-features = false, features = ['derive'], version = '1.3.0' }
-frame-support = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561',  default_features = false }
-frame-system  = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561',  default_features = false }
-sp-runtime = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561',  default_features = false }
+frame-support = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+frame-system  = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+sp-runtime = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
 
 [dev-dependencies]
-sp-core = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
-sp-io = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
+sp-core = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+sp-io = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }

--- a/pallets/storage-cache/Cargo.toml
+++ b/pallets/storage-cache/Cargo.toml
@@ -10,14 +10,14 @@ license = "GPL-3.0-or-later"
 parity-scale-codec = { default-features = false, features = ['derive'], version = '1.3.0' }
 
 # Substrate pallet/frame dependencies
-frame-support = { package = 'frame-support', version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
-frame-system = { package = 'frame-system', version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
-sp-runtime = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
-sp-std = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
+frame-support = { package = 'frame-support', version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+frame-system = { package = 'frame-system', version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+sp-runtime = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+sp-std = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
 
 [dev-dependencies]
-sp-core = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
-sp-io = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
+sp-core = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
+sp-io = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
 
 [features]
 default = ['std']

--- a/pallets/sum-storage/Cargo.toml
+++ b/pallets/sum-storage/Cargo.toml
@@ -7,15 +7,15 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-sp-runtime = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-frame-support = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-frame-system = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
+sp-std = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+sp-runtime = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+frame-support = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+frame-system = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
 
 
 [dev-dependencies]
-sp-io = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-sp-core = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
+sp-io = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+sp-core = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
 
 [features]
 default = ["std"]

--- a/pallets/sum-storage/rpc/Cargo.toml
+++ b/pallets/sum-storage/rpc/Cargo.toml
@@ -12,12 +12,12 @@ jsonrpc-core-client = "14.0.3"
 jsonrpc-derive = "14.0.3"
 serde = { version = "1.0.101", features = ["derive"], optional = true }
 
-sp-rpc = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-sp-runtime = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-sp-blockchain = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-sp-api = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false }
+sp-rpc = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+sp-runtime = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+sp-blockchain = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+sp-api = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
 
-sum-storage-runtime-api = { version = "2.0.0", path = "../runtime-api", default_features = false }
+sum-storage-runtime-api = { version = "2.0.0", path = "../runtime-api", default-features = false }
 
 [features]
 default = ["std"]

--- a/pallets/sum-storage/runtime-api/Cargo.toml
+++ b/pallets/sum-storage/runtime-api/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "GPL-3.0-or-later"
 
 [dependencies]
-sp-api = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
+sp-api = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
 
 [dev-dependencies]
 serde_json = "1.0.41"

--- a/runtimes/api-runtime/Cargo.toml
+++ b/runtimes/api-runtime/Cargo.toml
@@ -6,30 +6,30 @@ edition = "2018"
 license = "GPL-3.0-or-later"
 
 [dependencies]
-balances = { package = "pallet-balances", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-frame-support = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-indices = { package = "pallet-indices", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-sudo = { package = "pallet-sudo", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-frame-system = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-timestamp = { package = "pallet-timestamp", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-transaction-payment = { package = "pallet-transaction-payment", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-randomness-collective-flip = { package = "pallet-randomness-collective-flip", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
+balances = { package = "pallet-balances", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+frame-support = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+indices = { package = "pallet-indices", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+sudo = { package = "pallet-sudo", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+frame-system = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+timestamp = { package = "pallet-timestamp", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+transaction-payment = { package = "pallet-transaction-payment", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+randomness-collective-flip = { package = "pallet-randomness-collective-flip", version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
 
 parity-scale-codec = { version = "1.3.0", default-features = false, features = ["derive"] }
-frame-executive = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
+frame-executive = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
 
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-sp-api = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-sp-block-builder = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-sp-core = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-sp-inherents = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-sp-io = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-sp-offchain = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-sp-runtime = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-sp-session = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-sp-std = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-sp-transaction-pool = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
-sp-version = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
+sp-api = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+sp-block-builder = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+sp-core = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+sp-inherents = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+sp-io = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+sp-offchain = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+sp-runtime = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+sp-session = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+sp-std = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+sp-transaction-pool = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
+sp-version = { version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
 sum-storage = { default-features = false, path = "../../pallets/sum-storage" }
 sum-storage-runtime-api = { default-features = false, path = "../../pallets/sum-storage/runtime-api" }
 

--- a/runtimes/babe-grandpa-runtime/Cargo.toml
+++ b/runtimes/babe-grandpa-runtime/Cargo.toml
@@ -10,7 +10,7 @@ description = "A Substrate runtime that demonstrates managing Babe and Grandpa A
 parity-scale-codec = { version = "1.3.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 # Substrate Pallets
-babe = { package = 'pallet-babe', version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default_features = false}
+babe = { package = 'pallet-babe', version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false}
 balances = { package = 'pallet-balances', version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
 grandpa = { package = 'pallet-grandpa', version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }
 randomness-collective-flip = { package = 'pallet-randomness-collective-flip', version = '2.0.0-alpha.7', git = 'https://github.com/paritytech/substrate', rev = '7e9a2ae78d27cc56e053fbec3b34a1a258b89561', default-features = false }

--- a/runtimes/super-runtime/Cargo.toml
+++ b/runtimes/super-runtime/Cargo.toml
@@ -30,9 +30,9 @@ fixed-point = { path = "../../pallets/fixed-point", default-features = false }
 generic-event = { path = "../../pallets/generic-event", default-features = false }
 hello-substrate = { path = "../../pallets/hello-substrate", default-features = false }
 last-caller = { path = "../../pallets/last-caller", default-features = false }
-ringbuffer-queue = { path = "../../pallets/ringbuffer-queue", default_features = false }
-randomness = { path = "../../pallets/randomness", default_features = false }
-simple-event = { path = "../../pallets/simple-event", default_features = false }
+ringbuffer-queue = { path = "../../pallets/ringbuffer-queue", default-features = false }
+randomness = { path = "../../pallets/randomness", default-features = false }
+simple-event = { path = "../../pallets/simple-event", default-features = false }
 simple-map = { path = "../../pallets/simple-map", default-features = false }
 single-value = { path = "../../pallets/single-value", default-features = false }
 storage-cache = { path = "../../pallets/storage-cache", default-features = false }

--- a/text/3-entrees/testing/mock.md
+++ b/text/3-entrees/testing/mock.md
@@ -169,7 +169,7 @@ In the `Cargo.toml`, this only needs to be imported under `dev-dependencies` sin
 
 ```
 [dev-dependencies.sp-io]
-default_features = false
+default-features = false
 
 version = '2.0.0-alpha.7'
 ```


### PR DESCRIPTION
This PR cleans up several `Cargo.toml` files. This is generally good because uniformity is good. It also facilitates the release process, by making search and replace work better. There are two primary changes.

1. always use `default-features` rather than `default_features`
2. remove a few instances of two consecutive spaces between keys
3. remove a few instances of unnecessary package aliasing