### PR TITLE
Format markdown with Prettier

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "printWidth": 100,
+  "proseWrap": "always"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,39 +1,66 @@
 # Contributing Guidelines
 
-The Substrate Recipes strive to identify and extract useful patterns and examples of developing on Substrate, and to present those patterns in an approachable and fun format. **Your help is Welcome!**
+The Substrate Recipes strive to identify and extract useful patterns and examples of developing on
+Substrate, and to present those patterns in an approachable and fun format. **Your help is
+Welcome!**
 
-The Recipes are part of the Substrate Developer Hub, so inter-linking between the Recipes and other DevHub facets is common. In particular, the Recipes frequently links to:
-* The [Reference Docs](https://crates.parity.io/)
-* The [Tutorials](https://substrate.io/tutorials/)
-* The [Knowledge Base](https://substrate.io/kb/learn-substrate)
+The Recipes are part of the Substrate Developer Hub, so inter-linking between the Recipes and other
+DevHub facets is common. In particular, the Recipes frequently links to:
+
+-   The [Reference Docs](https://crates.parity.io/)
+-   The [Tutorials](https://substrate.io/tutorials/)
+-   The [Knowledge Base](https://substrate.io/kb/learn-substrate)
 
 ## Reporting Bugs
 
-One way to contribute to the Recipes, is to report issues you find when using the Recipes. You may report new issues at https://github.com/substrate-developer-hub/recipes/issues. When reporting an issue, please inlcude the following information.
+One way to contribute to the Recipes, is to report issues you find when using the Recipes. You may
+report new issues at https://github.com/substrate-developer-hub/recipes/issues. When reporting an
+issue, please inlcude the following information.
 
-* **Short summary of the issue encountered** - In a sentence or two explain what the issue is at a high level.
-* **What recipe has the issue** - You may specify the recipe by name (eg. )"Basic PoW Node"), directory (eg. `/nodes/basic-pow`), or GitHub link (eg. https://github.com/substrate-developer-hub/recipes/tree/master/nodes/basic-pow). Other unambiguous ways of specifying the particular recipe are also acceptable (eg. crates.io link, or rendered text link).
-* **Steps to reproduce** - What actions did you take to notice the issue? Did you submit a particular extrinsic? Did you compile the code a particular way? What command did you run the node with?
-* **Expected Behavior** - What were you expecting to happen when you encountered the bug?
-* **Observed Behavior** - What actually happened when you encountered the bug?
-* **Additional Relevant Information** - What error message did you receive? What OS and rust compiler are you using?
+-   **Short summary of the issue encountered** - In a sentence or two explain what the issue is at a
+    high level.
+-   **What recipe has the issue** - You may specify the recipe by name (eg. )"Basic PoW Node"),
+    directory (eg. `/nodes/basic-pow`), or GitHub link (eg.
+    https://github.com/substrate-developer-hub/recipes/tree/master/nodes/basic-pow). Other
+    unambiguous ways of specifying the particular recipe are also acceptable (eg. crates.io link, or
+    rendered text link).
+-   **Steps to reproduce** - What actions did you take to notice the issue? Did you submit a
+    particular extrinsic? Did you compile the code a particular way? What command did you run the
+    node with?
+-   **Expected Behavior** - What were you expecting to happen when you encountered the bug?
+-   **Observed Behavior** - What actually happened when you encountered the bug?
+-   **Additional Relevant Information** - What error message did you receive? What OS and rust
+    compiler are you using?
 
 ## Git Workflow
 
-The recipes follows closely to [gitflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow). That means there are two main branches in the repository, `master`, and `develop` as well as any number of topic branches. If you aren't familiar with gitflow, it is worth reading that article and studying the diagrams. One of the diagrams is included below.
+The recipes follows closely to
+[gitflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow). That means
+there are two main branches in the repository, `master`, and `develop` as well as any number of
+topic branches. If you aren't familiar with gitflow, it is worth reading that article and studying
+the diagrams. One of the diagrams is included below.
 
-![gitflow](https://wac-cdn.atlassian.com/dam/jcr:a9cea7b7-23c3-41a7-a4e0-affa053d9ea7/04%20(1).svg?cdnVersion=1017)
+![gitflow](<https://wac-cdn.atlassian.com/dam/jcr:a9cea7b7-23c3-41a7-a4e0-affa053d9ea7/04%20(1).svg?cdnVersion=1017>)
 
 ### Master Branch
 
-The `master` branch contains stable, published code and is where release versions are tagged. Released versions will always be in the history of the `master` branch. The code on `master` uses published dependencies from `crates.io` and uses git dependencies only where absolutely necessary because relevant crates are not published on crates.
+The `master` branch contains stable, published code and is where release versions are tagged.
+Released versions will always be in the history of the `master` branch. The code on `master` uses
+published dependencies from `crates.io` and uses git dependencies only where absolutely necessary
+because relevant crates are not published on crates.
 
 ### Develop Branch
-The `develop` branch is where active development happens. It is where new recipes, restructures, revisions, CI updates, and most other changes are merged. In order to keep up with the latest Substrate development, the `develop` branch allows dependencies from git.
+
+The `develop` branch is where active development happens. It is where new recipes, restructures,
+revisions, CI updates, and most other changes are merged. In order to keep up with the latest
+Substrate development, the `develop` branch allows dependencies from git.
 
 ### Cutting a Release
 
-It is time  to tag a new release when either, enough new features have been contributed that releasing makes sense, or, more likely, Substrate itself has tagged a new release. The release process also follows gitflow. The process of creating a new release is usually undertaken by the project maintainer, but the steps are outlined here nonetheless.
+It is time to tag a new release when either, enough new features have been contributed that
+releasing makes sense, or, more likely, Substrate itself has tagged a new release. The release
+process also follows gitflow. The process of creating a new release is usually undertaken by the
+project maintainer, but the steps are outlined here nonetheless.
 
 1. Create a release branch off of `develop`.
 1. Update dependencies to crates.io.
@@ -44,31 +71,52 @@ It is time  to tag a new release when either, enough new features have been cont
 
 ## Proposing Changes and Additions
 
-If you would like to make a change or addition to the recipes, you do not need anyone's permission to get started. You may simply open a Pull Request against the `develop` branch. Of course, not all changes will be accepted, and changes should either be in line with the existing Recipes structure or refactor that structure for a good reason. If you would like to get preliminary input from the Recipes' maintainers before beginning, you may [open an issue](https://github.com/substrate-developer-hub/recipes/issues) discussing your idea first. Either approach (PR or issue) is welcome.
+If you would like to make a change or addition to the recipes, you do not need anyone's permission
+to get started. You may simply open a Pull Request against the `develop` branch. Of course, not all
+changes will be accepted, and changes should either be in line with the existing Recipes structure
+or refactor that structure for a good reason. If you would like to get preliminary input from the
+Recipes' maintainers before beginning, you may
+[open an issue](https://github.com/substrate-developer-hub/recipes/issues) discussing your idea
+first. Either approach (PR or issue) is welcome.
 
 ### What to Contribute
 
-Anything you think will make the Recipes better, is worth proposing. Here are some ideas to get you started. All of these ideas and more are listed in our [issue queue](https://github.com/substrate-developer-hub/recipes/issues)
+Anything you think will make the Recipes better, is worth proposing. Here are some ideas to get you
+started. All of these ideas and more are listed in our
+[issue queue](https://github.com/substrate-developer-hub/recipes/issues)
 
-* **Test Coverage** - Not all code is covered, and not all covered code is covered well, but we would like more and better coverage.
-* **New recipes** - If you know how to do something useful in Substrate that is not yet covered in the Recipes, please contribute.
-* **UX improvements** - Any way to make it easier and less confusing to get new users on boarded is welcome.
-* **CI Improvements** - The more tests we have automated, the higher quality the Recipes will be.
+-   **Test Coverage** - Not all code is covered, and not all covered code is covered well, but we
+    would like more and better coverage.
+-   **New recipes** - If you know how to do something useful in Substrate that is not yet covered in
+    the Recipes, please contribute.
+-   **UX improvements** - Any way to make it easier and less confusing to get new users on boarded
+    is welcome.
+-   **CI Improvements** - The more tests we have automated, the higher quality the Recipes will be.
 
 ## Style
 
 ### Rust Code
-There is not yet strict enforcement of the [Rust in Substrate coding style](https://wiki.parity.io/Substrate-Style-Guide), but it is highly encouraged to wrap lines at 120 characters a line (or less) for improving reviewer experience on github.
 
-Graciously invoke `cargo fmt` and `cargo clippy` on any Rust code; This should soon be enforced by CI.
+There is not yet strict enforcement of the
+[Rust in Substrate coding style](https://wiki.parity.io/Substrate-Style-Guide), but it is highly
+encouraged to wrap lines at 120 characters a line (or less) for improving reviewer experience on
+github.
+
+Graciously invoke `cargo fmt` and `cargo clippy` on any Rust code; This should soon be enforced by
+CI.
 
 ### Cargo.toml
-Prefer listing dependencies under a single `[dependencies]` header in lieu of using a `[dependencies.some_import]` for every `some_import` module imported.
+
+Prefer listing dependencies under a single `[dependencies]` header in lieu of using a
+`[dependencies.some_import]` for every `some_import` module imported.
 
 ### English
-No standards for language style are enforced aside from the common English spelling/grammar rules. @4meta5 has a few *preferences*:
-* Avoid using "we", "our", "you" because it often is conducive to unnecessary language
-* Prefer active voice ("you may want to use active voice" `=>` "use active voice")
-* Link as often as possible to outside content and useful resources including other recipes, knowledge base,
-tutorials, Wikipedia, and 3rd party content. It is not necessary to re-link the same external resource on subsequent
-mentions in a single document.
+
+No standards for language style are enforced aside from the common English spelling/grammar rules.
+@4meta5 has a few _preferences_:
+
+-   Avoid using "we", "our", "you" because it often is conducive to unnecessary language
+-   Prefer active voice ("you may want to use active voice" `=>` "use active voice")
+-   Link as often as possible to outside content and useful resources including other recipes,
+    knowledge base, tutorials, Wikipedia, and 3rd party content. It is not necessary to re-link the
+    same external resource on subsequent mentions in a single document.

--- a/README.md
+++ b/README.md
@@ -1,26 +1,36 @@
 # <a href="https://substrate.dev/recipes">Substrate Recipes</a> 🍴😋🍴
+
 ![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fsubstrate-developer-hub%2Frecipes%2Fbadge%3Fref%3Dmaster&style=flat)
 ![Lines of Code](https://tokei.rs/b1/github/substrate-developer-hub/recipes)
 
 _A Hands-On Cookbook for Aspiring Blockchain Chefs_
 
 ## Get Started
-Ready to roll up your sleeves and cook some blockchain? Read the book online at [substrate.dev/recipes](https://substrate.dev/recipes)
+
+Ready to roll up your sleeves and cook some blockchain? Read the book online at
+[substrate.dev/recipes](https://substrate.dev/recipes)
 
 ## Repository Structure
+
 There are five primary directories in this repository:
 
-* **Text**: Source of [the book](https://substrate.dev/recipes) written in markdown. This text describes the code in the other three directories.
-* **Pallets**: Pallets for use in FRAME-based runtimes.
-* **Runtimes**: Runtimes for use in Substrate nodes.
-* **Consensus**: Consensus engines for use in Substrate nodes.
-* **Nodes**: Complete Substrate nodes ready to run.
+-   **Text**: Source of [the book](https://substrate.dev/recipes) written in markdown. This text
+    describes the code in the other three directories.
+-   **Pallets**: Pallets for use in FRAME-based runtimes.
+-   **Runtimes**: Runtimes for use in Substrate nodes.
+-   **Consensus**: Consensus engines for use in Substrate nodes.
+-   **Nodes**: Complete Substrate nodes ready to run.
 
-The book is built with [mdbook](https://rust-lang-nursery.github.io/mdBook/) and deployed via [github pages](https://pages.github.com/).
+The book is built with [mdbook](https://rust-lang-nursery.github.io/mdBook/) and deployed via
+[github pages](https://pages.github.com/).
 
 ## License
-The Substrate Recipes are [GPL 3.0 Licensed](LICENSE) It is open source and [open for contributions](./CONTRIBUTING.md).
+
+The Substrate Recipes are [GPL 3.0 Licensed](LICENSE) It is open source and
+[open for contributions](./CONTRIBUTING.md).
 
 ## Using Recipes in External Projects
 
-The pallets and runtimes provided here are tested and ready to be used in other Substrate-based blockchains. The big caveat is that you must use the same upstream Substrate version throughout the project.
+The pallets and runtimes provided here are tested and ready to be used in other Substrate-based
+blockchains. The big caveat is that you must use the same upstream Substrate version throughout the
+project.

--- a/nodes/babe-grandpa-node/README.md
+++ b/nodes/babe-grandpa-node/README.md
@@ -1,10 +1,13 @@
 # Kitchen Node
-This Substrate-based node does not contain its own runtime. Rather it imports another runtime (like the ones here in the kitchen) through it's `Cargo.toml` file, and wraps them with a standard blockchain chasis including:
 
-* Babe block production
-* Grandpa Finality
-* A CLI interface
-* An RPC compatible with Polkadot-js API
+This Substrate-based node does not contain its own runtime. Rather it imports another runtime (like
+the ones here in the kitchen) through it's `Cargo.toml` file, and wraps them with a standard
+blockchain chasis including:
+
+-   Babe block production
+-   Grandpa Finality
+-   A CLI interface
+-   An RPC compatible with Polkadot-js API
 
 ## Building
 
@@ -27,6 +30,7 @@ cargo build --release
 ```
 
 ## Starting a Node
+
 To start a dev node (after building) run
 
 ```bash
@@ -34,10 +38,14 @@ To start a dev node (after building) run
 ./target/release/kitchen-node --dev
 ```
 
-There are many other ways to use this node which can be explored by running `kitchen-node --help` or reading general [Substrate Documentation](https://substrate.dev/).
+There are many other ways to use this node which can be explored by running `kitchen-node --help` or
+reading general [Substrate Documentation](https://substrate.dev/).
 
 ## Swapping Runtimes
-Multiple runtimes in the kitchen are compatible with this node. To swap just edit the `Cargo.toml` file. You may also use this node template to wrap your own custom runtimes. Just make sure you have Babe, Grandpa, and possibly other necessary pallets installed properly.
+
+Multiple runtimes in the kitchen are compatible with this node. To swap just edit the `Cargo.toml`
+file. You may also use this node template to wrap your own custom runtimes. Just make sure you have
+Babe, Grandpa, and possibly other necessary pallets installed properly.
 
 ```toml
 # Edit these lines to point to a different runtime.

--- a/pallets/execution-schedule/README.md
+++ b/pallets/execution-schedule/README.md
@@ -1,18 +1,22 @@
 # Execution Schedule
 
-This pallet abstracts away the scheduling of task execution and governs the priority of tasks using a council of `AccountId`s stored in runtime storage. 
+This pallet abstracts away the scheduling of task execution and governs the priority of tasks using
+a council of `AccountId`s stored in runtime storage.
 
-Although we could add more nuanced governance to the `Council`, the purpose of this example is to demonstrate how and when to use `on_initialize` and `on_finalize`.
+Although we could add more nuanced governance to the `Council`, the purpose of this example is to
+demonstrate how and when to use `on_initialize` and `on_finalize`.
 
 This example also demonstrates
-* generous usage of type aliases
-* sorting tasks by priority in `on_finalize`
-* signalling priority by council in the runtime (`signal_priority`)
-* preparing on-chain state in `on_initialize`
-* using a `double_map`
-* unit testing with a mock runtime
 
-The context of the example is scheduling the execution of tasks in a queue stored in the runtime. Tasks are structs declared like
+-   generous usage of type aliases
+-   sorting tasks by priority in `on_finalize`
+-   signalling priority by council in the runtime (`signal_priority`)
+-   preparing on-chain state in `on_initialize`
+-   using a `double_map`
+-   unit testing with a mock runtime
+
+The context of the example is scheduling the execution of tasks in a queue stored in the runtime.
+Tasks are structs declared like
 
 ```rust, ignore
 pub struct Task<BlockNumber> {

--- a/text/1-prepare-kitchen/1-build-node.md
+++ b/text/1-prepare-kitchen/1-build-node.md
@@ -2,22 +2,32 @@
 
 ## Prerequisites
 
-Before we can even begin compiling our first blockchain node, we need to have a properly configured Rust toolchain. There is a convenient script that will set up this toolchain for us, and we can run it with the following command.
+Before we can even begin compiling our first blockchain node, we need to have a properly configured
+Rust toolchain. There is a convenient script that will set up this toolchain for us, and we can run
+it with the following command.
 
 ```bash
 # Setup Rust and Substrate
 curl https://getsubstrate.io -sSf | bash -s -- --fast
 ```
 
-> This command downloads and executes code from the internet. Give yourself peace-of-mind by inspecting the [script's source](https://getsubstrate.io) to confirm it isn't doing anything nasty.
+> This command downloads and executes code from the internet. Give yourself peace-of-mind by
+> inspecting the [script's source](https://getsubstrate.io) to confirm it isn't doing anything
+> nasty.
 
 ### For Windows
 
-These instructions and the rest of the instructions in this chapter assume a unix-like environment such as Linux, MacOS, or Windows Subsystem for Linux (WSL). If you are a Windows user, WSL is the best way to proceed. If you want or need to work in a native Windows environment, this is possible, but is not covered in detail here. Please follow along with the [Getting Started on Windows](https://substrate.dev/docs/en/overview/getting-started#getting-started-on-windows) guide, then return here when you're ready to proceed.
+These instructions and the rest of the instructions in this chapter assume a unix-like environment
+such as Linux, MacOS, or Windows Subsystem for Linux (WSL). If you are a Windows user, WSL is the
+best way to proceed. If you want or need to work in a native Windows environment, this is possible,
+but is not covered in detail here. Please follow along with the
+[Getting Started on Windows](https://substrate.dev/docs/en/overview/getting-started#getting-started-on-windows)
+guide, then return here when you're ready to proceed.
 
 ## Compile the Kitchen Node
 
-If you haven't already, `git clone` the recipes repository. We also want to kick-start the node compilation as it may take about 30 minutes to complete depending on your hardware.
+If you haven't already, `git clone` the recipes repository. We also want to kick-start the node
+compilation as it may take about 30 minutes to complete depending on your hardware.
 
 ```bash
 # Clone the Recipes Repository
@@ -32,11 +42,15 @@ cd recipes
 cargo build --release -p kitchen-node
 ```
 
-As you work through the recipes, refer back to these instructions each time you wish to re-compile the node. Over time the commands will become familiar, and you will even modify them to compile other nodes.
+As you work through the recipes, refer back to these instructions each time you wish to re-compile
+the node. Over time the commands will become familiar, and you will even modify them to compile
+other nodes.
 
 ## Checking Your Work
 
-Once the compilation is completed, you can ensure that the node has built properly by displaying its help page. Notice that the node has built to the `target/release` directory. This is the default location for Rust projects.
+Once the compilation is completed, you can ensure that the node has built properly by displaying its
+help page. Notice that the node has built to the `target/release` directory. This is the default
+location for Rust projects.
 
 ```bash
 # Inside `recipes` directory

--- a/text/1-prepare-kitchen/2-interact-node.md
+++ b/text/1-prepare-kitchen/2-interact-node.md
@@ -1,10 +1,13 @@
 # Interact with the Kitchen Node
 
-If you followed the instructions to [build the node](./1-build-node.md), you my proceed to launch your first blockchain.
+If you followed the instructions to [build the node](./1-build-node.md), you my proceed to launch
+your first blockchain.
 
 ## Launch a Development Node
 
-Before we launch our node we will purge any chain data. If you've followed the instructions exactly, you will not yet have any chain data to purge, but on each subsequent run, you will, and it is best to get in the habit of purging your chain now. We will start our node in development mode (`--dev`).
+Before we launch our node we will purge any chain data. If you've followed the instructions exactly,
+you will not yet have any chain data to purge, but on each subsequent run, you will, and it is best
+to get in the habit of purging your chain now. We will start our node in development mode (`--dev`).
 
 ```bash
 # Purge existing blockchain data (if any)
@@ -14,7 +17,11 @@ Before we launch our node we will purge any chain data. If you've followed the i
 ./target/release/kitchen-node --dev
 ```
 
-You should now see your node up and running and waiting for transactions. This Kitchen Node, and several other nodes included with the Recipes, is an instant seal node. That means it will not create any blocks until there are transactions to process. It also means that when a transaction is ready, the node will instantly create a block. Instant seal nodes are ideal for experimenting with your Substrate runtime. The output looks something like this.
+You should now see your node up and running and waiting for transactions. This Kitchen Node, and
+several other nodes included with the Recipes, is an instant seal node. That means it will not
+create any blocks until there are transactions to process. It also means that when a transaction is
+ready, the node will instantly create a block. Instant seal nodes are ideal for experimenting with
+your Substrate runtime. The output looks something like this.
 
 ```
 2020-05-18 14:33:35 Running in --dev mode, RPC CORS has been disabled.
@@ -36,20 +43,38 @@ You should now see your node up and running and waiting for transactions. This K
 
 ## Launch the Apps User Interface
 
-You can navigate to the  [Polkadot-JS Apps](https://polkadot.js.org/apps/#/settings/developer?rpc=ws://127.0.0.1:9944) user interface. This is a general purpose interface for interacting with many different Substrate-based blockchains including Polkadot. From now on we'll call it "Apps" for short. Before Apps will work with our blockchain, we need to give it a little chain-specific information known as the "types". You'll learn what all this means as you work through the recipes; for now just follow the instructions.
+You can navigate to the
+[Polkadot-JS Apps](https://polkadot.js.org/apps/#/settings/developer?rpc=ws://127.0.0.1:9944) user
+interface. This is a general purpose interface for interacting with many different Substrate-based
+blockchains including Polkadot. From now on we'll call it "Apps" for short. Before Apps will work
+with our blockchain, we need to give it a little chain-specific information known as the "types".
+You'll learn what all this means as you work through the recipes; for now just follow the
+instructions.
 
-> If you are not clicking the link above but visiting Apps directly, by default Apps connects to Kusama network. You will need to switch to your locally running network, with only one node, by clicking on the network icon on Apps top left corner.
+> If you are not clicking the link above but visiting Apps directly, by default Apps connects to
+> Kusama network. You will need to switch to your locally running network, with only one node, by
+> clicking on the network icon on Apps top left corner.
 >
 > ![Screenshot: Switching Network](../img/apps-select-network.png)
 
-> Some browsers, notably Firefox, will not connect to a local node from an https website. An easy work around is to try another browser, like Chromium. Another option is to [host this interface locally](https://github.com/polkadot-js/apps#development).
+> Some browsers, notably Firefox, will not connect to a local node from an https website. An easy
+> work around is to try another browser, like Chromium. Another option is to
+> [host this interface locally](https://github.com/polkadot-js/apps#development).
 
-If you're not already on the `Settings -> Developer`page, please navigate there. Copy the contents of `runtimes/super-runtime/types.json` into Apps.
+If you're not already on the `Settings -> Developer`page, please navigate there. Copy the contents
+of `runtimes/super-runtime/types.json` into Apps.
 
 ![Screenshot: pasting types into Apps UI](../img/apps-types.png)
 
-The kitchen node uses the super runtime by default. As you work through the recipes, you'll learn that it is easy to use other runtimes in this node, or use other nodes entirely. When you do use another runtime, you need to insert the appropriate types from the `runtimes/<whatever runtime you're using>/types.json` file. Every runtime that ships with the Recipes has this file.
+The kitchen node uses the super runtime by default. As you work through the recipes, you'll learn
+that it is easy to use other runtimes in this node, or use other nodes entirely. When you do use
+another runtime, you need to insert the appropriate types from the
+`runtimes/<whatever runtime you're using>/types.json` file. Every runtime that ships with the
+Recipes has this file.
 
 ## Submitting a Transaction
 
-You may now submit a simple token transfer transaction using the "Transfer" tab. When you do, you will notice that your node instantly creates a block, and the transaction is processed. As you work through the recipes, you will use the **Chain State** tab to query the blockchain status and **Extrinsics** to send transactions to the blockchain. Play around for a bit before moving on.
+You may now submit a simple token transfer transaction using the "Transfer" tab. When you do, you
+will notice that your node instantly creates a block, and the transaction is processed. As you work
+through the recipes, you will use the **Chain State** tab to query the blockchain status and
+**Extrinsics** to send transactions to the blockchain. Play around for a bit before moving on.

--- a/text/1-prepare-kitchen/3-kitchen-organization.md
+++ b/text/1-prepare-kitchen/3-kitchen-organization.md
@@ -1,14 +1,23 @@
 # Kitchen Organization
 
-Now that your kitchen is well-equipped with all the right tools (bowls, knives, Rust compiler, etc), let's take a look at how it is organized.
+Now that your kitchen is well-equipped with all the right tools (bowls, knives, Rust compiler, etc),
+let's take a look at how it is organized.
 
 ## Structure of a Substrate Node
 
-It is useful to recognize that [coding is all about abstraction](https://youtu.be/05H4YsyPA-U?t=1789).
+It is useful to recognize that
+[coding is all about abstraction](https://youtu.be/05H4YsyPA-U?t=1789).
 
-To understand how the code in this repository is organized, let's first take a look at how a Substrate node is constructed. Each node has many components that manage things like queueing transaction, communicating over a P2P network, reaching consensus on the state of the blockchain, and the chain's actual runtime logic. Each aspect of the node is interesting in its own right, and the runtime is particularly interesting because it contains the business logic (aka "state transition function") that codifies the chain's functionality.
+To understand how the code in this repository is organized, let's first take a look at how a
+Substrate node is constructed. Each node has many components that manage things like queueing
+transaction, communicating over a P2P network, reaching consensus on the state of the blockchain,
+and the chain's actual runtime logic. Each aspect of the node is interesting in its own right, and
+the runtime is particularly interesting because it contains the business logic (aka "state
+transition function") that codifies the chain's functionality.
 
-Much, but not all, of the Recipes focuses on writing runtimes with FRAME, Parity's Framework for composing runtimes from individual building blocks called Pallets. Runtimes built with FRAME typically contain several such pallets. The kitchen node you built previously follows this paradigm.
+Much, but not all, of the Recipes focuses on writing runtimes with FRAME, Parity's Framework for
+composing runtimes from individual building blocks called Pallets. Runtimes built with FRAME
+typically contain several such pallets. The kitchen node you built previously follows this paradigm.
 
 ![Substrate Architecture Diagram](../img/substrate-architecture.png)
 
@@ -16,13 +25,15 @@ Much, but not all, of the Recipes focuses on writing runtimes with FRAME, Parity
 
 There are five primary directories in this repository:
 
-* **Text**: Source of [the book](https://substrate.dev/recipes) written in markdown. This is what you're reading right now.
-* **Pallets**: Pallets for use in FRAME-based runtimes.
-* **Runtimes**: Runtimes for use in Substrate nodes.
-* **Consensus**: Consensus engines for use in Substrate nodes.
-* **Nodes**: Complete Substrate nodes ready to run.
+-   **Text**: Source of [the book](https://substrate.dev/recipes) written in markdown. This is what
+    you're reading right now.
+-   **Pallets**: Pallets for use in FRAME-based runtimes.
+-   **Runtimes**: Runtimes for use in Substrate nodes.
+-   **Consensus**: Consensus engines for use in Substrate nodes.
+-   **Nodes**: Complete Substrate nodes ready to run.
 
 Exploring those directories reveals a tree that looks like this
+
 ```
 recipes
 |
@@ -61,11 +72,16 @@ recipes
 
 ## Inside the Kitchen Node
 
-Let us take a deeper look at the [Kitchen Node](https://github.com/substrate-developer-hub/recipes/tree/master/nodes/kitchen-node).
+Let us take a deeper look at the
+[Kitchen Node](https://github.com/substrate-developer-hub/recipes/tree/master/nodes/kitchen-node).
 
-Looking inside the Kitchen Node's `Cargo.toml` file we see that it has many dependencies. Most of them come from Substrate itself. Indeed most parts of this Kitchen Node are not unique or specialized, and Substrate offers robust implementations that we can use. The runtime does not come from Substrate. Rather, we use our super-runtime which is in the `runtimes` folder.
+Looking inside the Kitchen Node's `Cargo.toml` file we see that it has many dependencies. Most of
+them come from Substrate itself. Indeed most parts of this Kitchen Node are not unique or
+specialized, and Substrate offers robust implementations that we can use. The runtime does not come
+from Substrate. Rather, we use our super-runtime which is in the `runtimes` folder.
 
 **`nodes/kitchen-node/Cargo.toml`**
+
 ```TOML
 # This node is compatible with any of the runtimes below
 # ---
@@ -85,16 +101,20 @@ runtime = { package = "super-runtime", path = "../../runtimes/super-runtime" }
 # ---
 ```
 
-The commented lines, quoted above, show that the Super Runtime is not the only runtime we could have chosen. We could also use the Weight-Fee runtime, and I encourage you to try that experiment (remember, instructions to re-compile the node are in the previous section).
+The commented lines, quoted above, show that the Super Runtime is not the only runtime we could have
+chosen. We could also use the Weight-Fee runtime, and I encourage you to try that experiment
+(remember, instructions to re-compile the node are in the previous section).
 
-Every node must have a runtime. You may confirm that by looking at the `Cago.toml` files of the other nodes included in our kitchen.
-
+Every node must have a runtime. You may confirm that by looking at the `Cago.toml` files of the
+other nodes included in our kitchen.
 
 ## Inside the Super Runtime
 
-Having seen that the Kitchen Node depends on a runtime, let us now look deeper at the [Super Runtime](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/super-runtime).
+Having seen that the Kitchen Node depends on a runtime, let us now look deeper at the
+[Super Runtime](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/super-runtime).
 
 **`runtimes/super-runtime/Cargo.toml`**
+
 ```TOML
 # -- snip --
 
@@ -106,22 +126,35 @@ adding-machine = { path = "../../pallets/adding-machine", default-features = fal
 basic-token = { path = "../../pallets/basic-token", default-features = false }
 ```
 
-Here we see that the runtime depends on many pallets. Some of these pallets come from Substrate itself. Indeed, Substrate offers a rich collection of commonly used pallets which you may use in your own runtimes. This runtime also contains several custom pallets that are written right here in our Kitchen.
+Here we see that the runtime depends on many pallets. Some of these pallets come from Substrate
+itself. Indeed, Substrate offers a rich collection of commonly used pallets which you may use in
+your own runtimes. This runtime also contains several custom pallets that are written right here in
+our Kitchen.
 
 ## Common Patterns
 
-We will not yet look closely at individual Pallets. We will begin that endeavor in the next chapter -- Appetizers.
+We will not yet look closely at individual Pallets. We will begin that endeavor in the next chapter
+-- Appetizers.
 
-We've just observed the general pattern used throughout the recipes. From the inside out, we see a piece of pallet code stored in `pallets/<pallet-name>/src/lib.rs`. The pallet is then included into a runtime by adding its name and relative path in `runtimes/<runtime-name>/Cargo.toml`. That runtime is then installed in a node by adding its name and relative path in `nodes/<node-name>/Cargo.toml`. Of course adding pallets and runtimes also requires changing actual _code_ as well. We will cover those details in due course. For now we're just focusing on macroscopic relationships between the parts of a Substrate node.
+We've just observed the general pattern used throughout the recipes. From the inside out, we see a
+piece of pallet code stored in `pallets/<pallet-name>/src/lib.rs`. The pallet is then included into
+a runtime by adding its name and relative path in `runtimes/<runtime-name>/Cargo.toml`. That runtime
+is then installed in a node by adding its name and relative path in `nodes/<node-name>/Cargo.toml`.
+Of course adding pallets and runtimes also requires changing actual _code_ as well. We will cover
+those details in due course. For now we're just focusing on macroscopic relationships between the
+parts of a Substrate node.
 
-Some recipes explore aspects of Blockchain development that are outside of the runtime. Looking back to our node architecture at the beginning of this section, you can imagine that changing a node's RPC or Consensus would be conceptually similar to changing its runtime.
+Some recipes explore aspects of Blockchain development that are outside of the runtime. Looking back
+to our node architecture at the beginning of this section, you can imagine that changing a node's
+RPC or Consensus would be conceptually similar to changing its runtime.
 
 ## Additional Resources
 
-Substrate Developer Hub offers tutorials that go into more depth about writing pallets and including them in runtimes. If you desire, you may read them as well.
+Substrate Developer Hub offers tutorials that go into more depth about writing pallets and including
+them in runtimes. If you desire, you may read them as well.
 
-* [Creating an External Pallet](https://substrate.dev/docs/en/next/tutorials/creating-a-runtime-module)
-* [Adding a Pallet to Your Runtime Tutorial](https://substrate.dev/docs/en/next/tutorials/adding-a-module-to-your-runtime)
+-   [Creating an External Pallet](https://substrate.dev/docs/en/next/tutorials/creating-a-runtime-module)
+-   [Adding a Pallet to Your Runtime Tutorial](https://substrate.dev/docs/en/next/tutorials/adding-a-module-to-your-runtime)
 
 # Let's Get Cooking!
 

--- a/text/1-prepare-kitchen/index.md
+++ b/text/1-prepare-kitchen/index.md
@@ -1,9 +1,14 @@
 # Setting Up Your Kitchen
 
-Any experienced chef will tell you that cooking delicious blockchains... I mean meals... starts with a properly equipped and organized kitchen. In this chapter we will guide you through setting up your development environment, and introduce you to the structure of the recipes repository.
+Any experienced chef will tell you that cooking delicious blockchains... I mean meals... starts with
+a properly equipped and organized kitchen. In this chapter we will guide you through setting up your
+development environment, and introduce you to the structure of the recipes repository.
 
 This section covers:
 
-* [Building a Node](./1-build-node.md) - Compile and execute your first Substrate-based blockchain node.
-* [Interacting with the Node](./2-interact-node.md) - Submit transactions and inspect state with a user interface.
-* [Understanding the Kitchen's Organization](./3-kitchen-organization.md) - How is the code organized, and why?
+-   [Building a Node](./1-build-node.md) - Compile and execute your first Substrate-based blockchain
+    node.
+-   [Interacting with the Node](./2-interact-node.md) - Submit transactions and inspect state with a
+    user interface.
+-   [Understanding the Kitchen's Organization](./3-kitchen-organization.md) - How is the code
+    organized, and why?

--- a/text/2-appetizers/1-hello-substrate.md
+++ b/text/2-appetizers/1-hello-substrate.md
@@ -1,11 +1,17 @@
 # Hello Substrate
-*[`pallets/hello-substrate`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/hello-substrate)*
 
-The first pallet we'll explore is a simple "hello world" example. This pallet will have one dispatchable call that prints a message to the node's output. Because this is our first pallet, we'll also explore the structure that every pallet has. This code lives in `pallets/hello-substrate/src/lib.rs`.
+_[`pallets/hello-substrate`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/hello-substrate)_
+
+The first pallet we'll explore is a simple "hello world" example. This pallet will have one
+dispatchable call that prints a message to the node's output. Because this is our first pallet,
+we'll also explore the structure that every pallet has. This code lives in
+`pallets/hello-substrate/src/lib.rs`.
 
 ## No Std
 
-The very first line of code tells the rust compiler that this crate should not use rust's standard library except when explicitly told to. This is useful because Substrate runtimes compile to Web Assembly where the standard library is not available.
+The very first line of code tells the rust compiler that this crate should not use rust's standard
+library except when explicitly told to. This is useful because Substrate runtimes compile to Web
+Assembly where the standard library is not available.
 
 ```rust, ignore
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -13,7 +19,11 @@ The very first line of code tells the rust compiler that this crate should not u
 
 ## Imports
 
-Next, you'll find imports that come from various parts of the Substrate framework. All pallets will import from a few common crates including [`frame-support`](https://crates.parity.io/frame_support/index.html), and [`frame-system`](https://crates.parity.io/frame_system/index.html).  Complex pallets will have many imports as we'll see later. The `hello-substrate` pallet uses these imports.
+Next, you'll find imports that come from various parts of the Substrate framework. All pallets will
+import from a few common crates including
+[`frame-support`](https://crates.parity.io/frame_support/index.html), and
+[`frame-system`](https://crates.parity.io/frame_system/index.html). Complex pallets will have many
+imports as we'll see later. The `hello-substrate` pallet uses these imports.
 
 ```rust, ignore
 use frame_support::{ decl_module, dispatch::DispatchResult, debug };
@@ -23,11 +33,16 @@ use sp_runtime::print;
 
 ## Tests
 
-Next we see a reference to the tests module. This pallet has tests written in a separate file called `tests.rs`. We will not discuss the tests further at this point, but they are covered in the [Testing section](../3-entrees/testing/index.md) of the book.
+Next we see a reference to the tests module. This pallet has tests written in a separate file called
+`tests.rs`. We will not discuss the tests further at this point, but they are covered in the
+[Testing section](../3-entrees/testing/index.md) of the book.
 
 ## Configuration Trait
 
-Next, each pallet has a configuration trait which is called `Trait`. The configuration trait can be used to access features from other pallets, or [constants](../3-entrees/constants.md) that effect the pallet's behavior. This pallet is simple enough that our configuration trait can remain empty, although it must still exist.
+Next, each pallet has a configuration trait which is called `Trait`. The configuration trait can be
+used to access features from other pallets, or [constants](../3-entrees/constants.md) that effect
+the pallet's behavior. This pallet is simple enough that our configuration trait can remain empty,
+although it must still exist.
 
 ```rust, ignore
 pub trait Trait: system::Trait {}
@@ -35,7 +50,11 @@ pub trait Trait: system::Trait {}
 
 ## Dispatchable Calls
 
-A Dispatchable call is a function that a blockchain user can call as part of an Extrinsic. "Extrinsic" is Substrate jargon meaning a call from outside of the chain. Most of the time they are transactions, and for now it is fine to think of them as transactions. Dispatchable calls are defined in the [`decl_module!` macro](https://crates.parity.io/frame_support/macro.decl_module.html).
+A Dispatchable call is a function that a blockchain user can call as part of an Extrinsic.
+"Extrinsic" is Substrate jargon meaning a call from outside of the chain. Most of the time they are
+transactions, and for now it is fine to think of them as transactions. Dispatchable calls are
+defined in the
+[`decl_module!` macro](https://crates.parity.io/frame_support/macro.decl_module.html).
 
 ```rust, ignore
 decl_module! {
@@ -52,10 +71,19 @@ decl_module! {
 }
 ```
 
-As you can see, our `hello-substrate` pallet has a dispatchable call that takes a single argument, called `origin` which we'll investigate shortly. The call returns a [`DispatchResult`](https://crates.parity.io/frame_support/dispatch/type.DispatchResult.html) which can be either `Ok(())` indicating that the call succeeded, or an `Err` which we'll investigate in the [appetizer about errors](./3-errors.md).
+As you can see, our `hello-substrate` pallet has a dispatchable call that takes a single argument,
+called `origin` which we'll investigate shortly. The call returns a
+[`DispatchResult`](https://crates.parity.io/frame_support/dispatch/type.DispatchResult.html) which
+can be either `Ok(())` indicating that the call succeeded, or an `Err` which we'll investigate in
+the [appetizer about errors](./3-errors.md).
 
 ### Weight Annotations
-Right before the `hello-substrate` function, we see the line `#[weight = 10_000]`. This line attaches a default weight to the call. Ultimately weights affect the fees a user will have to pay to call the function. Weights are a very interesting aspect of developing with Substrate, but they too shall be covered later in the section on [Weights](../3-entrees/weights.md). For now, and for may of the recipes pallets, we will simply use the default weight as we have done here.
+
+Right before the `hello-substrate` function, we see the line `#[weight = 10_000]`. This line
+attaches a default weight to the call. Ultimately weights affect the fees a user will have to pay to
+call the function. Weights are a very interesting aspect of developing with Substrate, but they too
+shall be covered later in the section on [Weights](../3-entrees/weights.md). For now, and for may of
+the recipes pallets, we will simply use the default weight as we have done here.
 
 ## Inside a Dispatchable Call
 
@@ -76,33 +104,65 @@ pub fn say_hello(origin) -> DispatchResult {
 }
 ```
 
-This function essentially does three things. First, it uses the [`ensure_signed` function](https://crates.parity.io/frame_system/fn.ensure_signed.html) to ensure that the caller of the function was a regular user who owns a private key. This function also returns who that caller was. We store the caller's identity in the `caller` variable.
+This function essentially does three things. First, it uses the
+[`ensure_signed` function](https://crates.parity.io/frame_system/fn.ensure_signed.html) to ensure
+that the caller of the function was a regular user who owns a private key. This function also
+returns who that caller was. We store the caller's identity in the `caller` variable.
 
-Second, it prints a message and logs the caller. Notice that we aren't using Rust's normal `println!` macro, but rather a special [`print` function](https://crates.parity.io/sp_runtime/fn.print.html) and [`debug::info!` macro](https://crates.parity.io/frame_support/debug/macro.info.html). The reason for this is explained in the next section.
+Second, it prints a message and logs the caller. Notice that we aren't using Rust's normal
+`println!` macro, but rather a special
+[`print` function](https://crates.parity.io/sp_runtime/fn.print.html) and
+[`debug::info!` macro](https://crates.parity.io/frame_support/debug/macro.info.html). The reason for
+this is explained in the next section.
 
-Finally, the call returns `Ok(())` to indicate that the call has succeeded. At a glance it seems that there is no way for this call to fail, but this is not quite true. The `ensure_signed` function, used at the beginning, can return an error if the call was not from a signed origin. This is the first time we're seeing the important paradigm "**Verify first, write last**". In Substrate development, it is important that you always ensure preconditions are met and return errors at the beginning. After these checks have completed, then you may begin the functions computation.
+Finally, the call returns `Ok(())` to indicate that the call has succeeded. At a glance it seems
+that there is no way for this call to fail, but this is not quite true. The `ensure_signed`
+function, used at the beginning, can return an error if the call was not from a signed origin. This
+is the first time we're seeing the important paradigm "**Verify first, write last**". In Substrate
+development, it is important that you always ensure preconditions are met and return errors at the
+beginning. After these checks have completed, then you may begin the functions computation.
 
 ## Printing from the Runtime
 
-Printing to the terminal from a Rust program is typically very simple using the `println!` macro. However, Substrate runtimes are compiled to Web Assembly as well as a regular native binary, and do not have access to rust's standard library. That means we cannot use the regular `println!`. I encourage you to modify the code to try using `println!` and confirm that it will not compile. Nonetheless, printing a message from the runtime is useful both for logging information, and also for debugging.
+Printing to the terminal from a Rust program is typically very simple using the `println!` macro.
+However, Substrate runtimes are compiled to Web Assembly as well as a regular native binary, and do
+not have access to rust's standard library. That means we cannot use the regular `println!`. I
+encourage you to modify the code to try using `println!` and confirm that it will not compile.
+Nonetheless, printing a message from the runtime is useful both for logging information, and also
+for debugging.
 
 ![Substrate Architecture Diagram](../img/substrate-architecture.png)
 
-At the top of our pallet, we imported `sp_runtime`'s [`print` function](https://crates.parity.io/sp_runtime/fn.print.html). This special function allows the runtime to pass a message for printing to the outer part of the node which is not built to Wasm. This function is only able to print items that implement the [`Printable` trait](https://crates.parity.io/sp_runtime/traits/trait.Printable.html). Luckily all the primitive types already implement this trait, and you can implement the trait for your own datatypes too.
+At the top of our pallet, we imported `sp_runtime`'s
+[`print` function](https://crates.parity.io/sp_runtime/fn.print.html). This special function allows
+the runtime to pass a message for printing to the outer part of the node which is not built to Wasm.
+This function is only able to print items that implement the
+[`Printable` trait](https://crates.parity.io/sp_runtime/traits/trait.Printable.html). Luckily all
+the primitive types already implement this trait, and you can implement the trait for your own
+datatypes too.
 
-**Print function note:** To actually see the printed messages, we need to use the flag `-lruntime=debug` when running the kitchen node. So, for the kitchen node, the command would become `./target/release/kitchen-node --dev -lruntime=debug`.
+**Print function note:** To actually see the printed messages, we need to use the flag
+`-lruntime=debug` when running the kitchen node. So, for the kitchen node, the command would become
+`./target/release/kitchen-node --dev -lruntime=debug`.
 
-The next line demonstrates using `debug::info!` macro to log to the screen and also inspecting the variable's content. The syntax inside the macro is very similar to what regular rust macro `println!` takes.
+The next line demonstrates using `debug::info!` macro to log to the screen and also inspecting the
+variable's content. The syntax inside the macro is very similar to what regular rust macro
+`println!` takes.
 
-**Runtime logger note:** When we execute the runtime in native, `debug::info!` messages are printed. However, if we execute the runtime in Wasm, then an additional step to initialise [RuntimeLogger](https://crates.parity.io/frame_support/debug/struct.RuntimeLogger.html) is required.
+**Runtime logger note:** When we execute the runtime in native, `debug::info!` messages are printed.
+However, if we execute the runtime in Wasm, then an additional step to initialise
+[RuntimeLogger](https://crates.parity.io/frame_support/debug/struct.RuntimeLogger.html) is required.
 
 ## Installing the Pallet in a Runtime
 
-In order to actually use a pallet, it must be installed in a Substrate runtime. This particular pallet is installed in the `super-runtime` which you built as part of the kitchen node. To install a pallet in a runtime, you must do three things.
+In order to actually use a pallet, it must be installed in a Substrate runtime. This particular
+pallet is installed in the `super-runtime` which you built as part of the kitchen node. To install a
+pallet in a runtime, you must do three things.
 
 ### Depend on the Pallet
 
-First we must include the pallet in our runtime's `Cargo.toml` file. In the case of the super-runtime, this file is at `runtimes/super-runtime/Cargo.toml`.
+First we must include the pallet in our runtime's `Cargo.toml` file. In the case of the
+super-runtime, this file is at `runtimes/super-runtime/Cargo.toml`.
 
 ```toml
 [dependencies]
@@ -110,7 +170,8 @@ First we must include the pallet in our runtime's `Cargo.toml` file. In the case
 hello-substrate = { path = "../../pallets/hello-substrate", default-features = false }
 ```
 
-Because the runtime is built to both native and Wasm, we must ensure that our pallet is built to the correct target as well. At the bottom of the `Cargo.toml` file, we see this.
+Because the runtime is built to both native and Wasm, we must ensure that our pallet is built to the
+correct target as well. At the bottom of the `Cargo.toml` file, we see this.
 
 ```toml
 [features]
@@ -123,16 +184,21 @@ std = [
 
 ### Implement its Configuration Trait
 
-Next we must implement the pallet's configuration trait. This happens in the runtime's main `lib.rs` file. In the case of the super-runtime, this file is at `runtimes/super-runtime/src/lib.rs`. Because this pallet's configuration trait is trivial, so is implementing it.
+Next we must implement the pallet's configuration trait. This happens in the runtime's main `lib.rs`
+file. In the case of the super-runtime, this file is at `runtimes/super-runtime/src/lib.rs`. Because
+this pallet's configuration trait is trivial, so is implementing it.
 
 ```rust ignore
 impl hello_substrate::Trait for Runtime {}
 ```
-You can see the other pallets' trait implementations in the surrounding lines. Most of them are more complex.
+
+You can see the other pallets' trait implementations in the surrounding lines. Most of them are more
+complex.
 
 ### Add it to `construct_runtime!`
 
-Finally, we add our pallet to the [`construct_runtime!` macro](https://crates.parity.io/frame_support/macro.construct_runtime.html).
+Finally, we add our pallet to the
+[`construct_runtime!` macro](https://crates.parity.io/frame_support/macro.construct_runtime.html).
 
 ```rust, ignore
 construct_runtime!(
@@ -147,12 +213,21 @@ construct_runtime!(
 );
 ```
 
-This macro does the heavy lifting of composing each individual pallet into a single usable runtime. Let's explain the syntax for each line. Each Pallet listed in the macro needs several pieces of information.
+This macro does the heavy lifting of composing each individual pallet into a single usable runtime.
+Let's explain the syntax for each line. Each Pallet listed in the macro needs several pieces of
+information.
 
-First is a convenient name to give to this pallet. We've chosen `HelloSubstrate`. It is common to choose the same name as the pallet itself except when there is [more than one instance](../3-entrees/instantiable.md). Next is the name of the crate that the pallet lives in. And finally there is a list of features the pallet provides. All pallets require `Module`. Our pallet also provides dispatchable calls, so it requires `Call`.
+First is a convenient name to give to this pallet. We've chosen `HelloSubstrate`. It is common to
+choose the same name as the pallet itself except when there is
+[more than one instance](../3-entrees/instantiable.md). Next is the name of the crate that the
+pallet lives in. And finally there is a list of features the pallet provides. All pallets require
+`Module`. Our pallet also provides dispatchable calls, so it requires `Call`.
 
 ## Try it Out
 
-If you haven't already, try interacting with the pallet using the Apps UI. You should see your message printed to the log of your node. Remember to run the kitchen node with the correct flags: `./target/release/kitchen-node --dev -lruntime=debug`
+If you haven't already, try interacting with the pallet using the Apps UI. You should see your
+message printed to the log of your node. Remember to run the kitchen node with the correct flags:
+`./target/release/kitchen-node --dev -lruntime=debug`
 
-You're now well on your way to becoming a blockchain chef. Let's continue to build our skills with another appetizer.
+You're now well on your way to becoming a blockchain chef. Let's continue to build our skills with
+another appetizer.

--- a/text/2-appetizers/2-storage-values.md
+++ b/text/2-appetizers/2-storage-values.md
@@ -1,11 +1,18 @@
 # Single Value
-*[`pallets/single-value`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/single-value)*
 
-Storage is used for data that should be kept between blocks, and accessible to future transactions. Most runtimes will have many storage values, and together the storage values make up the blockchain's "state". The storage values themselves are _not_ stored in the blocks. Instead the blocks contains extrinsics which represent _changes_ to the storage values. It is the job of each node in a blockchain network to keep track of the current storage. The current state of storage can be determined by executing all of the blocks in the chain.
+_[`pallets/single-value`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/single-value)_
+
+Storage is used for data that should be kept between blocks, and accessible to future transactions.
+Most runtimes will have many storage values, and together the storage values make up the
+blockchain's "state". The storage values themselves are _not_ stored in the blocks. Instead the
+blocks contains extrinsics which represent _changes_ to the storage values. It is the job of each
+node in a blockchain network to keep track of the current storage. The current state of storage can
+be determined by executing all of the blocks in the chain.
 
 ## Declaring Storage
 
-A pallet's storage items are declared with the [`decl_storage!` macro](https://crates.parity.io/frame_support/macro.decl_storage.html).
+A pallet's storage items are declared with the
+[`decl_storage!` macro](https://crates.parity.io/frame_support/macro.decl_storage.html).
 
 ```rust, ignore
 decl_storage! {
@@ -15,26 +22,43 @@ decl_storage! {
 }
 ```
 
-The code above is boilerplate that does not change with the exception of the `SingleValue`. The macro uses this as the name for a struct that it creates. As a pallet author you don't need to worry about this value much, and it is fine to use the name of the pallet itself.
+The code above is boilerplate that does not change with the exception of the `SingleValue`. The
+macro uses this as the name for a struct that it creates. As a pallet author you don't need to worry
+about this value much, and it is fine to use the name of the pallet itself.
 
-This pallet has two storage items, both of which are single storage values. Substrate's storage API also supports more complex storage types which are [covered in the entrees](../3-entrees/storage-api/index.html). The fundamentals for all types are the same.
+This pallet has two storage items, both of which are single storage values. Substrate's storage API
+also supports more complex storage types which are
+[covered in the entrees](../3-entrees/storage-api/index.html). The fundamentals for all types are
+the same.
 
 Our first storage item is a `u32` value which is declared with this syntax
+
 ```rust, ignore
 StoredValue get(fn stored_value): u32;
 ```
-The `StorageValue` is the name of the storage item, similar to a variable name. We will use this name any time we write to the storage item. The `get(fn stored_value)` is optional. It tells the `decl_storage!` macro to create a getter function for us. That means we get a function called `stored_value` which returns the value in that storage item. Finally, the `: u32` declares the type of the item.
 
-The next storage item is an `AccountId`. This is not a primitive type, but rather comes from the system pallet. Types like this need to be prefixed with a `T::` as we see here.
+The `StorageValue` is the name of the storage item, similar to a variable name. We will use this
+name any time we write to the storage item. The `get(fn stored_value)` is optional. It tells the
+`decl_storage!` macro to create a getter function for us. That means we get a function called
+`stored_value` which returns the value in that storage item. Finally, the `: u32` declares the type
+of the item.
+
+The next storage item is an `AccountId`. This is not a primitive type, but rather comes from the
+system pallet. Types like this need to be prefixed with a `T::` as we see here.
+
 ```rust, ignore
 StoredAccount get(fn stored_account): T::AccountId;
 ```
 
 ## Reading and Writing to Storage
 
-Functions used to access a single storage value are defined in the [`StorageValue` trait](https://crates.parity.io/frame_support/storage/trait.StorageValue.html). In this pallet, we use the most common method, `put`, but it is worth skimming the other methods so you know what is available.
+Functions used to access a single storage value are defined in the
+[`StorageValue` trait](https://crates.parity.io/frame_support/storage/trait.StorageValue.html). In
+this pallet, we use the most common method, `put`, but it is worth skimming the other methods so you
+know what is available.
 
-The `set_value` method demonstrates writing to storage, as well as taking a parameter in our dispatchable call.
+The `set_value` method demonstrates writing to storage, as well as taking a parameter in our
+dispatchable call.
 
 ```rust, ignore
 fn set_value(origin, value: u32) -> DispatchResult {
@@ -46,7 +70,9 @@ fn set_value(origin, value: u32) -> DispatchResult {
 }
 ```
 
-To read a value from storage, we could use the `get` method, or we could use the getter method we declared in `decl_storage!`.
+To read a value from storage, we could use the `get` method, or we could use the getter method we
+declared in `decl_storage!`.
+
 ```rust, ignore
 // The following lines are equivalent
 let my_val = StoredValue::get();
@@ -55,7 +81,9 @@ let my_val = Self::stored_value();
 
 ## Storing the Callers Account
 
-In terms of storage, the `set_account` method is quite similar to `set_value`, but it also demonstrates how to retreive the `AccountId` of the caller using the [`ensure_signed` function](https://crates.parity.io/frame_system/fn.ensure_signed.html).
+In terms of storage, the `set_account` method is quite similar to `set_value`, but it also
+demonstrates how to retreive the `AccountId` of the caller using the
+[`ensure_signed` function](https://crates.parity.io/frame_system/fn.ensure_signed.html).
 
 ```rust, ignore
 fn set_account(origin) -> DispatchResult {
@@ -67,11 +95,16 @@ fn set_account(origin) -> DispatchResult {
 }
 ```
 
-Because `AccountId` type comes from the configuration trait, we must use slightly different syntax. Notice the `<T>` attached to the name of the storage value this time. Notice also that because `AccountId` is not primitive, we lend a reference to it rather than transferring ownership.
+Because `AccountId` type comes from the configuration trait, we must use slightly different syntax.
+Notice the `<T>` attached to the name of the storage value this time. Notice also that because
+`AccountId` is not primitive, we lend a reference to it rather than transferring ownership.
 
 ## Constructing the Runtime
 
-We learned about the [`construct_runtime!` macro](https://crates.parity.io/frame_support/macro.construct_runtime.html) in the previous section. Because this pallet uses storage items, we must add this to the line in construct runtime. In the Super Runtime, we see the additional `Storage` feature.
+We learned about the
+[`construct_runtime!` macro](https://crates.parity.io/frame_support/macro.construct_runtime.html) in
+the previous section. Because this pallet uses storage items, we must add this to the line in
+construct runtime. In the Super Runtime, we see the additional `Storage` feature.
 
 ```rust, ignore
 construct_runtime!(

--- a/text/2-appetizers/3-errors.md
+++ b/text/2-appetizers/3-errors.md
@@ -1,11 +1,16 @@
 # Handling Errors
-*[`pallets/adding-machine`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/adding-machine)*
 
-As we've mentioned before, in Substrate development, it is important to **Verify first, write last**. In this recipe, we'll create an adding machine checks for unlucky numbers (a silly example) as well as integer overflow (a serious and realistic example), and throws the appropriate errors.
+_[`pallets/adding-machine`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/adding-machine)_
+
+As we've mentioned before, in Substrate development, it is important to **Verify first, write
+last**. In this recipe, we'll create an adding machine checks for unlucky numbers (a silly example)
+as well as integer overflow (a serious and realistic example), and throws the appropriate errors.
 
 ## Declaring Errors
 
-Errors are declared with the [`decl_error!` macro](https://crates.parity.io/frame_support/macro.decl_error.html). Although it is optional, it is good practice to write doc comments for each error variant as demonstrated here.
+Errors are declared with the
+[`decl_error!` macro](https://crates.parity.io/frame_support/macro.decl_error.html). Although it is
+optional, it is good practice to write doc comments for each error variant as demonstrated here.
 
 ```rust, ignore
 decl_error! {
@@ -20,7 +25,10 @@ decl_error! {
 
 ## Throwing Errors in `match` Statement
 
-Errors can be thrown in two different ways, both of which are demonstrated in the the `add` dispatchable call. The first is with the [`ensure!` macro](https://crates.parity.io/frame_support/macro.ensure.html) where the error to throw is the second parameter. The second is to throw the error by explicitly returning it.
+Errors can be thrown in two different ways, both of which are demonstrated in the the `add`
+dispatchable call. The first is with the
+[`ensure!` macro](https://crates.parity.io/frame_support/macro.ensure.html) where the error to throw
+is the second parameter. The second is to throw the error by explicitly returning it.
 
 ```rust, ignore
 fn add(origin, val_to_add: u32) -> DispatchResult {
@@ -42,14 +50,15 @@ fn add(origin, val_to_add: u32) -> DispatchResult {
 }
 ```
 
-Notice that the `Error` type always takes the generic parameter `T`. Notice also that we have verified all preconditions, and thrown all possible errors before ever writing to storage.
+Notice that the `Error` type always takes the generic parameter `T`. Notice also that we have
+verified all preconditions, and thrown all possible errors before ever writing to storage.
 
 ## Throwing Errors with `.ok_or` and `.map_err`
 
 In fact, the pattern of:
 
-* calling functions that returned a `Result` or `Option`, and
-* checking if the result is `Some` or `Ok`. If not, returns from the function early with an error
+-   calling functions that returned a `Result` or `Option`, and
+-   checking if the result is `Some` or `Ok`. If not, returns from the function early with an error
 
 are so common that there are two standard Rust methods help performing the task.
 
@@ -68,10 +77,14 @@ fn add_alternate(origin, val_to_add: u32) -> DispatchResult {
 }
 ```
 
-Notice the pattern of `.ok_or(<Error<T>>::MyError)?;`. This is really handy when you have a function call that returns an `Option` and you expect there should be a value inside. If not, returns early with an error message, all the while unwrapping the value for your further processing.
+Notice the pattern of `.ok_or(<Error<T>>::MyError)?;`. This is really handy when you have a function
+call that returns an `Option` and you expect there should be a value inside. If not, returns early
+with an error message, all the while unwrapping the value for your further processing.
 
-If your function returns a `Result<T, E>`, you could apply `.map_err(|_e| <Error<T>>::MyError)?;` in the same spirit.
+If your function returns a `Result<T, E>`, you could apply `.map_err(|_e| <Error<T>>::MyError)?;` in
+the same spirit.
 
 ## Constructing the Runtime
 
-Unlike before, adding errors to our pallet does _not_ require a change to the line in `construct_runtime!`. This is just an idiosyncrasy of developing in Substrate.
+Unlike before, adding errors to our pallet does _not_ require a change to the line in
+`construct_runtime!`. This is just an idiosyncrasy of developing in Substrate.

--- a/text/2-appetizers/4-events.md
+++ b/text/2-appetizers/4-events.md
@@ -1,13 +1,23 @@
 # Using Events
-*[`pallets/simple-event`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/simple-event)*, *[`pallets/generic-event`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/generic-event)*
 
-Having a [transaction](https://substrate.dev/docs/en/overview/glossary#transaction) included in a block does not guarantee that the function executed successfully. As we saw in the previous recipe, many calls can cause errors, but still be included in a block. To verify that functions have executed successfully, emit an [event](https://substrate.dev/docs/en/overview/glossary#events) at the bottom of the function body.
+_[`pallets/simple-event`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/simple-event)_,
+_[`pallets/generic-event`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/generic-event)_
+
+Having a [transaction](https://substrate.dev/docs/en/overview/glossary#transaction) included in a
+block does not guarantee that the function executed successfully. As we saw in the previous recipe,
+many calls can cause errors, but still be included in a block. To verify that functions have
+executed successfully, emit an [event](https://substrate.dev/docs/en/overview/glossary#events) at
+the bottom of the function body.
 
 Events notify the off-chain world of successful state transitions.
 
 ## Some Prerequisites
 
-When using events, we have to include the `Event` type in our configuration trait. Although the syntax is a bit complex, it is the same every time. If you are a skilled Rust programmer you will recognize this as a series of [trait bounds](https://doc.rust-lang.org/book/ch10-02-traits.html). If you don't recognize this feature of Rust yet, don't worry; it is the same every time, so you can just copy it and move on.
+When using events, we have to include the `Event` type in our configuration trait. Although the
+syntax is a bit complex, it is the same every time. If you are a skilled Rust programmer you will
+recognize this as a series of [trait bounds](https://doc.rust-lang.org/book/ch10-02-traits.html). If
+you don't recognize this feature of Rust yet, don't worry; it is the same every time, so you can
+just copy it and move on.
 
 ```rust, ignore
 pub trait Trait: system::Trait {
@@ -15,7 +25,9 @@ pub trait Trait: system::Trait {
 }
 ```
 
-Next we have to add a line inside of the `decl_module!` macro which generates the 	`deposit_event` function we'll use later when emitting our events. Even experienced Rust programmers will not recognize this syntax because it is unique to this macro. Just copy it each time.
+Next we have to add a line inside of the `decl_module!` macro which generates the `deposit_event`
+function we'll use later when emitting our events. Even experienced Rust programmers will not
+recognize this syntax because it is unique to this macro. Just copy it each time.
 
 ```rust, ignore
 decl_module! {
@@ -31,7 +43,12 @@ decl_module! {
 
 ## Declaring Events
 
-To declare an event, use the [`decl_event!` macro](https://crates.parity.io/frame_support/macro.decl_event.html). Like any rust enum, Events have names, and can optionally carry data with them. The syntax is slightly different depending on whether the events carry data of primitive types, or generic types from the pallet's configuration trait. These two techniques are demonstrated in the `simple-event` and `generic-event` pallets respectively.
+To declare an event, use the
+[`decl_event!` macro](https://crates.parity.io/frame_support/macro.decl_event.html). Like any rust
+enum, Events have names, and can optionally carry data with them. The syntax is slightly different
+depending on whether the events carry data of primitive types, or generic types from the pallet's
+configuration trait. These two techniques are demonstrated in the `simple-event` and `generic-event`
+pallets respectively.
 
 ### Simple Events
 
@@ -47,7 +64,9 @@ decl_event!(
 
 ### Events with Generic Types
 
-[Sometimes](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/generic-event) events might contain types from the pallet's Configuration Trait. In this case, it is necessary to specify additional syntax
+[Sometimes](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/generic-event)
+events might contain types from the pallet's Configuration Trait. In this case, it is necessary to
+specify additional syntax
 
 ```rust, ignore
 decl_event!(
@@ -57,8 +76,8 @@ decl_event!(
 );
 ```
 
-This example also demonstrates how the `where` clause can be used to specify type aliasing for more readable code.
-
+This example also demonstrates how the `where` clause can be used to specify type aliasing for more
+readable code.
 
 ## Emitting Events
 
@@ -77,7 +96,8 @@ Self::deposit_event(Event::EmitInput(new_number));
 
 ### Events with Generic Types
 
-The syntax for `deposit_event` now takes the `RawEvent` type because it is generic over the pallet's configuration trait.
+The syntax for `deposit_event` now takes the `RawEvent` type because it is generic over the pallet's
+configuration trait.
 
 ```rust, ignore
 Self::deposit_event(RawEvent::EmitInput(user, new_number));
@@ -85,7 +105,9 @@ Self::deposit_event(RawEvent::EmitInput(user, new_number));
 
 ### Constructing the Runtime
 
-For the first time in the recipes, our pallet has an associated type in its configuration trait. We must specify this type when implementing its trait. In the case of the `Event` type, this is entirely straight forward, and looks the same for both simple events and generic events.
+For the first time in the recipes, our pallet has an associated type in its configuration trait. We
+must specify this type when implementing its trait. In the case of the `Event` type, this is
+entirely straight forward, and looks the same for both simple events and generic events.
 
 ```rust, ignore
 impl simple_event::Trait for Runtime {
@@ -93,7 +115,8 @@ impl simple_event::Trait for Runtime {
 }
 ```
 
-Events, like dispatchable calls and storage items, requires a slight change to the line in `construct_runtime!`. Notice that the `<T>` is necessary for generic events.
+Events, like dispatchable calls and storage items, requires a slight change to the line in
+`construct_runtime!`. Notice that the `<T>` is necessary for generic events.
 
 ```rust, ignore
 construct_runtime!(

--- a/text/2-appetizers/index.md
+++ b/text/2-appetizers/index.md
@@ -1,10 +1,13 @@
 # Appetizers
 
-This section of the cookbook will focus on Appetizers, small runtime pallets that teach you the basics of writing pallets with a little hand-holding. If you are brand new to Substrate, you should follow through these appetizers in order. If you've already got the basics of pallet development down, you may skip ahead to the entrees which may be read in any order.
+This section of the cookbook will focus on Appetizers, small runtime pallets that teach you the
+basics of writing pallets with a little hand-holding. If you are brand new to Substrate, you should
+follow through these appetizers in order. If you've already got the basics of pallet development
+down, you may skip ahead to the entrees which may be read in any order.
 
 This section covers:
 
-* [Dispatchable Calls](./1-hello-substrate.md) - How users submit transactions
-* [Storage Values](./2-storage-values.md) - Storing the state of the blockchain
-* [Errors](./3-errors.md) - When things go wrong during a transaction
-* [Events](./4-events.md) - Notifying the offchain world of success
+-   [Dispatchable Calls](./1-hello-substrate.md) - How users submit transactions
+-   [Storage Values](./2-storage-values.md) - Storing the state of the blockchain
+-   [Errors](./3-errors.md) - When things go wrong during a transaction
+-   [Events](./4-events.md) - Notifying the offchain world of success

--- a/text/3-entrees/basic-pow.md
+++ b/text/3-entrees/basic-pow.md
@@ -1,28 +1,58 @@
 # Basic Proof of Work
-*[`nodes/basic-pow`](https://github.com/substrate-developer-hub/recipes/tree/master/nodes/basic-pow)*
 
-The `basic-pow` node demonstrates how wire a custom consensus engine into the Substrate Service. It uses a minimal proof of work consensus engine to reach agreement over the blockchain. It will teach us many useful aspects of dealing with consensus and prepare us to understand more advanced consensus engines in the future. In particular we will learn about:
+_[`nodes/basic-pow`](https://github.com/substrate-developer-hub/recipes/tree/master/nodes/basic-pow)_
 
-* Substrate's [`BlockImport` trait](https://crates.parity.io/sp_consensus/block_import/trait.BlockImport.html)
-* Substrate's [import pipeline](https://crates.parity.io/sp_consensus/import_queue/index.html)
-* Structure of a typical [Substrate Service](https://crates.parity.io/sc_service/index.html)
-* Configuration of [`InherentDataProvider`](https://crates.parity.io/sp_authorship/struct.InherentDataProvider.html)s
+The `basic-pow` node demonstrates how wire a custom consensus engine into the Substrate Service. It
+uses a minimal proof of work consensus engine to reach agreement over the blockchain. It will teach
+us many useful aspects of dealing with consensus and prepare us to understand more advanced
+consensus engines in the future. In particular we will learn about:
+
+-   Substrate's
+    [`BlockImport` trait](https://crates.parity.io/sp_consensus/block_import/trait.BlockImport.html)
+-   Substrate's [import pipeline](https://crates.parity.io/sp_consensus/import_queue/index.html)
+-   Structure of a typical [Substrate Service](https://crates.parity.io/sc_service/index.html)
+-   Configuration of
+    [`InherentDataProvider`](https://crates.parity.io/sp_authorship/struct.InherentDataProvider.html)s
 
 ## The Structure of a Node
 
-You may remember from the [hello-substrate recipe](../2-appetizers/1-hello-substrate.md) that a Substrate node has two parts. An outer part that is responsible for gossiping transactions and blocks, handling [rpc requests](./custom-rpc.md), and reaching consensus. And a runtime that is responsible for the business logic of the chain. This architecture diagram illustrates the distinction.
+You may remember from the [hello-substrate recipe](../2-appetizers/1-hello-substrate.md) that a
+Substrate node has two parts. An outer part that is responsible for gossiping transactions and
+blocks, handling [rpc requests](./custom-rpc.md), and reaching consensus. And a runtime that is
+responsible for the business logic of the chain. This architecture diagram illustrates the
+distinction.
 
 ![Substrate Architecture Diagram](../img/substrate-architecture.png)
 
-In principle the consensus engine, part of the outer node, is agnostic over the runtime that is used with it. But in practice, most consensus engines will require the runtime to provide certain [runtime APIs](./runtime-api.md) that affect the engine. For example, Aura and Babe query the runtime for the set of validators. A more real-world PoW consensus would query the runtime for the block difficulty. Additionally, some runtimes rely on the consensus engine to provide [pre-runtime digests](https://crates.parity.io/sp_runtime/generic/enum.DigestItem.html#variant.PreRuntime). For example, runtimes that include the Babe pallet expect a pre-runtime digest containing information about the current babe slot.
+In principle the consensus engine, part of the outer node, is agnostic over the runtime that is used
+with it. But in practice, most consensus engines will require the runtime to provide certain
+[runtime APIs](./runtime-api.md) that affect the engine. For example, Aura and Babe query the
+runtime for the set of validators. A more real-world PoW consensus would query the runtime for the
+block difficulty. Additionally, some runtimes rely on the consensus engine to provide
+[pre-runtime digests](https://crates.parity.io/sp_runtime/generic/enum.DigestItem.html#variant.PreRuntime).
+For example, runtimes that include the Babe pallet expect a pre-runtime digest containing
+information about the current babe slot.
 
-In this recipe we will avoid those practical complexities by using the [Minimal Sha3 Proof of Work](./sha3-pow-consensus.md) consensus engine, and a dedicated `pow-runtime` which are truly isolated from each other. The contents of the runtime should be familiar, and will not be discussed here.
+In this recipe we will avoid those practical complexities by using the
+[Minimal Sha3 Proof of Work](./sha3-pow-consensus.md) consensus engine, and a dedicated
+`pow-runtime` which are truly isolated from each other. The contents of the runtime should be
+familiar, and will not be discussed here.
 
 ## The Service Builder
 
-The [Substrate Service](https://crates.parity.io/sc_service/trait.AbstractService.html) is the main coordinator of the various parts of a Substrate node, including consensus. The service is large and takes many parameters, so it is built with a [ServiceBuilder](https://crates.parity.io/sc_service/struct.ServiceBuilder.html) following [Rust's builder pattern](https://doc.rust-lang.org/1.0.0/style/ownership/builders.html). This code is demonstrated in the nodes `src/service.rs` file.
+The [Substrate Service](https://crates.parity.io/sc_service/trait.AbstractService.html) is the main
+coordinator of the various parts of a Substrate node, including consensus. The service is large and
+takes many parameters, so it is built with a
+[ServiceBuilder](https://crates.parity.io/sc_service/struct.ServiceBuilder.html) following
+[Rust's builder pattern](https://doc.rust-lang.org/1.0.0/style/ownership/builders.html). This code
+is demonstrated in the nodes `src/service.rs` file.
 
-The particular builder method that is relevant here is [`with_import_queue`](https://crates.parity.io/sc_service/struct.ServiceBuilder.html#method.with_import_queue). Here we construct an instance of the [`PowBlockImport` struct](https://crates.parity.io/sc_consensus_pow/struct.PowBlockImport.html), providing it with references to our client, our `MinimalSha3Algorithm`, and some other necessary data.
+The particular builder method that is relevant here is
+[`with_import_queue`](https://crates.parity.io/sc_service/struct.ServiceBuilder.html#method.with_import_queue).
+Here we construct an instance of the
+[`PowBlockImport` struct](https://crates.parity.io/sc_consensus_pow/struct.PowBlockImport.html),
+providing it with references to our client, our `MinimalSha3Algorithm`, and some other necessary
+data.
 
 ```rust, ignore
 builder
@@ -49,15 +79,24 @@ builder
 	})?;
 ```
 
-Once the `PowBlockImport` is constructed, we can use it to create an actual import queue that the service will use for importing blocks into the client.
+Once the `PowBlockImport` is constructed, we can use it to create an actual import queue that the
+service will use for importing blocks into the client.
 
 ### The Block Import Pipeline
 
-You may have noticed that when we created the `PowBlockImport` we gave it two separate references to the client. The second reference will always be to a client. But the first is interesting. The [rustdocs tell us](https://crates.parity.io/sc_consensus_pow/struct.PowBlockImport.html#method.new) that the first parameter is `inner: BlockImport<B, Transaction = TransactionFor<C, B>>`. Why would a block import have a reference to another block import? Because the "block import pipeline" is constructed in an onion-like fashion, where one layer of block import wraps the next. In this minimal PoW node, there is only one layer to the onion. But in other nodes, including our own kitchen node, there are two layers: one for babe and one for grandpa.
+You may have noticed that when we created the `PowBlockImport` we gave it two separate references to
+the client. The second reference will always be to a client. But the first is interesting. The
+[rustdocs tell us](https://crates.parity.io/sc_consensus_pow/struct.PowBlockImport.html#method.new)
+that the first parameter is `inner: BlockImport<B, Transaction = TransactionFor<C, B>>`. Why would a
+block import have a reference to another block import? Because the "block import pipeline" is
+constructed in an onion-like fashion, where one layer of block import wraps the next. In this
+minimal PoW node, there is only one layer to the onion. But in other nodes, including our own
+kitchen node, there are two layers: one for babe and one for grandpa.
 
 ### Inherent Data Providers
 
-Both the BlockImport and the `import_queue` are given an instance called `inherent_data_providers`. This object is created in a helper function defined at the beginning of `service.rs`
+Both the BlockImport and the `import_queue` are given an instance called `inherent_data_providers`.
+This object is created in a helper function defined at the beginning of `service.rs`
 
 ```rust, ignore
 pub fn build_inherent_data_providers() -> Result<InherentDataProviders, ServiceError> {
@@ -72,11 +111,20 @@ pub fn build_inherent_data_providers() -> Result<InherentDataProviders, ServiceE
 }
 ```
 
-Anything that implements the [`ProvideInherentData` trait](https://crates.parity.io/sp_inherents/trait.ProvideInherentData.html) may be used here. The block authoring logic must supply all inherents that the runtime expects. In this case of this basic-pow chain, that is just the [`TimestampInherentData`](https://crates.parity.io/sp_timestamp/trait.TimestampInherentData.html) expected by the [timestamp pallet](https://crates.parity.io/pallet_timestamp/index.html). In order to register other inherents, you would call `register_provider` multiple times, and map errors accordingly.
+Anything that implements the
+[`ProvideInherentData` trait](https://crates.parity.io/sp_inherents/trait.ProvideInherentData.html)
+may be used here. The block authoring logic must supply all inherents that the runtime expects. In
+this case of this basic-pow chain, that is just the
+[`TimestampInherentData`](https://crates.parity.io/sp_timestamp/trait.TimestampInherentData.html)
+expected by the [timestamp pallet](https://crates.parity.io/pallet_timestamp/index.html). In order
+to register other inherents, you would call `register_provider` multiple times, and map errors
+accordingly.
 
 ## Mining
 
-We've already implemented a mining algorithm as part of our [`MinimalSha3Algorithm`](./sha3-pow-consensus.md), but we haven't yet told our service to actually mine with that algorithm. This is our last task in the `new_full` function.
+We've already implemented a mining algorithm as part of our
+[`MinimalSha3Algorithm`](./sha3-pow-consensus.md), but we haven't yet told our service to actually
+mine with that algorithm. This is our last task in the `new_full` function.
 
 ```rust, ignore
 if participates_in_consensus {
@@ -111,19 +159,34 @@ if participates_in_consensus {
 }
 ```
 
-We begin by testing whether this node participates in consensus, which is to say we check whether the user wants the node to act as a miner. If this node is to be a miner, we gather references to various parts of the node that the [`start_mine` function](https://crates.parity.io/sc_consensus_pow/fn.start_mine.html) requires, and define that we will attempt 500 rounds of mining for each block before pausing. Finally we call `start_mine`.
+We begin by testing whether this node participates in consensus, which is to say we check whether
+the user wants the node to act as a miner. If this node is to be a miner, we gather references to
+various parts of the node that the
+[`start_mine` function](https://crates.parity.io/sc_consensus_pow/fn.start_mine.html) requires, and
+define that we will attempt 500 rounds of mining for each block before pausing. Finally we call
+`start_mine`.
 
 ## The Light Client
 
-The last thing in the `service.rs` file is constructing the [light client](https://www.parity.io/what-is-a-light-client/)'s service. This code is quite similar to the construction of the full service.
+The last thing in the `service.rs` file is constructing the
+[light client](https://www.parity.io/what-is-a-light-client/)'s service. This code is quite similar
+to the construction of the full service.
 
-Instead of using the `with_import_queue` function we used previously, we use the `with_import_queue_and_fprb` function. FPRB stand for [`FinalityProofRequestBuilder`](https://crates.parity.io/sc_network/config/trait.FinalityProofRequestBuilder.html). In chains with deterministic finality, light clients must request proofs of finality from full nodes. But in our chain, we do not have deterministic finality, so we can use the [`DummyFinalityProofRequestBuilder`](https://crates.parity.io/sc_network/config/struct.DummyFinalityProofRequestBuilder.html) which does nothing except satisfying Rust's type checker.
+Instead of using the `with_import_queue` function we used previously, we use the
+`with_import_queue_and_fprb` function. FPRB stand for
+[`FinalityProofRequestBuilder`](https://crates.parity.io/sc_network/config/trait.FinalityProofRequestBuilder.html).
+In chains with deterministic finality, light clients must request proofs of finality from full
+nodes. But in our chain, we do not have deterministic finality, so we can use the
+[`DummyFinalityProofRequestBuilder`](https://crates.parity.io/sc_network/config/struct.DummyFinalityProofRequestBuilder.html)
+which does nothing except satisfying Rust's type checker.
 
-Once the dummy request builder is configured, the `BlockImport` and import queue are configured exactly as they were in the full node.
+Once the dummy request builder is configured, the `BlockImport` and import queue are configured
+exactly as they were in the full node.
 
 ## Note of Finality
 
-If we run the `basic-pow` node now, we see in console logs, that the finalized block always remains at 0.
+If we run the `basic-pow` node now, we see in console logs, that the finalized block always remains
+at 0.
 
 ```
 ...
@@ -134,4 +197,6 @@ If we run the `basic-pow` node now, we see in console logs, that the finalized b
 2020-03-22 12:50:15 Idle (1 peers), best: #189 (0x8581…9f5a), finalized #0 (0xff0d…5cb9), ⬇ 0 ⬆ 0
 ```
 
-This is expected because Proof of Work is a consensus mechanism with probabilistic finality. This means a block is never truly finalized and can always be reverted. The further behind the blockchain head a block is, the less likely it is going to be reverted.
+This is expected because Proof of Work is a consensus mechanism with probabilistic finality. This
+means a block is never truly finalized and can always be reverted. The further behind the blockchain
+head a block is, the less likely it is going to be reverted.

--- a/text/3-entrees/basic-token.md
+++ b/text/3-entrees/basic-token.md
@@ -1,16 +1,24 @@
 # Basic Token
-*[`pallets/basic-token`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/basic-token)*
+
+_[`pallets/basic-token`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/basic-token)_
 
 This recipe demonstrates a simple but functional token in a pallet.
 
 ## Mapping Accounts to Balances
-Mappings are a very powerful primitive. A *stateful* cryptocurrency might store a mapping between accounts and balances. Likewise, mappings prove useful when representing *owned* data. By tracking ownership with maps, it is easy manage permissions for modifying values specific to individual users or groups.
+
+Mappings are a very powerful primitive. A _stateful_ cryptocurrency might store a mapping between
+accounts and balances. Likewise, mappings prove useful when representing _owned_ data. By tracking
+ownership with maps, it is easy manage permissions for modifying values specific to individual users
+or groups.
 
 ## Storage Items
 
-The primary storage item is the mapping between AccountIds and Balances described above. Every account that holds tokens appears as a key in that map and its value is the number of tokens it holds.
+The primary storage item is the mapping between AccountIds and Balances described above. Every
+account that holds tokens appears as a key in that map and its value is the number of tokens it
+holds.
 
-The next two storage items set the total supply of the token and keep track of whether the token has been initialized yet.
+The next two storage items set the total supply of the token and keep track of whether the token has
+been initialized yet.
 
 ```rust, ignore
 decl_storage! {
@@ -24,11 +32,13 @@ decl_storage! {
 }
 ```
 
-Because users can influence the keys in our storage map, we've chosen the `blake2_128_concat` hasher as described in the recipe on [storage maps](storage-api/storage-maps.md)s.
+Because users can influence the keys in our storage map, we've chosen the `blake2_128_concat` hasher
+as described in the recipe on [storage maps](storage-api/storage-maps.md)s.
 
 ## Events and Errors
 
-The pallet defines events and errors for common lifecycle events such as successful and failed transfers, and successful and failed initialization.
+The pallet defines events and errors for common lifecycle events such as successful and failed
+transfers, and successful and failed initialization.
 
 ```rust, ignore
 decl_event!(
@@ -54,7 +64,12 @@ decl_error! {
 ```
 
 ## Initializing the Token
-In order for the token to be useful, some accounts need to own it. There are many possible ways to initialize a token including genesis config, claims process, lockdrop, and many more. This pallet will use a simple process where the first user to call the `init` function receives all of the funds. The total supply is hard-coded in the pallet in a fairly naive way: It is specified as the default value in the `decl_storage!` block.
+
+In order for the token to be useful, some accounts need to own it. There are many possible ways to
+initialize a token including genesis config, claims process, lockdrop, and many more. This pallet
+will use a simple process where the first user to call the `init` function receives all of the
+funds. The total supply is hard-coded in the pallet in a fairly naive way: It is specified as the
+default value in the `decl_storage!` block.
 
 ```rust ignore
 fn init(origin) -> DispatchResult {
@@ -68,12 +83,17 @@ fn init(origin) -> DispatchResult {
 }
 ```
 
-As usual, we first check for preconditions. In this case that means making sure that the token is not already initialized. Then we do any mutation necessary.
+As usual, we first check for preconditions. In this case that means making sure that the token is
+not already initialized. Then we do any mutation necessary.
 
 ## Transferring Tokens
-To transfer tokens, a user who owns some tokens calls the `transfer` method specifying the recipient and the amount of tokens to transfer as parameters.
 
-We again check for error conditions before mutating storage. In this case it is _not_ necessary to check whether the token has been initialized. If it has not, nobody has any funds and the transfer will simply fail with `InsufficientFunds`.
+To transfer tokens, a user who owns some tokens calls the `transfer` method specifying the recipient
+and the amount of tokens to transfer as parameters.
+
+We again check for error conditions before mutating storage. In this case it is _not_ necessary to
+check whether the token has been initialized. If it has not, nobody has any funds and the transfer
+will simply fail with `InsufficientFunds`.
 
 ```rust, ignore
 fn transfer(_origin, to: T::AccountId, value: u64) -> DispatchResult {
@@ -96,4 +116,6 @@ fn transfer(_origin, to: T::AccountId, value: u64) -> DispatchResult {
 
 ## Don't Panic!
 
-When adding the incoming balance, notice the peculiar `.expect` method. In a Substrate runtime, **you must never panic**. To encourage careful thinking about your code, you use the `.expect` method and provide a proof of why the potential panic will never happen.
+When adding the incoming balance, notice the peculiar `.expect` method. In a Substrate runtime,
+**you must never panic**. To encourage careful thinking about your code, you use the `.expect`
+method and provide a proof of why the potential panic will never happen.

--- a/text/3-entrees/charity.md
+++ b/text/3-entrees/charity.md
@@ -1,19 +1,30 @@
 # Charity
-*[`pallets/charity`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/charity)*
 
-The Charity pallet represents a simple charitable organization that collects funds into a pot that it controls, and allocates those funds to the appropriate causes. It demonstrates two useful concepts in Substrate development:
-* A pallet-controlled shared pot of funds
-* Absorbing imbalances from the runtime
+_[`pallets/charity`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/charity)_
+
+The Charity pallet represents a simple charitable organization that collects funds into a pot that
+it controls, and allocates those funds to the appropriate causes. It demonstrates two useful
+concepts in Substrate development:
+
+-   A pallet-controlled shared pot of funds
+-   Absorbing imbalances from the runtime
 
 ## Instantiate a Pot
 
-Our charity needs an account to hold its funds. Unlike other accounts, it will not be controlled by a user's cryptographic key pair, but directly by the pallet. To instantiate such a pool of funds, import [`ModuleId`](https://crates.parity.io/sp_runtime/struct.ModuleId.html) and [`AccountIdConversion`](https://crates.parity.io/sp_runtime/traits/trait.AccountIdConversion.html) from [`sp-runtime`](https://crates.parity.io/sp_runtime/index.html).
+Our charity needs an account to hold its funds. Unlike other accounts, it will not be controlled by
+a user's cryptographic key pair, but directly by the pallet. To instantiate such a pool of funds,
+import [`ModuleId`](https://crates.parity.io/sp_runtime/struct.ModuleId.html) and
+[`AccountIdConversion`](https://crates.parity.io/sp_runtime/traits/trait.AccountIdConversion.html)
+from [`sp-runtime`](https://crates.parity.io/sp_runtime/index.html).
 
 ```rust, ignore
 use sp-runtime::{ModuleId, traits::AccountIdConversion};
 ```
 
-With these imports, a `PALLET_ID` constant can be generated as an identifier for the pool of funds. The `PALLET_ID` must be exactly eight characters long which is why we've included the exclamation point. (Well, that and Charity work is just so exciting!) This identifier can be converted into an `AccountId` with the `into_account()` method provided by the `AccountIdConversion` trait.
+With these imports, a `PALLET_ID` constant can be generated as an identifier for the pool of funds.
+The `PALLET_ID` must be exactly eight characters long which is why we've included the exclamation
+point. (Well, that and Charity work is just so exciting!) This identifier can be converted into an
+`AccountId` with the `into_account()` method provided by the `AccountIdConversion` trait.
 
 ```rust, ignore
 const PALLET_ID: ModuleId = ModuleId(*b"Charity!");
@@ -32,10 +43,13 @@ impl<T: Trait> Module<T> {
 ```
 
 # Receiving Funds
+
 Our charity can receive funds in two different ways.
 
 ## Donations
-The first and perhaps more familiar way is through charitable donations. Donations can be made through a standard `donate` extrinsic which accepts the amount to be donated as a parameter.
+
+The first and perhaps more familiar way is through charitable donations. Donations can be made
+through a standard `donate` extrinsic which accepts the amount to be donated as a parameter.
 
 ```rust,ignore
 fn donate(
@@ -52,7 +66,16 @@ fn donate(
 ```
 
 ## Imbalances
-The second way the charity can receive funds is by absorbing imbalances created elsewhere in the runtime. An [`Imbalance`](https://crates.parity.io/frame_support/traits/trait.Imbalance.html) is created whenever tokens are burned, or minted. Because our charity wants to _collect_ funds, we are specifically interested in [`NegativeImbalance`](https://crates.parity.io/pallet_balances/struct.NegativeImbalance.html)s. Negative imbalances are created, for example, when a validator is slashed for violating consensus rules, transaction fees are collected, or another pallet burns funds as part of an incentive-alignment mechanism. To allow our pallet to absorb these imbalances, we implement the [`OnUnbalanced` trait](https://crates.parity.io/frame_support/traits/trait.OnUnbalanced.html).
+
+The second way the charity can receive funds is by absorbing imbalances created elsewhere in the
+runtime. An [`Imbalance`](https://crates.parity.io/frame_support/traits/trait.Imbalance.html) is
+created whenever tokens are burned, or minted. Because our charity wants to _collect_ funds, we are
+specifically interested in
+[`NegativeImbalance`](https://crates.parity.io/pallet_balances/struct.NegativeImbalance.html)s.
+Negative imbalances are created, for example, when a validator is slashed for violating consensus
+rules, transaction fees are collected, or another pallet burns funds as part of an
+incentive-alignment mechanism. To allow our pallet to absorb these imbalances, we implement the
+[`OnUnbalanced` trait](https://crates.parity.io/frame_support/traits/trait.OnUnbalanced.html).
 
 ```rust,ignore
 use frame_support::traits::{OnUnbalanced, Imbalance};
@@ -71,4 +94,9 @@ impl<T: Trait> OnUnbalanced<NegativeImbalanceOf<T>> for Module<T> {
 ```
 
 # Allocating Funds
-In order for the charity to affect change with the funds it has collected it must be able to allocate those funds. Our charity pallet abstracts the governance of where funds will be allocated to the rest of the runtime. Funds can be allocated by a root call to the `allocate` extrinsic. One good example of a governance mechanism for such decisions is Substrate's own [Democracy pallet](https://crates.parity.io/pallet_democracy/index.html).
+
+In order for the charity to affect change with the funds it has collected it must be able to
+allocate those funds. Our charity pallet abstracts the governance of where funds will be allocated
+to the rest of the runtime. Funds can be allocated by a root call to the `allocate` extrinsic. One
+good example of a governance mechanism for such decisions is Substrate's own
+[Democracy pallet](https://crates.parity.io/pallet_democracy/index.html).

--- a/text/3-entrees/constants.md
+++ b/text/3-entrees/constants.md
@@ -1,13 +1,16 @@
 # Configurable Pallet Constants
-*[`pallets/constant-config`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/constant-config)*
 
-To declare constant values within a runtime, it is necessary to import the [`Get`](https://crates.parity.io/frame_support/traits/trait.Get.html) trait from `frame_support`
+_[`pallets/constant-config`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/constant-config)_
+
+To declare constant values within a runtime, it is necessary to import the
+[`Get`](https://crates.parity.io/frame_support/traits/trait.Get.html) trait from `frame_support`
 
 ```rust, ignore
 use frame_support::traits::Get;
 ```
 
-Configurable constants are declared as associated types in the pallet's configuration trait using the `Get<T>` syntax for any type `T`.
+Configurable constants are declared as associated types in the pallet's configuration trait using
+the `Get<T>` syntax for any type `T`.
 
 ```rust, ignore
 pub trait Trait: system::Trait {
@@ -21,7 +24,9 @@ pub trait Trait: system::Trait {
 }
 ```
 
-In order to make these constants and their values appear in the runtime metadata, it is necessary to declare them with the `const` syntax in the `decl_module!` block. Usually constants are declared at the top of this block, right after `fn deposit_event`.
+In order to make these constants and their values appear in the runtime metadata, it is necessary to
+declare them with the `const` syntax in the `decl_module!` block. Usually constants are declared at
+the top of this block, right after `fn deposit_event`.
 
 ```rust, ignore
 decl_module! {
@@ -47,7 +52,8 @@ decl_storage! {
 }
 ```
 
-`SingleValue` is set to `0` every `ClearFrequency` number of blocks in the `on_finalize` function that runs at the end of blocks execution.
+`SingleValue` is set to `0` every `ClearFrequency` number of blocks in the `on_finalize` function
+that runs at the end of blocks execution.
 
 ```rust, ignore
 fn on_finalize(n: T::BlockNumber) {
@@ -59,7 +65,10 @@ fn on_finalize(n: T::BlockNumber) {
 }
 ```
 
-Signed transactions may invoke the `add_value` runtime method to increase `SingleValue` as long as each call adds less than `MaxAddend`. *There is no anti-sybil mechanism so a user could just split a larger request into multiple smaller requests to overcome the `MaxAddend`*, but overflow is still handled appropriately.
+Signed transactions may invoke the `add_value` runtime method to increase `SingleValue` as long as
+each call adds less than `MaxAddend`. _There is no anti-sybil mechanism so a user could just split a
+larger request into multiple smaller requests to overcome the `MaxAddend`_, but overflow is still
+handled appropriately.
 
 ```rust, ignore
 fn add_value(origin, val_to_add: u32) -> DispatchResult {
@@ -80,13 +89,20 @@ fn add_value(origin, val_to_add: u32) -> DispatchResult {
 }
 ```
 
-In more complex patterns, the constant value may be used as a static, base value that is scaled by a multiplier to incorporate stateful context for calculating some dynamic fee (ie floating transaction fees).
+In more complex patterns, the constant value may be used as a static, base value that is scaled by a
+multiplier to incorporate stateful context for calculating some dynamic fee (ie floating transaction
+fees).
 
-To test the range of pallet configurations introduced by configurable constants, see *[custom configuration of externalities](./testing/externalities.md)*
+To test the range of pallet configurations introduced by configurable constants, see
+_[custom configuration of externalities](./testing/externalities.md)_
 
 ## Supplying the Constant Value
 
-When the pallet is included in a runtime, the runtime developer supplies the value of the constant using the [`parameter_types!` macro](https://crates.parity.io/frame_support/macro.parameter_types.html). This pallet is included in the `super-runtime` where we see the following macro invocation and trat implementation.
+When the pallet is included in a runtime, the runtime developer supplies the value of the constant
+using the
+[`parameter_types!` macro](https://crates.parity.io/frame_support/macro.parameter_types.html). This
+pallet is included in the `super-runtime` where we see the following macro invocation and trat
+implementation.
 
 ```rust
 parameter_types! {

--- a/text/3-entrees/currency.md
+++ b/text/3-entrees/currency.md
@@ -1,15 +1,22 @@
 # Currency Types
-*[`pallets/lockable-currency`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/lockable-currency), [`pallets/reservable-currency`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/reservable-currency), [`pallets/currency-imbalances`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/currency-imbalances)*
+
+_[`pallets/lockable-currency`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/lockable-currency),
+[`pallets/reservable-currency`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/reservable-currency),
+[`pallets/currency-imbalances`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/currency-imbalances)_
 
 ## Just Plain Currency
 
-To use a balances type in the runtime, import the [`Currency`](https://crates.parity.io/frame_support/traits/trait.Currency.html) trait from `frame_support`.
+To use a balances type in the runtime, import the
+[`Currency`](https://crates.parity.io/frame_support/traits/trait.Currency.html) trait from
+`frame_support`.
 
 ```rust, ignore
 use support::traits::Currency;
 ```
 
-The `Currency` trait provides an abstraction over a fungible assets system. To use such a fuingible asset from your pallet, include an associated type with the `Currency` trait bound in your pallet's configuration trait.
+The `Currency` trait provides an abstraction over a fungible assets system. To use such a fuingible
+asset from your pallet, include an associated type with the `Currency` trait bound in your pallet's
+configuration trait.
 
 ```rust, ignore
 pub trait Trait: system::Trait {
@@ -17,7 +24,9 @@ pub trait Trait: system::Trait {
 }
 ```
 
-Defining an associated type with this trait bound allows this pallet to access the provided methods of [`Currency`](https://crates.parity.io/frame_support/traits/trait.Currency.html). For example, it is straightforward to check the total issuance of the system:
+Defining an associated type with this trait bound allows this pallet to access the provided methods
+of [`Currency`](https://crates.parity.io/frame_support/traits/trait.Currency.html). For example, it
+is straightforward to check the total issuance of the system:
 
 ```rust, ignore
 // in decl_module block
@@ -30,11 +39,19 @@ As promised, it is also possible to type alias a balances type for use in the ru
 type BalanceOf<T> = <<T as Trait>::Currency as Currency<<T as system::Trait>::AccountId>>::Balance;
 ```
 
-This new `BalanceOf<T>` type satisfies the type constraints of `Self::Balance` for the provided methods of `Currency`. This means that this type can be used for [transfer](https://crates.parity.io/frame_support/traits/trait.Currency.html#tymethod.transfer), [minting](https://crates.parity.io/frame_support/traits/trait.Currency.html#tymethod.deposit_into_existing), and much more.
+This new `BalanceOf<T>` type satisfies the type constraints of `Self::Balance` for the provided
+methods of `Currency`. This means that this type can be used for
+[transfer](https://crates.parity.io/frame_support/traits/trait.Currency.html#tymethod.transfer),
+[minting](https://crates.parity.io/frame_support/traits/trait.Currency.html#tymethod.deposit_into_existing),
+and much more.
 
 ## Reservable Currency
 
-Substrate's [Treasury pallet](https://crates.parity.io/pallet_treasury/index.html) uses the `Currency` type for bonding spending proposals. To reserve and unreserve balances for bonding, `treasury` uses the [`ReservableCurrency`](https://crates.parity.io/frame_support/traits/trait.ReservableCurrency.html) trait. The import and associated type declaration follow convention
+Substrate's [Treasury pallet](https://crates.parity.io/pallet_treasury/index.html) uses the
+`Currency` type for bonding spending proposals. To reserve and unreserve balances for bonding,
+`treasury` uses the
+[`ReservableCurrency`](https://crates.parity.io/frame_support/traits/trait.ReservableCurrency.html)
+trait. The import and associated type declaration follow convention
 
 ```rust, ignore
 use frame_support::traits::{Currency, ReservableCurrency};
@@ -44,7 +61,8 @@ pub trait Trait: system::Trait {
 }
 ```
 
-To lock or unlock some quantity of funds, it is sufficient to invoke `reserve` and `unreserve` respectively
+To lock or unlock some quantity of funds, it is sufficient to invoke `reserve` and `unreserve`
+respectively
 
 ```rust, ignore
 pub fn reserve_funds(origin, amount: BalanceOf<T>) -> DispatchResult {
@@ -76,19 +94,25 @@ pub fn unreserve_funds(origin, amount: BalanceOf<T>) -> DispatchResult {
 
 ## Lockable Currency
 
-Substrate's [Staking pallet](https://crates.parity.io/pallet_staking/index.html) similarly uses [`LockableCurrency`](https://crates.parity.io/frame_support/traits/trait.LockableCurrency.html) trait for more nuanced handling of capital locking based on time increments. This type can be very useful in the context of economic systems that enforce accountability by collateralizing fungible resources. Import this trait in the usual way
+Substrate's [Staking pallet](https://crates.parity.io/pallet_staking/index.html) similarly uses
+[`LockableCurrency`](https://crates.parity.io/frame_support/traits/trait.LockableCurrency.html)
+trait for more nuanced handling of capital locking based on time increments. This type can be very
+useful in the context of economic systems that enforce accountability by collateralizing fungible
+resources. Import this trait in the usual way
 
 ```rust, ignore
 use frame_support::traits::{LockIdentifier, LockableCurrency}
 ```
 
-To use `LockableCurrency`, it is necessary to define a [`LockIdentifier`](https://crates.parity.io/frame_support/traits/type.LockIdentifier.html).
+To use `LockableCurrency`, it is necessary to define a
+[`LockIdentifier`](https://crates.parity.io/frame_support/traits/type.LockIdentifier.html).
 
 ```rust, ignore
 const EXAMPLE_ID: LockIdentifier = *b"example ";
 ```
 
-By using this `EXAMPLE_ID`, it is straightforward to define logic within the runtime to schedule locking, unlocking, and extending existing locks.
+By using this `EXAMPLE_ID`, it is straightforward to define logic within the runtime to schedule
+locking, unlocking, and extending existing locks.
 
 ```rust, ignore
 fn lock_capital(origin, amount: BalanceOf<T>) -> DispatchResult {
@@ -108,9 +132,14 @@ fn lock_capital(origin, amount: BalanceOf<T>) -> DispatchResult {
 
 ## Imbalances
 
-Functions that alter balances return an object of the [`Imbalance`](https://crates.parity.io/frame_support/traits/trait.Imbalance.html) type to express how much account balances have been altered in aggregate. This is useful in the context of state transitions that adjust the total supply of the `Currency` type in question.
+Functions that alter balances return an object of the
+[`Imbalance`](https://crates.parity.io/frame_support/traits/trait.Imbalance.html) type to express
+how much account balances have been altered in aggregate. This is useful in the context of state
+transitions that adjust the total supply of the `Currency` type in question.
 
-To manage this supply adjustment, the [`OnUnbalanced`](https://crates.parity.io/frame_support/traits/trait.OnUnbalanced.html) handler is often used. An example might look something like
+To manage this supply adjustment, the
+[`OnUnbalanced`](https://crates.parity.io/frame_support/traits/trait.OnUnbalanced.html) handler is
+often used. An example might look something like
 
 ```rust, ignore
 pub fn reward_funds(origin, to_reward: T::AccountId, reward: BalanceOf<T>) {
@@ -129,4 +158,7 @@ pub fn reward_funds(origin, to_reward: T::AccountId, reward: BalanceOf<T>) {
 
 ## takeaway
 
-The way we represent value in the runtime dictates both the security and flexibility of the underlying transactional system. Likewise, it is convenient to be able to take advantage of Rust's [flexible trait system](https://blog.rust-lang.org/2015/05/11/traits.html) when building systems intended to rethink how we exchange information and value 🚀
+The way we represent value in the runtime dictates both the security and flexibility of the
+underlying transactional system. Likewise, it is convenient to be able to take advantage of Rust's
+[flexible trait system](https://blog.rust-lang.org/2015/05/11/traits.html) when building systems
+intended to rethink how we exchange information and value 🚀

--- a/text/3-entrees/custom-rpc.md
+++ b/text/3-entrees/custom-rpc.md
@@ -1,12 +1,20 @@
 # Custom RPCs
-*[`nodes/rpc-node`](https://github.com/substrate-developer-hub/recipes/tree/master/nodes/rpc-node)*
-*[`runtime/api-runtime`](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/api-runtime)*
 
-Remote Procedure Calls, or RPCs, are a way for an external program (eg. a frontend) to communicate with a Substrate node. They are used for checking storage values, submitting transactions, and querying the current consensus authorities. Substrate comes with several [default RPCs](https://polkadot.js.org/api/substrate/rpc.html). In many cases it is useful to add custom RPCs to your node. In this recipe, we will add two custom RPCs to our node, one of which calls into a [custom runtime API](./runtime-api.md).
+_[`nodes/rpc-node`](https://github.com/substrate-developer-hub/recipes/tree/master/nodes/rpc-node)_
+_[`runtime/api-runtime`](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/api-runtime)_
+
+Remote Procedure Calls, or RPCs, are a way for an external program (eg. a frontend) to communicate
+with a Substrate node. They are used for checking storage values, submitting transactions, and
+querying the current consensus authorities. Substrate comes with several
+[default RPCs](https://polkadot.js.org/api/substrate/rpc.html). In many cases it is useful to add
+custom RPCs to your node. In this recipe, we will add two custom RPCs to our node, one of which
+calls into a [custom runtime API](./runtime-api.md).
 
 ## Defining an RPC
+
 Every RPC that the node will use must be defined in a trait. We'll begin by defining a simple RPC
-called "silly rpc" which just returns constant integers. A Hello world of sorts. In the `nodes/rpc-node/src/silly_rpc.rs` file, we define a basic rpc as
+called "silly rpc" which just returns constant integers. A Hello world of sorts. In the
+`nodes/rpc-node/src/silly_rpc.rs` file, we define a basic rpc as
 
 ```rust
 #[rpc]
@@ -19,7 +27,9 @@ pub trait SillyRpc {
 }
 ```
 
-This definition defines two RPC methods called `hello_five` and `hello_seven`. Each RPC method must take a `&self` reference and must return a `Result`. Next, we define a struct that implements this trait.
+This definition defines two RPC methods called `hello_five` and `hello_seven`. Each RPC method must
+take a `&self` reference and must return a `Result`. Next, we define a struct that implements this
+trait.
 
 ```rust
 pub struct Silly;
@@ -36,12 +46,15 @@ impl SillyRpc for Silly {
 ```
 
 Finally, to make the contents of this new file usable, we need to add a line in our `main.rs`.
+
 ```rust
 mod silly_rpc;
 ```
 
 ## Including the RPC
-With our RPC written, we're ready to install it on our node. We begin with a few dependencies in our `rpc-node`'s `Cargo.toml`.
+
+With our RPC written, we're ready to install it on our node. We begin with a few dependencies in our
+`rpc-node`'s `Cargo.toml`.
 
 ```toml
 jsonrpc-core = "14.0.3"
@@ -50,14 +63,18 @@ jsonrpc-derive = "14.0.3"
 sc-rpc = { version = '2.0.0-alpha.7' }
 ```
 
-Next, in our `rpc-node`'s `service.rs` file, we extend the service with our RPC. We've chosen to install this RPC for full nodes, so we've included the code in the `new_full_start!` macro. You could also install the RPC on a light client by making the corresponding changes to `new_light`.
+Next, in our `rpc-node`'s `service.rs` file, we extend the service with our RPC. We've chosen to
+install this RPC for full nodes, so we've included the code in the `new_full_start!` macro. You
+could also install the RPC on a light client by making the corresponding changes to `new_light`.
 
 The first change to this macro is a simple type definition
+
 ```rust
 type RpcExtension = jsonrpc_core::IoHandler<sc_rpc::Metadata>;
 ```
 
-Then, once you've called the service builder, you can extend it with an RPC by using its `with_rpc_extensions` method as follows.
+Then, once you've called the service builder, you can extend it with an RPC by using its
+`with_rpc_extensions` method as follows.
 
 ```rust
 .with_rpc_extensions(|builder| -> Result<RpcExtension, _> {
@@ -74,7 +91,10 @@ Then, once you've called the service builder, you can extend it with an RPC by u
 ```
 
 ## Calling the RPC
-Once your node is running, you can test the RPC by calling it with any client that speaks json RPC. One widely available option `curl`.
+
+Once your node is running, you can test the RPC by calling it with any client that speaks json RPC.
+One widely available option `curl`.
+
 ```bash
 $ curl http://localhost:9933 -H "Content-Type:application/json;charset=utf-8" -d   '{
      "jsonrpc":"2.0",
@@ -85,11 +105,13 @@ $ curl http://localhost:9933 -H "Content-Type:application/json;charset=utf-8" -d
 ```
 
 To which the RPC responds
+
 ```
 {"jsonrpc":"2.0","result":7,"id":1}
 ```
 
-You may have noticed that our second RPC takes a parameter, the value to double. You can supply this parameter by including its in the  `params` list. For example:
+You may have noticed that our second RPC takes a parameter, the value to double. You can supply this
+parameter by including its in the `params` list. For example:
 
 ```bash
 $ curl http://localhost:9933 -H "Content-Type:application/json;charset=utf-8" -d   '{
@@ -101,21 +123,32 @@ $ curl http://localhost:9933 -H "Content-Type:application/json;charset=utf-8" -d
 ```
 
 To which the RPC responds with the doubled parameter
+
 ```
 {"jsonrpc":"2.0","result":14,"id":1}
 ```
 
 ## RPC to Call a Runtime API
 
-The silly RPC demonstrates the fundamentals of working with RPCs in Substrate. Nonetheless, most RPCs will go beyond what we've learned so far, and actually interact with other parts of the node. In this second example, we will include an RPC that calls into the `sum-storage` runtime API from the [runtime API recipe](./runtime-api.md). While it isn't strictly necessary to understand what the runtime API does, reading that recipe may provide helpful context.
+The silly RPC demonstrates the fundamentals of working with RPCs in Substrate. Nonetheless, most
+RPCs will go beyond what we've learned so far, and actually interact with other parts of the node.
+In this second example, we will include an RPC that calls into the `sum-storage` runtime API from
+the [runtime API recipe](./runtime-api.md). While it isn't strictly necessary to understand what the
+runtime API does, reading that recipe may provide helpful context.
 
-Because this RPC's behavior is closely related to a specific pallet, we've chosen to define the RPC in the pallet's directory. In this case the RPC is defined in `pallets/sum-storage/rpc`. So rather than using the `mod` keyword as we did before, we must include this RPC definition in the node's `Cargo.toml` file.
+Because this RPC's behavior is closely related to a specific pallet, we've chosen to define the RPC
+in the pallet's directory. In this case the RPC is defined in `pallets/sum-storage/rpc`. So rather
+than using the `mod` keyword as we did before, we must include this RPC definition in the node's
+`Cargo.toml` file.
 
 ```toml
 sum-storage-rpc = { path = "../../pallets/sum-storage/rpc" }
 ```
 
-Defining the RPC interface is similar to before, but there are a few differences worth noting. First, the struct that implements the RPC needs a reference to the `client`. This is necessary so we can actually call into the runtime. Second the struct is generic over the `BlockHash` type. This is because it will call a runtime API, and runtime APIs must always be called at a specific block.
+Defining the RPC interface is similar to before, but there are a few differences worth noting.
+First, the struct that implements the RPC needs a reference to the `client`. This is necessary so we
+can actually call into the runtime. Second the struct is generic over the `BlockHash` type. This is
+because it will call a runtime API, and runtime APIs must always be called at a specific block.
 
 ```rust
 #[rpc]
@@ -141,7 +174,10 @@ impl<C, M> SumStorage<C, M> {
 }
 ```
 
-The RPC's implementation is also similar to before. The additional syntax here is related to calling the runtime at a specific block, as well as ensuring that the runtime we're calling actually has the correct runtime API available.
+The RPC's implementation is also similar to before. The additional syntax here is related to calling
+the runtime at a specific block, as well as ensuring that the runtime we're calling actually has the
+correct runtime API available.
+
 ```rust
 impl<C, Block> SumStorageApi<<Block as BlockT>::Hash>
 	for SumStorage<C, Block>
@@ -174,6 +210,7 @@ where
 ```
 
 Finally, to install this RPC on in our service, we expand the existing `with_rpc_extensions` call to
+
 ```rust
 .with_rpc_extensions(|builder| -> Result<RpcExtension, _> {
 	// Make an io handler to be extended with individual RPCs
@@ -191,7 +228,10 @@ Finally, to install this RPC on in our service, we expand the existing `with_rpc
 ```
 
 ## Optional RPC Parameters
-This RPC takes a parameter ,`at`, whose type is `Option<_>`. We may call this RPC by omitting the optional parameter entirely. In this case the implementation provides a default value of the best block.
+
+This RPC takes a parameter ,`at`, whose type is `Option<_>`. We may call this RPC by omitting the
+optional parameter entirely. In this case the implementation provides a default value of the best
+block.
 
 ```bash
 $ curl http://localhost:9933 -H "Content-Type:application/json;charset=utf-8" -d   '{
@@ -202,7 +242,8 @@ $ curl http://localhost:9933 -H "Content-Type:application/json;charset=utf-8" -d
     }'
 ```
 
-We may also call the RPC by providing a block hash. One easy way to get a block hash to test this call is by copying it from the logs of a running node.
+We may also call the RPC by providing a block hash. One easy way to get a block hash to test this
+call is by copying it from the logs of a running node.
 
 ```bash
 $ curl http://localhost:9933 -H "Content-Type:application/json;charset=utf-8" -d   '{
@@ -213,7 +254,11 @@ $ curl http://localhost:9933 -H "Content-Type:application/json;charset=utf-8" -d
     }'
 ```
 
-As an exercise, you should change the storage values, and confirm that the RPC provides the correct updated sum. Then call the RPC at an old block and confirm you get the old sum.
+As an exercise, you should change the storage values, and confirm that the RPC provides the correct
+updated sum. Then call the RPC at an old block and confirm you get the old sum.
 
 ## Polkadot JS API
-Many frontends interact with Substrate nodes through Polkadot JS API. While the recipes does not strive to document that project, we have included a snippet of javascript for interacting with these custom RPCs in the `nodes/rpc-node/js` directory.
+
+Many frontends interact with Substrate nodes through Polkadot JS API. While the recipes does not
+strive to document that project, we have included a snippet of javascript for interacting with these
+custom RPCs in the `nodes/rpc-node/js` directory.

--- a/text/3-entrees/fees.md
+++ b/text/3-entrees/fees.md
@@ -1,12 +1,22 @@
 # Transaction Fees
-*[runtimes/weight-fee-runtime](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/weight-fee-runtime)*
 
-Substrate provides the [`transaction_payment` pallet](https://crates.parity.io/pallet_transaction_payment/index.html) for calculating and collecting fees for executing transactions. Fees are broken down into several components:
+_[runtimes/weight-fee-runtime](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/weight-fee-runtime)_
 
-* Base fee - A fixed fee applied to each transaction. A parameter in the `transaction_payment` pallet.
-* Length fee - A fee proportional to the transaction's length in bytes. The proportionality constant is a parameter in the `transaction_payment` pallet.
-* Weight fee - A fee calculated from the transaction's weight. Weights are intended to capture the actual resources consumed by the transaction. Learn more in the [recipe on weights](./weights.md). It doesn't need to be linear, although it often is. The same conversion function is applied across all transactions from all pallets in the runtime.
-* Fee Multiplier - A multiplier for the computed fee, that can change as the chain progresses. This topic is not (yet) covered further in the recipes.
+Substrate provides the
+[`transaction_payment` pallet](https://crates.parity.io/pallet_transaction_payment/index.html) for
+calculating and collecting fees for executing transactions. Fees are broken down into several
+components:
+
+-   Base fee - A fixed fee applied to each transaction. A parameter in the `transaction_payment`
+    pallet.
+-   Length fee - A fee proportional to the transaction's length in bytes. The proportionality
+    constant is a parameter in the `transaction_payment` pallet.
+-   Weight fee - A fee calculated from the transaction's weight. Weights are intended to capture the
+    actual resources consumed by the transaction. Learn more in the
+    [recipe on weights](./weights.md). It doesn't need to be linear, although it often is. The same
+    conversion function is applied across all transactions from all pallets in the runtime.
+-   Fee Multiplier - A multiplier for the computed fee, that can change as the chain progresses.
+    This topic is not (yet) covered further in the recipes.
 
 ```
 total_fee = base_fee + transaction_length * length_fee + weight_to_fee(total_weight)
@@ -14,9 +24,11 @@ total_fee = base_fee + transaction_length * length_fee + weight_to_fee(total_wei
 
 ## Setting the Constants
 
-Each of the parameters described above is set in the `transaction_payment` pallet's configuration trait. For example, the `super-runtime` sets these parameters as follows.
+Each of the parameters described above is set in the `transaction_payment` pallet's configuration
+trait. For example, the `super-runtime` sets these parameters as follows.
 
-src: [`runtimes/super-runtime/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/super-runtime/src/lib.rs)
+src:
+[`runtimes/super-runtime/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/super-runtime/src/lib.rs)
 
 ```rust,ignore
 parameter_types! {
@@ -36,11 +48,18 @@ impl transaction_payment::Trait for Runtime {
 
 ## Converting Weight To Fees
 
-In many cases converting weight to fees in a one-to-one fashion, as shown above, will suffice and can be accomplished with [`ConvertInto`](https://crates.parity.io/sp_runtime/traits/struct.ConvertInto.html). This approach is also taken in the [node template](https://github.com/substrate-developer-hub/substrate-node-template/blob/43ee95347b6626580b1d9d554c3c8b77dc85bc01/runtime/src/lib.rs#L230). It is also possible to provide a type that makes a more complex calculation. Any type that implements `Convert<Weight, Balance>` will suffice.
+In many cases converting weight to fees in a one-to-one fashion, as shown above, will suffice and
+can be accomplished with
+[`ConvertInto`](https://crates.parity.io/sp_runtime/traits/struct.ConvertInto.html). This approach
+is also taken in the
+[node template](https://github.com/substrate-developer-hub/substrate-node-template/blob/43ee95347b6626580b1d9d554c3c8b77dc85bc01/runtime/src/lib.rs#L230).
+It is also possible to provide a type that makes a more complex calculation. Any type that
+implements `Convert<Weight, Balance>` will suffice.
 
 This example uses a quadratic conversion and supports custom coefficients.
 
-src: [`runtimes/weight-fee-runtime/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/weight-fee-runtime/src/lib.rs)
+src:
+[`runtimes/weight-fee-runtime/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/weight-fee-runtime/src/lib.rs)
 
 ```rust, ignore
 pub struct QuadraticWeightToFee<C0, C1, C2>(C0, C1, C2);
@@ -62,9 +81,15 @@ impl<C0, C1, C2> Convert<Weight, Balance> for QuadraticWeightToFee<C0, C1, C2>
 
 ## Collecting Fees
 
-Having calculated the amount of fees due, runtime authors must decide which asset the fees should be paid in. A common choice is the use the [`Ballances` pallet](https://crates.parity.io/pallet_balances/index.html), but any type that implements the [`Currency` trait](https://crates.parity.io/frame_support/traits/trait.Currency.html) can be used. The weight-fee-runtime demonstrates how to use an asset provided by the [`Generic Asset` pallet](https://crates.parity.io/pallet_generic_asset/index.html).
+Having calculated the amount of fees due, runtime authors must decide which asset the fees should be
+paid in. A common choice is the use the
+[`Ballances` pallet](https://crates.parity.io/pallet_balances/index.html), but any type that
+implements the [`Currency` trait](https://crates.parity.io/frame_support/traits/trait.Currency.html)
+can be used. The weight-fee-runtime demonstrates how to use an asset provided by the
+[`Generic Asset` pallet](https://crates.parity.io/pallet_generic_asset/index.html).
 
-src: [`runtimes/weight-fee-runtime/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/weight-fee-runtime/src/lib.rs)
+src:
+[`runtimes/weight-fee-runtime/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/weight-fee-runtime/src/lib.rs)
 
 ```rust,ignore
 impl transaction_payment::Trait for Runtime {

--- a/text/3-entrees/fixed-point.md
+++ b/text/3-entrees/fixed-point.md
@@ -1,27 +1,58 @@
 # Fixed Point Arithmetic
-*[`pallets/fixed-point`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/fixed-point)* *[`pallets/compounding-interest`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/compounding-interest)*
 
-When programmers learn to use non-integer numbers in their programs, they are usually taught to use [floating point](https://en.wikipedia.org/wiki/Floating-point_arithmetic)s. In blockchain, we use an alternative representation of fractional numbers called [fixed point](https://en.wikipedia.org/wiki/Fixed-point_arithmetic). There are several ways to use fixed point numbers, and this recipe will introduce three of them. In particular we'll see:
+_[`pallets/fixed-point`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/fixed-point)_
+_[`pallets/compounding-interest`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/compounding-interest)_
 
-* Substrate's own fixed point structs and traits
-* The [substrate-fixed](https://github.com/encointer/substrate-fixed/) library
-* A manual fixed point implementation (and why it's nicer to use a library)
-* A comparison of the two libraries in a compounding interest example
+When programmers learn to use non-integer numbers in their programs, they are usually taught to use
+[floating point](https://en.wikipedia.org/wiki/Floating-point_arithmetic)s. In blockchain, we use an
+alternative representation of fractional numbers called
+[fixed point](https://en.wikipedia.org/wiki/Fixed-point_arithmetic). There are several ways to use
+fixed point numbers, and this recipe will introduce three of them. In particular we'll see:
+
+-   Substrate's own fixed point structs and traits
+-   The [substrate-fixed](https://github.com/encointer/substrate-fixed/) library
+-   A manual fixed point implementation (and why it's nicer to use a library)
+-   A comparison of the two libraries in a compounding interest example
 
 ## What's Wrong with Floats?
 
-Floats are cool for all kinds of reasons, but they also have one important drawback. Floating point arithmetic is **nondeterministic** which means that different processors compute (slightly) different results for the same operation. Although there is an [IEEE spec](https://en.wikipedia.org/wiki/IEEE_754), nondeterminism can come from specific libraries used, or even hardware. In order for the nodes in a blockchain network to reach agreement on the state of the chain, all operations must be completely deterministic. Luckily fixed point arithmetic is deterministic, and is often not much harder to use once you get the hang of it.
+Floats are cool for all kinds of reasons, but they also have one important drawback. Floating point
+arithmetic is **nondeterministic** which means that different processors compute (slightly)
+different results for the same operation. Although there is an
+[IEEE spec](https://en.wikipedia.org/wiki/IEEE_754), nondeterminism can come from specific libraries
+used, or even hardware. In order for the nodes in a blockchain network to reach agreement on the
+state of the chain, all operations must be completely deterministic. Luckily fixed point arithmetic
+is deterministic, and is often not much harder to use once you get the hang of it.
 
 ## Multiplicative Accumulators
-*[`pallets/fixed-point`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/fixed-point)*
 
-The first pallet covered in this recipe contains three implementations of a multiplicative accumulator. That's a fancy way to say the pallet lets users submit fractional numbers and keeps track of the product from multiplying them all together. The value starts out at one (the [multiplicative identity](https://en.wikipedia.org/wiki/Identity_element)), and it gets multiplied by whatever values the users submit. These three independent implementations compare and contrast the features of each.
+_[`pallets/fixed-point`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/fixed-point)_
+
+The first pallet covered in this recipe contains three implementations of a multiplicative
+accumulator. That's a fancy way to say the pallet lets users submit fractional numbers and keeps
+track of the product from multiplying them all together. The value starts out at one (the
+[multiplicative identity](https://en.wikipedia.org/wiki/Identity_element)), and it gets multiplied
+by whatever values the users submit. These three independent implementations compare and contrast
+the features of each.
 
 ### Permill Accumulator
 
-We'll using the most common approach which takes its fixed point implementation from Substrate itself. There are a few fixed-point structs available in Substrate, all of which implement the [`PerThing` trait](https://crates.parity.io/sp_arithmetic/trait.PerThing.html), that cover different amounts of precision. For this accumulator example, we'll use the [`PerMill` struct](https://crates.parity.io/sp_arithmetic/struct.Permill.html) which represents fractions as parts per million. There are also [`Perbill`](https://crates.parity.io/sp_arithmetic/struct.Perbill.html), [`PerCent`](https://crates.parity.io/sp_arithmetic/struct.Percent.html), and [`PerU16`](https://crates.parity.io/sp_arithmetic/struct.PerU16.html), which all provide the same interface (because it comes from the trait). Substrate's fixed-point structs are somewhat unique because they represent _only_ fractional parts of numbers. That means they can represent numbers between 0 and 1 inclusive, but _not_ numbers with whole parts like 2.718 or 3.14.
+We'll using the most common approach which takes its fixed point implementation from Substrate
+itself. There are a few fixed-point structs available in Substrate, all of which implement the
+[`PerThing` trait](https://crates.parity.io/sp_arithmetic/trait.PerThing.html), that cover different
+amounts of precision. For this accumulator example, we'll use the
+[`PerMill` struct](https://crates.parity.io/sp_arithmetic/struct.Permill.html) which represents
+fractions as parts per million. There are also
+[`Perbill`](https://crates.parity.io/sp_arithmetic/struct.Perbill.html),
+[`PerCent`](https://crates.parity.io/sp_arithmetic/struct.Percent.html), and
+[`PerU16`](https://crates.parity.io/sp_arithmetic/struct.PerU16.html), which all provide the same
+interface (because it comes from the trait). Substrate's fixed-point structs are somewhat unique
+because they represent _only_ fractional parts of numbers. That means they can represent numbers
+between 0 and 1 inclusive, but _not_ numbers with whole parts like 2.718 or 3.14.
 
-To begin we declare the storage item that will hold our accumulated product. You can see that the trait provides a handy function for getting the identity value which we use to set the default storage value to `1`.
+To begin we declare the storage item that will hold our accumulated product. You can see that the
+trait provides a handy function for getting the identity value which we use to set the default
+storage value to `1`.
 
 ```rust, ignore
 decl_storage! {
@@ -34,7 +65,8 @@ decl_storage! {
 }
 ```
 
-The only extrinsic for this Permill accumulator is the one that allows users to submit new `Permill` values to get multiplied into the accumulator.
+The only extrinsic for this Permill accumulator is the one that allows users to submit new `Permill`
+values to get multiplied into the accumulator.
 
 ```rust, ignore
 fn update_permill(origin, new_factor: Permill) -> DispatchResult {
@@ -55,15 +87,31 @@ fn update_permill(origin, new_factor: Permill) -> DispatchResult {
 }
 ```
 
-The code of this extrinsic largely speaks for itself. One thing to take particular note of is that we _don't_ check for overflow on the multiplication. If you've read many of the recipes you know that a Substrate runtime must never panic, and a developer must be extremely diligent in always checking for and gracefully handling error conditions. Because `Permill` only holds values between 0 and 1, we know that their product will always be in that same range. Thus it is impossible to overflow or saturate. So we can happily use `saturating_mul` and move on.
+The code of this extrinsic largely speaks for itself. One thing to take particular note of is that
+we _don't_ check for overflow on the multiplication. If you've read many of the recipes you know
+that a Substrate runtime must never panic, and a developer must be extremely diligent in always
+checking for and gracefully handling error conditions. Because `Permill` only holds values between 0
+and 1, we know that their product will always be in that same range. Thus it is impossible to
+overflow or saturate. So we can happily use `saturating_mul` and move on.
 
 ### Substrate-fixed Accumulator
 
-[Substrate-fixed](https://github.com/encointer/substrate-fixed/) takes a more traditional approach in that their types represent numbers with both whole _and_ fractional parts. For this implementation, we'll use the `U16F16` type. This type contains an unsigned number (indicated by the `U` at the beginning) and has 32 _total_ bits of precision - 16 for the integer part, and 16 for the fractional part. There are several other types provided that follow the same naming convention. Some examples include `U32F32` and `I32F32` where the `I` indicates a signed number, just like in Rust primitive types.
+[Substrate-fixed](https://github.com/encointer/substrate-fixed/) takes a more traditional approach
+in that their types represent numbers with both whole _and_ fractional parts. For this
+implementation, we'll use the `U16F16` type. This type contains an unsigned number (indicated by the
+`U` at the beginning) and has 32 _total_ bits of precision - 16 for the integer part, and 16 for the
+fractional part. There are several other types provided that follow the same naming convention. Some
+examples include `U32F32` and `I32F32` where the `I` indicates a signed number, just like in Rust
+primitive types.
 
-As in the `Permill` example, we begin by declaring the storage item. With substrate-fixed, there is not a `one` function, but there is a `from_num` function that we use to set the storage item's default value. This `from_num` method and its counterpart `to-num` are your primary ways of converting between substrate-fixed types and Rust primitive types. If your use case does a lot of fixed-point arithmetic, like ours does, it is advisable to keep your data in substrate-fixed types.
+As in the `Permill` example, we begin by declaring the storage item. With substrate-fixed, there is
+not a `one` function, but there is a `from_num` function that we use to set the storage item's
+default value. This `from_num` method and its counterpart `to-num` are your primary ways of
+converting between substrate-fixed types and Rust primitive types. If your use case does a lot of
+fixed-point arithmetic, like ours does, it is advisable to keep your data in substrate-fixed types.
 
-> We're able to use `U16F16` as a storage item type because it, and the other substrate-fixed types, implements the parity scale codec.
+> We're able to use `U16F16` as a storage item type because it, and the other substrate-fixed types,
+> implements the parity scale codec.
 
 ```rust, ignore
 decl_storage! {
@@ -76,7 +124,8 @@ decl_storage! {
 }
 ```
 
-Next we implement the extrinsic that allows users to update the accumulator by multiplying in a new value.
+Next we implement the extrinsic that allows users to update the accumulator by multiplying in a new
+value.
 
 ```rust, ignore
 fn update_fixed(origin, new_factor: U16F16) -> DispatchResult {
@@ -97,17 +146,31 @@ fn update_fixed(origin, new_factor: U16F16) -> DispatchResult {
 }
 ```
 
-This extrinsic is quite similar to the `Permill` version with one notable difference. Because `U16F16` handles numbers greater than one, overflow is possible, and we need to handle it. The error handling here is straightforward, the important part is just that you remember to do it.
+This extrinsic is quite similar to the `Permill` version with one notable difference. Because
+`U16F16` handles numbers greater than one, overflow is possible, and we need to handle it. The error
+handling here is straightforward, the important part is just that you remember to do it.
 
-This example has shown the fundamentals of substrate-fixed, but this library has much more to offer as we'll see in the compounding interest example.
+This example has shown the fundamentals of substrate-fixed, but this library has much more to offer
+as we'll see in the compounding interest example.
 
 ### Manual Accumulator
 
-In this final accumulator implementation, we manually track fixed point numbers using Rust's native `u32` as the underlying data type. This example is educational, but is only practical in the simplest scenarios. Generally you will have a ~~more fun~~ less error-prone time coding if you use one of the previous two fixed-point types in your real-world applications.
+In this final accumulator implementation, we manually track fixed point numbers using Rust's native
+`u32` as the underlying data type. This example is educational, but is only practical in the
+simplest scenarios. Generally you will have a ~~more fun~~ less error-prone time coding if you use
+one of the previous two fixed-point types in your real-world applications.
 
-Fixed point is not very complex conceptually. We represent fractional numbers as regular old integers, and we decide in advance to consider some of the place values fractional. It's just like saying we'll omit the decimal point when talking about money and all agree that "1995" actually _means_ 19.95 €. This is exactly how Substrate's [Balances pallet](https://crates.parity.io/pallet_balances/index.html) works, a tradition that's been in blockchain since Bitcon. In our example we will treat 16 bits as integer values, and 16 as fractional, just as substrate-fixed's `U16F16` did.
+Fixed point is not very complex conceptually. We represent fractional numbers as regular old
+integers, and we decide in advance to consider some of the place values fractional. It's just like
+saying we'll omit the decimal point when talking about money and all agree that "1995" actually
+_means_ 19.95 €. This is exactly how Substrate's
+[Balances pallet](https://crates.parity.io/pallet_balances/index.html) works, a tradition that's
+been in blockchain since Bitcon. In our example we will treat 16 bits as integer values, and 16 as
+fractional, just as substrate-fixed's `U16F16` did.
 
-If you're rusty or unfamiliar with place values in the [binary number system](https://en.wikipedia.org/wiki/Binary_number), it may be useful to brush up. (Or skip this detailed section and proceed to the compounding interest example.)
+If you're rusty or unfamiliar with place values in the
+[binary number system](https://en.wikipedia.org/wiki/Binary_number), it may be useful to brush up.
+(Or skip this detailed section and proceed to the compounding interest example.)
 
 ```
 Normal interpretation of u32 place values
@@ -119,9 +182,18 @@ Fixed interpretation of u32 place values
 ...  8   4   2   1    1/2 1/4 1/8 1/16...
 ```
 
-Although the concepts are straight-forward, you'll see that manually implementing operations like multiplication is quite error prone. Therefore, when writing your own blockchain applications, it is often best to use on of the provided libraries covered in the other two implementations of the accumulator.
+Although the concepts are straight-forward, you'll see that manually implementing operations like
+multiplication is quite error prone. Therefore, when writing your own blockchain applications, it is
+often best to use on of the provided libraries covered in the other two implementations of the
+accumulator.
 
-As before, we begin by declaring the storage value. This time around it is just a simple u32. But the default value, `1 << 16` looks quite funny. If you haven't encountered it before `<<` is Rust's [bit shift operator](https://doc.rust-lang.org/reference/expressions/operator-expr.html#arithmetic-and-logical-binary-operators). It takes a value and moves all the bits to the left. In this case we start with the value `1` and move it 16 bits to the left. This is because Rust interprets `1` as a regular `u32` value and puts the `1` in the far right place value. But because we're treating this `u32` specially, we need to shift that bit to the middle just left of the imaginary radix point.
+As before, we begin by declaring the storage value. This time around it is just a simple u32. But
+the default value, `1 << 16` looks quite funny. If you haven't encountered it before `<<` is Rust's
+[bit shift operator](https://doc.rust-lang.org/reference/expressions/operator-expr.html#arithmetic-and-logical-binary-operators).
+It takes a value and moves all the bits to the left. In this case we start with the value `1` and
+move it 16 bits to the left. This is because Rust interprets `1` as a regular `u32` value and puts
+the `1` in the far right place value. But because we're treating this `u32` specially, we need to
+shift that bit to the middle just left of the imaginary radix point.
 
 ```rust, ignore
 decl_storage! {
@@ -134,7 +206,11 @@ decl_storage! {
 }
 ```
 
-The extrinsic to multiply a new factor into the accumulator follows the same general flow as in the other two implementations. In this case, there are more intermediate values calculated, and more comments explaining the bit-shifting operations. In the function body most intermediate values are held in `u64` variables. This is because when you multiply two 32-bit numbers, you can end up with as much as 64 bits in the product.
+The extrinsic to multiply a new factor into the accumulator follows the same general flow as in the
+other two implementations. In this case, there are more intermediate values calculated, and more
+comments explaining the bit-shifting operations. In the function body most intermediate values are
+held in `u64` variables. This is because when you multiply two 32-bit numbers, you can end up with
+as much as 64 bits in the product.
 
 ```rust, ignore
 fn update_manual(origin, new_factor: u32) -> DispatchResult {
@@ -168,22 +244,43 @@ fn update_manual(origin, new_factor: u32) -> DispatchResult {
 }
 ```
 
-As mentioned above, when you multiply two 32-bit numbers, you can end up with as much as 64 bits in the product. In this 64-bit intermediate product, we have 32 integer bits and 32 fractional. We can simply throw away the 16 right-most fractional bits that merely provide extra precision. But we need to be careful with the 16 left-most integer bits. If any of those bits are non-zero after the multiplication it means overflow has occurred. If they are all zero, then we can safely throw them away as well.
+As mentioned above, when you multiply two 32-bit numbers, you can end up with as much as 64 bits in
+the product. In this 64-bit intermediate product, we have 32 integer bits and 32 fractional. We can
+simply throw away the 16 right-most fractional bits that merely provide extra precision. But we need
+to be careful with the 16 left-most integer bits. If any of those bits are non-zero after the
+multiplication it means overflow has occurred. If they are all zero, then we can safely throw them
+away as well.
 
-> If this business about having more bits after the multiplication is confusing, try this exercise in the more familiar decimal system. Consider these numbers that have 4 total digits (2 integer, and two fractional): 12.34 and 56.78. Multiply them together. How many integer and fractional digits are in the product? Try that again with larger numbers like 01.23 * 02.48 and smaller like 11.11 and 22.22. Which of these products can be fit back into a 4-digit number like the ones we started with?
+> If this business about having more bits after the multiplication is confusing, try this exercise
+> in the more familiar decimal system. Consider these numbers that have 4 total digits (2 integer,
+> and two fractional): 12.34 and 56.78. Multiply them together. How many integer and fractional
+> digits are in the product? Try that again with larger numbers like 01.23 \* 02.48 and smaller like
+> 11.11 and 22.22. Which of these products can be fit back into a 4-digit number like the ones we
+> started with?
 
 ## Compounding Interest
-*[`pallets/compounding-interest`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/compounding-interest)*
 
-Many financial agreements involve interest for loaned or borrowed money. [Compounding interest](https://en.wikipedia.org/wiki/Compound_interest) is when new interest is paid on top of not only the original loan amount, the so-called "principal", but also any interest that has been previously paid.
+_[`pallets/compounding-interest`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/compounding-interest)_
+
+Many financial agreements involve interest for loaned or borrowed money.
+[Compounding interest](https://en.wikipedia.org/wiki/Compound_interest) is when new interest is paid
+on top of not only the original loan amount, the so-called "principal", but also any interest that
+has been previously paid.
 
 ### Discrete Compounding
 
-Our first example will look at discrete compounding interest. This is when interest is paid at a fixed interval. In our case, interest will be paid every ten blocks.
+Our first example will look at discrete compounding interest. This is when interest is paid at a
+fixed interval. In our case, interest will be paid every ten blocks.
 
-For this implementation we've chosen to use Substrate's [`Percent` type](https://crates.parity.io/sp_arithmetic/struct.Percent.html). It works nearly the same as `Permill`, but it represents numbers as "parts per hundred" rather than "parts per million". We could also have used Substrate-fixed for this implementation, but chose to save it for the next example.
+For this implementation we've chosen to use Substrate's
+[`Percent` type](https://crates.parity.io/sp_arithmetic/struct.Percent.html). It works nearly the
+same as `Permill`, but it represents numbers as "parts per hundred" rather than "parts per million".
+We could also have used Substrate-fixed for this implementation, but chose to save it for the next
+example.
 
-The only storage item needed is a tracker of the account's balance. In order to focus on the fixed-point- and interest-related topics, this pallet does not actually interface with a `Currency`. Instead we just allow anyone to "deposit" or "withdraw" funds with no source or destination.
+The only storage item needed is a tracker of the account's balance. In order to focus on the
+fixed-point- and interest-related topics, this pallet does not actually interface with a `Currency`.
+Instead we just allow anyone to "deposit" or "withdraw" funds with no source or destination.
 
 ```rust, ignore
 decl_storage! {
@@ -196,7 +293,9 @@ decl_storage! {
 }
 ```
 
-There are two extrinsics associated with the discrete interest account. The `deposit_discrete` extrinsic is shown here, and the `withdraw_discrete` extrinsic is nearly identical. Check it out in the kitchen.
+There are two extrinsics associated with the discrete interest account. The `deposit_discrete`
+extrinsic is shown here, and the `withdraw_discrete` extrinsic is nearly identical. Check it out in
+the kitchen.
 
 ```rust, ignore
 fn deposit_discrete(origin, val_to_add: u64) -> DispatchResult {
@@ -213,9 +312,11 @@ fn deposit_discrete(origin, val_to_add: u64) -> DispatchResult {
 }
 ```
 
-The flow of these deposit and withdraw extrinsics is entirely straight-forward. They each perform a simple addition or substraction from the stored value, and they have nothing to do with interest.
+The flow of these deposit and withdraw extrinsics is entirely straight-forward. They each perform a
+simple addition or substraction from the stored value, and they have nothing to do with interest.
 
-Because the interest is paid discretely every ten blocks it can be handled independently of deposits and withdrawals. The interest calculation happens automatically in the `on_finalize` block.
+Because the interest is paid discretely every ten blocks it can be handled independently of deposits
+and withdrawals. The interest calculation happens automatically in the `on_finalize` block.
 
 ```rust, ignore
 fn on_finalize(n: T::BlockNumber) {
@@ -241,16 +342,30 @@ fn on_finalize(n: T::BlockNumber) {
 }
 ```
 
-`on_finalize` is called at the end of every block, but we only want to pay interest every ten blocks, so the first thing we do is check whether this block is a multiple of ten. If it is we calculate the interest due by the formula `interest = principal * rate * time`. As the comments explain, there is some subtlety in the order of the multiplication. You can multiply `PerCent * u64` but not `u64 * PerCent`.
-
+`on_finalize` is called at the end of every block, but we only want to pay interest every ten
+blocks, so the first thing we do is check whether this block is a multiple of ten. If it is we
+calculate the interest due by the formula `interest = principal * rate * time`. As the comments
+explain, there is some subtlety in the order of the multiplication. You can multiply `PerCent * u64`
+but not `u64 * PerCent`.
 
 ### Continuously Compounding
 
-You can imagine increasing the frequency at which the interest is paid out. Increasing the frequency enough approaches [continuously compounding interest](https://en.wikipedia.org/wiki/Compound_interest#Continuous_compounding). Calculating continuously compounding interest requires the [exponential function](https://en.wikipedia.org/wiki/Exponential_function) which is not available using Substrate's `PerThing` types. Luckily exponential and other [transcendental functions](https://en.wikipedia.org/wiki/Transcendental_function) are available in substrate-fixed, which is why we've chosen to use it for this example.
+You can imagine increasing the frequency at which the interest is paid out. Increasing the frequency
+enough approaches
+[continuously compounding interest](https://en.wikipedia.org/wiki/Compound_interest#Continuous_compounding).
+Calculating continuously compounding interest requires the
+[exponential function](https://en.wikipedia.org/wiki/Exponential_function) which is not available
+using Substrate's `PerThing` types. Luckily exponential and other
+[transcendental functions](https://en.wikipedia.org/wiki/Transcendental_function) are available in
+substrate-fixed, which is why we've chosen to use it for this example.
 
-With continuously compounded interest, we _could_ update the interest in `on_finalize` as we did before, but it would need to be updated every single block. Instead we wait until a user tries to use the account (to deposit or withdraw funds), and then calculate the account's current value "just in time".
+With continuously compounded interest, we _could_ update the interest in `on_finalize` as we did
+before, but it would need to be updated every single block. Instead we wait until a user tries to
+use the account (to deposit or withdraw funds), and then calculate the account's current value "just
+in time".
 
-To facilitate this implementation, we represent the state of the account not only as a balance, but as a balance, paired with the time when that balance was last updated.
+To facilitate this implementation, we represent the state of the account not only as a balance, but
+as a balance, paired with the time when that balance was last updated.
 
 ```rust, ignore
 #[derive(Encode, Decode, Default)]
@@ -262,7 +377,9 @@ pub struct ContinuousAccountData<BlockNumber> {
 }
 ```
 
-You can see we've chosen substrate-fixed's `I32F32` as our balance type this time. While we don't intend to handle negative balances, there is currently a limitation in the transcendental functions that requires using signed types.
+You can see we've chosen substrate-fixed's `I32F32` as our balance type this time. While we don't
+intend to handle negative balances, there is currently a limitation in the transcendental functions
+that requires using signed types.
 
 With the struct to represent the account's state defined, we can initialize the storage value.
 
@@ -277,7 +394,8 @@ decl_storage! {
 }
 ```
 
-As before, there are two relevant extrinsics, `deposit_continuous` and `withdraw_continuous`. They are nearly identical so we'll only show one.
+As before, there are two relevant extrinsics, `deposit_continuous` and `withdraw_continuous`. They
+are nearly identical so we'll only show one.
 
 ```rust, ignore
 fn deposit_continuous(origin, val_to_add: u64) -> DispatchResult {
@@ -300,7 +418,11 @@ fn deposit_continuous(origin, val_to_add: u64) -> DispatchResult {
 }
 ```
 
-This function itself isn't too insightful. It does the same basic things as the discrete variant: look up the old value and the deposit, update storage, and emit an event. The one interesting part is that it calls a helper function to get the account's previous value. This helper function calculates the value of the account considering all the interest that has accrued since the last time the account was touched. Let's take a closer look.
+This function itself isn't too insightful. It does the same basic things as the discrete variant:
+look up the old value and the deposit, update storage, and emit an event. The one interesting part
+is that it calls a helper function to get the account's previous value. This helper function
+calculates the value of the account considering all the interest that has accrued since the last
+time the account was touched. Let's take a closer look.
 
 ```rust, ignore
 fn value_of_continuous_account(now: &<T as system::Trait>::BlockNumber) -> I32F32 {
@@ -324,6 +446,13 @@ fn value_of_continuous_account(now: &<T as system::Trait>::BlockNumber) -> I32F3
 }
 ```
 
-This function gets the previous state of the account, makes the interest calculation and returns the result. The reality of making these fixed point calculations is that type conversion will likely be your biggest pain point. Most of the lines are doing type conversion between the `BlockNumber`, `u32`, and `I32F32` types.
+This function gets the previous state of the account, makes the interest calculation and returns the
+result. The reality of making these fixed point calculations is that type conversion will likely be
+your biggest pain point. Most of the lines are doing type conversion between the `BlockNumber`,
+`u32`, and `I32F32` types.
 
-We've already seen that this helper function is used within the runtime for calculating the current balance "just in time" to make adjustments. In a real-world scenario, chain users would also want to check their balance at any given time. Because the current balance is not stored in runtime storage, it would be wise to [implement a runtime API](./runtime-api.md) so this helper can be called from outside the runtime.
+We've already seen that this helper function is used within the runtime for calculating the current
+balance "just in time" to make adjustments. In a real-world scenario, chain users would also want to
+check their balance at any given time. Because the current balance is not stored in runtime storage,
+it would be wise to [implement a runtime API](./runtime-api.md) so this helper can be called from
+outside the runtime.

--- a/text/3-entrees/hybrid-consensus.md
+++ b/text/3-entrees/hybrid-consensus.md
@@ -1,13 +1,28 @@
 #Hybrid Consensus
-*[`nodes/hybrid-consensus`](https://github.com/substrate-developer-hub/recipes/tree/master/nodes/hybrid-consensus)*
+_[`nodes/hybrid-consensus`](https://github.com/substrate-developer-hub/recipes/tree/master/nodes/hybrid-consensus)_
 
-This recipe demonstrates a Substrate-based node that employs hybrid consensus. Specifically, it uses [Sha3 Proof of Work](./sha3-pow-consensus.md) to dictate block authoring, and the [Grandpa](https://crates.parity.io/sc_finality_grandpa/index.html) finality gadget to provide [deterministic finality](https://www.substrate.io/kb/advanced/consensus#finality). The minimal proof of work consensus lives entirely outside of the runtime while the grandpa finality obtains its authorities from the runtime via the [GrandpaAPI](https://crates.parity.io/sp_finality_grandpa/trait.GrandpaApi.html)
+This recipe demonstrates a Substrate-based node that employs hybrid consensus. Specifically, it uses
+[Sha3 Proof of Work](./sha3-pow-consensus.md) to dictate block authoring, and the
+[Grandpa](https://crates.parity.io/sc_finality_grandpa/index.html) finality gadget to provide
+[deterministic finality](https://www.substrate.io/kb/advanced/consensus#finality). The minimal proof
+of work consensus lives entirely outside of the runtime while the grandpa finality obtains its
+authorities from the runtime via the
+[GrandpaAPI](https://crates.parity.io/sp_finality_grandpa/trait.GrandpaApi.html)
 
 ## The Block Import Pipeline
 
-Substrate's block import pipeline is structured like an onion in the sense that it is layered. A Substrate node can compose pieces of block import logic by wrapping block imports in other block imports. In this node we need to ensure that blocks are valid according to both Pow _and_ grandpa. So we will construct a block import for each of them and wrap one with the other. The end of the block import pipeline is always the client, which contains the underlying datbase of imported blocks.
+Substrate's block import pipeline is structured like an onion in the sense that it is layered. A
+Substrate node can compose pieces of block import logic by wrapping block imports in other block
+imports. In this node we need to ensure that blocks are valid according to both Pow _and_ grandpa.
+So we will construct a block import for each of them and wrap one with the other. The end of the
+block import pipeline is always the client, which contains the underlying datbase of imported
+blocks.
 
-We begin by creating the block import for grandpa. In addition to the block import itself, we get back a `grandpa_link`. This link is a channel over which the block import can communicate with the background task that actually casts grandpa votes. The [details of the grandpa protocol](https://research.web3.foundation/en/latest/polkadot/GRANDPA.html) are beyond the scope of this recipe.
+We begin by creating the block import for grandpa. In addition to the block import itself, we get
+back a `grandpa_link`. This link is a channel over which the block import can communicate with the
+background task that actually casts grandpa votes. The
+[details of the grandpa protocol](https://research.web3.foundation/en/latest/polkadot/GRANDPA.html)
+are beyond the scope of this recipe.
 
 ```rust, ignore
 let (grandpa_block_import, grandpa_link) =
@@ -16,12 +31,15 @@ let (grandpa_block_import, grandpa_link) =
 	)?;
 ```
 
-This same block import will be used as a justification import, so we clone it right after constructing it.
+This same block import will be used as a justification import, so we clone it right after
+constructing it.
+
 ```rust, ignore
 let justification_import = grandpa_block_import.clone();
 ```
 
-With the grandpa block import created, we can now create the PoW block import. The Pow block import is the outer-most layer of the block import onion and it wraps the grandpa block import.
+With the grandpa block import created, we can now create the PoW block import. The Pow block import
+is the outer-most layer of the block import onion and it wraps the grandpa block import.
 
 ```rust, ignore
 let pow_block_import = sc_consensus_pow::PowBlockImport::new(
@@ -36,7 +54,9 @@ let pow_block_import = sc_consensus_pow::PowBlockImport::new(
 
 ## The Import Queue
 
-With the block imports setup, we can proceed to creating the import queue. We make it using PoW's `import_queue` helper function. Notice that it requires the entire block import pipeline which we refer to as `pow_block_import` because PoW is the outermost layer.
+With the block imports setup, we can proceed to creating the import queue. We make it using PoW's
+`import_queue` helper function. Notice that it requires the entire block import pipeline which we
+refer to as `pow_block_import` because PoW is the outermost layer.
 
 ```rust, ignore
 let import_queue = sc_consensus_pow::import_queue(
@@ -51,7 +71,9 @@ let import_queue = sc_consensus_pow::import_queue(
 
 ## The Finality Proof Provider
 
-Occasionally in the operation of a blockchain, other nodes will contact our node asking for proof that a particular block is finalized. To respond to these requests, we include a finality proof provider.
+Occasionally in the operation of a blockchain, other nodes will contact our node asking for proof
+that a particular block is finalized. To respond to these requests, we include a finality proof
+provider.
 
 ```rust, ignore
 .with_finality_proof_provider(|client, backend| {
@@ -62,7 +84,8 @@ Occasionally in the operation of a blockchain, other nodes will contact our node
 
 ## Spawning the PoW Authorship Task
 
-Any node that is acting as an authority, typically called "miners" in the PoW context, must run a mining task in another thread.
+Any node that is acting as an authority, typically called "miners" in the PoW context, must run a
+mining task in another thread.
 
 ```rust, ignore
 sc_consensus_pow::start_mine(
@@ -80,11 +103,16 @@ sc_consensus_pow::start_mine(
 );
 ```
 
-The use of a separate thread for block authorship is unlike other Substrate-based authorship tasks which are typically run as `async` futures. Because mining is a CPU intensive process, it is necessary to provide a separate thread or else the mining task would run continually and other tasks such as transaction processing, gossiping, and peer discovery would be starved for CPU.
+The use of a separate thread for block authorship is unlike other Substrate-based authorship tasks
+which are typically run as `async` futures. Because mining is a CPU intensive process, it is
+necessary to provide a separate thread or else the mining task would run continually and other tasks
+such as transaction processing, gossiping, and peer discovery would be starved for CPU.
 
 ## Spawning the Grandpa Task
 
-Grandpa is _not_ CPU intensive, so we will use a standard `async` worker to listen to and cast grandpa votes. We begin by creating a grandpa [`Config`](https://crates.parity.io/sc_finality_grandpa/struct.Config.html).
+Grandpa is _not_ CPU intensive, so we will use a standard `async` worker to listen to and cast
+grandpa votes. We begin by creating a grandpa
+[`Config`](https://crates.parity.io/sc_finality_grandpa/struct.Config.html).
 
 ```rust, ignore
 let grandpa_config = sc_finality_grandpa::Config {
@@ -97,7 +125,8 @@ let grandpa_config = sc_finality_grandpa::Config {
 };
 ```
 
-We can then use this config to create an instance of [`GrandpaParams`](https://crates.parity.io/sc_finality_grandpa/struct.GrandpaParams.html).
+We can then use this config to create an instance of
+[`GrandpaParams`](https://crates.parity.io/sc_finality_grandpa/struct.GrandpaParams.html).
 
 ```rust, ignore
 let grandpa_config = sc_finality_grandpa::GrandpaParams {
@@ -122,7 +151,9 @@ service.spawn_essential_task(
 
 ### Disabled Grandpa
 
-Proof of Authority networks generally contain many full nodes that are not authorities. When Grandpa is present in the network, we still need to tell the node how to interpret grandpa-related messages it may receive (just ignore them).
+Proof of Authority networks generally contain many full nodes that are not authorities. When Grandpa
+is present in the network, we still need to tell the node how to interpret grandpa-related messages
+it may receive (just ignore them).
 
 ```rust, ignore
 sc_finality_grandpa::setup_disabled_grandpa(
@@ -136,6 +167,11 @@ sc_finality_grandpa::setup_disabled_grandpa(
 
 ### Runtime APIs
 
-Grandpa relies on getting its authority sets from the runtime via the [GrandpaAPI](https://crates.parity.io/sp_finality_grandpa/trait.GrandpaApi.html). So trying to build this node with a runtime that does not provide this API will fail to compile. For that reason, we have included the dedicated `minimal-grandpa-runtime`.
+Grandpa relies on getting its authority sets from the runtime via the
+[GrandpaAPI](https://crates.parity.io/sp_finality_grandpa/trait.GrandpaApi.html). So trying to build
+this node with a runtime that does not provide this API will fail to compile. For that reason, we
+have included the dedicated `minimal-grandpa-runtime`.
 
-The opposite is not true, however. A node that does _not_ require grandpa may use the `minimal-grandpa-runtime` successfully. The unused `GrandpaAPI` will remain as a harmless vestige in the runtime.
+The opposite is not true, however. A node that does _not_ require grandpa may use the
+`minimal-grandpa-runtime` successfully. The unused `GrandpaAPI` will remain as a harmless vestige in
+the runtime.

--- a/text/3-entrees/index.md
+++ b/text/3-entrees/index.md
@@ -1,3 +1,5 @@
 # Entrees
 
-These Entrees are for chefs who have the basics down. If you've read through the first two chapters of this cookbook, that includes you! The entrees cover a wide variety of topics in Substrate development, and are meant to be read in _any order_.
+These Entrees are for chefs who have the basics down. If you've read through the first two chapters
+of this cookbook, that includes you! The entrees cover a wide variety of topics in Substrate
+development, and are meant to be read in _any order_.

--- a/text/3-entrees/kitchen-node.md
+++ b/text/3-entrees/kitchen-node.md
@@ -1,15 +1,22 @@
 # Manual Seal
-*[`nodes/kitchen-node`](https://github.com/substrate-developer-hub/recipes/tree/master/nodes/kitchen-node)*
 
-This recipe demonstrates a general purpose Substrate node that supports most of the recipes' runtimes, and uses [Instant Seal consensus](https://crates.parity.io/sc_consensus_manual_seal/index.html).
+_[`nodes/kitchen-node`](https://github.com/substrate-developer-hub/recipes/tree/master/nodes/kitchen-node)_
 
-The kitchen node serves as the first point of entry for most aspiring chefs when they first encounter the recipes. By default it builds with the super-runtime, but it can be used with most of the runtimes in the recipes. Changing the runtime is described below. It features the instant seal consensus which is perfect for testing and iterating on a runtime.
+This recipe demonstrates a general purpose Substrate node that supports most of the recipes'
+runtimes, and uses
+[Instant Seal consensus](https://crates.parity.io/sc_consensus_manual_seal/index.html).
+
+The kitchen node serves as the first point of entry for most aspiring chefs when they first
+encounter the recipes. By default it builds with the super-runtime, but it can be used with most of
+the runtimes in the recipes. Changing the runtime is described below. It features the instant seal
+consensus which is perfect for testing and iterating on a runtime.
 
 ## Installing a Runtime
 
 ### Cargo Dependency
 
-The `Cargo.toml` file specifies the runtime as a dependency. The file imports the super-runtime, and has dependencies on other runtimes commented out.
+The `Cargo.toml` file specifies the runtime as a dependency. The file imports the super-runtime, and
+has dependencies on other runtimes commented out.
 
 ```toml
 # Common runtime configured with most Recipes pallets.
@@ -27,15 +34,27 @@ runtime = { package = "super-runtime", path = "../../runtimes/super-runtime" }
 #runtime = { package = "api-runtime", path = "../../runtimes/api-runtime" }
 ```
 
-Installing a different runtime in the node is just a matter of commenting out the super-runtime line, and enabling another one. Try the weight-fee runtime for example. Of course cargo will complain if you try to import two crates under the name `runtime`.
+Installing a different runtime in the node is just a matter of commenting out the super-runtime
+line, and enabling another one. Try the weight-fee runtime for example. Of course cargo will
+complain if you try to import two crates under the name `runtime`.
 
-It is worth noting that this node does not work with _all_ of the recipes' runtimes. In particular, it is not compatible with the babe-grandpa runtime. That runtime uses the babe pallet which requires a node that will include a special [`PreRuntime` `DigestItem`](https://crates.parity.io/sp_runtime/enum.DigestItem.html#variant.PreRuntime).
+It is worth noting that this node does not work with _all_ of the recipes' runtimes. In particular,
+it is not compatible with the babe-grandpa runtime. That runtime uses the babe pallet which requires
+a node that will include a special
+[`PreRuntime` `DigestItem`](https://crates.parity.io/sp_runtime/enum.DigestItem.html#variant.PreRuntime).
 
 ### Building a Service with the Runtime
 
-With a runtime of our choosing listed among our dependencies, we can provide the runtime to the [`ServiceBuilder`](https://crates.parity.io/sc_service/struct.ServiceBuilder.html). The `ServiceBuilder` is responsible for assembling all of the necessary pieces that a node will need, and creating a [`Substrate Service`](https://crates.parity.io/sc_service/struct.Service.html) which will manage the communication between them.
+With a runtime of our choosing listed among our dependencies, we can provide the runtime to the
+[`ServiceBuilder`](https://crates.parity.io/sc_service/struct.ServiceBuilder.html). The
+`ServiceBuilder` is responsible for assembling all of the necessary pieces that a node will need,
+and creating a [`Substrate Service`](https://crates.parity.io/sc_service/struct.Service.html) which
+will manage the communication between them.
 
-We begin by invoking the [`native_executor_instance!` macro](https://crates.parity.io/sc_executor/macro.native_executor_instance.html). This creates an executor which is responsible for executing transactions in  the runtime and determining whether to run the native of wasm version of the runtime.
+We begin by invoking the
+[`native_executor_instance!` macro](https://crates.parity.io/sc_executor/macro.native_executor_instance.html).
+This creates an executor which is responsible for executing transactions in the runtime and
+determining whether to run the native of wasm version of the runtime.
 
 ```rust_ignore
 native_executor_instance!(
@@ -45,7 +64,8 @@ native_executor_instance!(
 );
 ```
 
-Finally, we create a new `ServiceBuilder` for a full node. (The `$` in the syntax is because we are in a [macro definition](https://doc.rust-lang.org/book/ch19-06-macros.html).
+Finally, we create a new `ServiceBuilder` for a full node. (The `$` in the syntax is because we are
+in a [macro definition](https://doc.rust-lang.org/book/ch19-06-macros.html).
 
 ```rust, ignore
 let builder = sc_service::ServiceBuilder::new_full::<
@@ -56,7 +76,14 @@ let builder = sc_service::ServiceBuilder::new_full::<
 
 ## Instant Seal Consensus
 
-The instant seal consensus engine, and its cousin the manual seal consensus engine, are both included in the same [`sc-consensus-manual-seal` crate](https://crates.parity.io/sc_consensus_manual_seal/index.html). The recipes has a recipe dedicated to using [manual seal](./manual-seal.md). Instant seal is a very convenient tool for when you are developing or experimenting with a runtime. The consensus engine simply authors a new block whenever a new transaction is available in the queue. This is similar to [Truffle Suite's Ganache](https://www.trufflesuite.com/ganache) in the Ethereum ecosystem, but without the UI.
+The instant seal consensus engine, and its cousin the manual seal consensus engine, are both
+included in the same
+[`sc-consensus-manual-seal` crate](https://crates.parity.io/sc_consensus_manual_seal/index.html).
+The recipes has a recipe dedicated to using [manual seal](./manual-seal.md). Instant seal is a very
+convenient tool for when you are developing or experimenting with a runtime. The consensus engine
+simply authors a new block whenever a new transaction is available in the queue. This is similar to
+[Truffle Suite's Ganache](https://www.trufflesuite.com/ganache) in the Ethereum ecosystem, but
+without the UI.
 
 ### The Cargo Dependencies
 
@@ -67,11 +94,14 @@ sp-consensus = '0.8.0-alpha.7'
 sc-consensus-manual-seal = '0.8.0-alpha.7'
 ```
 
-The dependency on `sc-client-db` will become unnecessary once [issue #238](https://github.com/substrate-developer-hub/recipes/pull/238) is merged.
+The dependency on `sc-client-db` will become unnecessary once
+[issue #238](https://github.com/substrate-developer-hub/recipes/pull/238) is merged.
 
 ### The Proposer
 
-We begin by creating a [`Proposer`](https://crates.parity.io/sc_basic_authorship/struct.Proposer.html) which will be responsible for creating proposing blocks in the chain.
+We begin by creating a
+[`Proposer`](https://crates.parity.io/sc_basic_authorship/struct.Proposer.html) which will be
+responsible for creating proposing blocks in the chain.
 
 ```rust, ignore
 let proposer = sc_basic_authorship::ProposerFactory::new(
@@ -82,7 +112,9 @@ let proposer = sc_basic_authorship::ProposerFactory::new(
 
 ### The Import Queue
 
-Next we make a manual-seal import queue. This process is identical to creating the import queue used in the [Manual Seal Node](./manual-seal.md). It is also similar to, but simpler than, the [basic-pow](./basic-pow.md) import queue.
+Next we make a manual-seal import queue. This process is identical to creating the import queue used
+in the [Manual Seal Node](./manual-seal.md). It is also similar to, but simpler than, the
+[basic-pow](./basic-pow.md) import queue.
 
 ```rust, ignore
 .with_import_queue(|_config, client, _select_chain, _transaction_pool| {
@@ -105,7 +137,8 @@ let authorship_future = sc_consensus_manual_seal::run_instant_seal(
 );
 ```
 
-With the future created, we can now kick it off using the service's [`spawn_essential_task` method](https://crates.parity.io/sc_service/struct.Service.html#method.spawn_essential_task).
+With the future created, we can now kick it off using the service's
+[`spawn_essential_task` method](https://crates.parity.io/sc_service/struct.Service.html#method.spawn_essential_task).
 
 ```rust, ignore
 service.spawn_essential_task("instant-seal", authorship_future);
@@ -113,7 +146,10 @@ service.spawn_essential_task("instant-seal", authorship_future);
 
 ### What about the Light Client?
 
-The light client is not yet supported in this node, but it likely will be in the future (See [issue #238](https://github.com/substrate-developer-hub/recipes/pull/238).) Because it will typically be used for learning, experimenting, and testing in a single-node environment this restriction should not cause many problems.. Instead we mark it as `unimplemented!`.
+The light client is not yet supported in this node, but it likely will be in the future (See
+[issue #238](https://github.com/substrate-developer-hub/recipes/pull/238).) Because it will
+typically be used for learning, experimenting, and testing in a single-node environment this
+restriction should not cause many problems.. Instead we mark it as `unimplemented!`.
 
 ```rust, ignore
 /// Builds a new service for a light client.

--- a/text/3-entrees/manual-seal.md
+++ b/text/3-entrees/manual-seal.md
@@ -1,11 +1,16 @@
 # Manual Seal
-*[`nodes/manual-seal`](https://github.com/substrate-developer-hub/recipes/tree/master/nodes/manual-seal)*
 
-This recipe demonstrates a Substrate node using the [Manual Seal consensus](https://crates.parity.io/sc_consensus_manual_seal/index.html). Unlike the other consensus engines included with Substrate, manual seal does not create blocks on a regular basis. Rather, it waits for an RPC call telling to create a block.
+_[`nodes/manual-seal`](https://github.com/substrate-developer-hub/recipes/tree/master/nodes/manual-seal)_
+
+This recipe demonstrates a Substrate node using the
+[Manual Seal consensus](https://crates.parity.io/sc_consensus_manual_seal/index.html). Unlike the
+other consensus engines included with Substrate, manual seal does not create blocks on a regular
+basis. Rather, it waits for an RPC call telling to create a block.
 
 ## Using Manual Seal
 
-Before we explore the code, let's begin by seeing how to use the manual-seal node. Build and start the node in the usual way.
+Before we explore the code, let's begin by seeing how to use the manual-seal node. Build and start
+the node in the usual way.
 
 ```bash
 cargo build --release -p manual-seal
@@ -13,7 +18,11 @@ cargo build --release -p manual-seal
 ```
 
 ## Manually Sealing Blocks
-Once your node is running, you will see that it just sits there idly. It will accept transactions to the pool, but it will not author blocks on its own. In manual seal, the node does not author a block until we explicitly tell it to. We can tell it to author a block by calling the `engine_createBlock` RPC.
+
+Once your node is running, you will see that it just sits there idly. It will accept transactions to
+the pool, but it will not author blocks on its own. In manual seal, the node does not author a block
+until we explicitly tell it to. We can tell it to author a block by calling the `engine_createBlock`
+RPC.
 
 ```bash
 $ curl http://localhost:9933 -H "Content-Type:application/json;charset=utf-8" -d   '{
@@ -27,16 +36,31 @@ $ curl http://localhost:9933 -H "Content-Type:application/json;charset=utf-8" -d
 This call takes three parameters, each of which are worth exploring.
 
 ### Create Empty
-`create_empty` is a Boolean value indicating whether empty blocks may be created. Setting `create-empty` to true does not mean that an empty block will necessarily be created. Rather it means that the engine should go ahead creating a block even if no transaction are present. If transactions are present in the queue, they will be included regardless of `create_empty`'s value.'
+
+`create_empty` is a Boolean value indicating whether empty blocks may be created. Setting
+`create-empty` to true does not mean that an empty block will necessarily be created. Rather it
+means that the engine should go ahead creating a block even if no transaction are present. If
+transactions are present in the queue, they will be included regardless of `create_empty`'s value.'
 
 ### Finalize
-`finalize` is a Boolean indicating whether the block (and its ancestors, recursively) should be finalized after creation. Manually controlling finality is interesting, but also dangerous. If you attempt to author and finalize a block that does not build on the best finalized chain, the block will not be imported. If you finalize one block in one node, and a conflicting block in another node, you will cause a safety violation when the nodes synchronize.
+
+`finalize` is a Boolean indicating whether the block (and its ancestors, recursively) should be
+finalized after creation. Manually controlling finality is interesting, but also dangerous. If you
+attempt to author and finalize a block that does not build on the best finalized chain, the block
+will not be imported. If you finalize one block in one node, and a conflicting block in another
+node, you will cause a safety violation when the nodes synchronize.
 
 ### Parent Hash
-`parent_hash` is an optional hash of a block to use as a parent. To set the parent, use the format `"0x0e0626477621754200486f323e3858cd5f28fcbe52c69b2581aecb622e384764"`. To omit the parent, use `null`. When the parent is omitted the block is built on the current best block. Manually specifying the parent is useful for constructing fork scenarios and demonstrating chain reorganizations.
+
+`parent_hash` is an optional hash of a block to use as a parent. To set the parent, use the format
+`"0x0e0626477621754200486f323e3858cd5f28fcbe52c69b2581aecb622e384764"`. To omit the parent, use
+`null`. When the parent is omitted the block is built on the current best block. Manually specifying
+the parent is useful for constructing fork scenarios and demonstrating chain reorganizations.
 
 ## Manually Finalizing Blocks
-In addition to finalizing blocks while creating them, they can be finalized later by using the second provided RPC call, `engine_finalizeBlock`.
+
+In addition to finalizing blocks while creating them, they can be finalized later by using the
+second provided RPC call, `engine_finalizeBlock`.
 
 ```bash
 $ curl http://localhost:9933 -H "Content-Type:application/json;charset=utf-8" -d   '{
@@ -48,16 +72,20 @@ $ curl http://localhost:9933 -H "Content-Type:application/json;charset=utf-8" -d
 ```
 
 The two parameters are:
-* The hash of the block to finalize.
-* A Justification. TODO what is the justification and why might I want to use it?
+
+-   The hash of the block to finalize.
+-   A Justification. TODO what is the justification and why might I want to use it?
 
 ## Building the Service
 
-So far we've learned how to use the manual seal node and why it might be useful. Let's now turn our attention to how the service is built in the nodes `src/service.rs` file.
+So far we've learned how to use the manual seal node and why it might be useful. Let's now turn our
+attention to how the service is built in the nodes `src/service.rs` file.
 
 ### The Import Queue
 
-We begin by creating a manual-seal import queue. This process is identical to creating the import queue used in the [Kitchen Node](./kitchen-node.md). It is also similar to, but simpler than, the [basic-pow](./basic-pow.md) import queue.
+We begin by creating a manual-seal import queue. This process is identical to creating the import
+queue used in the [Kitchen Node](./kitchen-node.md). It is also similar to, but simpler than, the
+[basic-pow](./basic-pow.md) import queue.
 
 ```rust, ignore
 .with_import_queue(|_config, client, _select_chain, _transaction_pool| {
@@ -67,7 +95,10 @@ We begin by creating a manual-seal import queue. This process is identical to cr
 
 ### What about the Light Client?
 
-The light client is not yet supported in this node, but it likely will be in the future (See [issue #238](https://github.com/substrate-developer-hub/recipes/pull/238).) Because it will typically be used for learning, experimenting, and testing in a single-node environment this restriction should not cause many problems.. Instead we mark it as `unimplemented!`.
+The light client is not yet supported in this node, but it likely will be in the future (See
+[issue #238](https://github.com/substrate-developer-hub/recipes/pull/238).) Because it will
+typically be used for learning, experimenting, and testing in a single-node environment this
+restriction should not cause many problems.. Instead we mark it as `unimplemented!`.
 
 ```rust, ignore
 /// Builds a new service for a light client.
@@ -81,19 +112,25 @@ pub fn new_light(_config: Configuration) -> Result<impl AbstractService, Service
 }
 ```
 
-Because the return type of this function contains `impl AbstractService`, Rust's typechecker is unable to infer the concrete type. We give it a hand by calling `new_full` at the end, but don't worry, this code will never actually be executed. `unimplemented!` will panic first.
-
+Because the return type of this function contains `impl AbstractService`, Rust's typechecker is
+unable to infer the concrete type. We give it a hand by calling `new_full` at the end, but don't
+worry, this code will never actually be executed. `unimplemented!` will panic first.
 
 ### The Manual Seal RPC
 
-Because the node runs in manual seal mode, we need to wire up the RPC commands that we explored earlier. This process is nearly identical to those described in the [custom rpc recipe](./custom-rpc.md).
+Because the node runs in manual seal mode, we need to wire up the RPC commands that we explored
+earlier. This process is nearly identical to those described in the
+[custom rpc recipe](./custom-rpc.md).
 
 As prep work, we make a type alias,
+
 ```rust, ignore
 type RpcExtension = jsonrpc_core::IoHandler<sc_rpc::Metadata>;
 ```
 
-Next we create a channel over which the rpc handler and the authorship task can communicate with one another. The RPC handler will send messages asking to create or finalize a block and the import queue will receive the message and do so.
+Next we create a channel over which the rpc handler and the authorship task can communicate with one
+another. The RPC handler will send messages asking to create or finalize a block and the import
+queue will receive the message and do so.
 
 ```rust, ignore
 // channel for the rpc handler to communicate with the authorship task.
@@ -117,7 +154,8 @@ let service = builder
 
 ### The Authorship Task
 
-As with every authoring engine, manual seal needs to be run as an `async` authoring tasks. Here we provide the receiving end of the channel we created earlier.
+As with every authoring engine, manual seal needs to be run as an `async` authoring tasks. Here we
+provide the receiving end of the channel we created earlier.
 
 ```rust, ignore
 // Background authorship future.
@@ -132,7 +170,8 @@ let authorship_future = manual_seal::run_manual_seal(
 	);
 ```
 
-With the future created, we can now kick it off using the service's [`spawn_essential_task` method](https://crates.parity.io/sc_service/struct.Service.html#method.spawn_essential_task).
+With the future created, we can now kick it off using the service's
+[`spawn_essential_task` method](https://crates.parity.io/sc_service/struct.Service.html#method.spawn_essential_task).
 
 ```rust, ignore
 // we spawn the future on a background thread managed by service.

--- a/text/3-entrees/off-chain-workers/index.md
+++ b/text/3-entrees/off-chain-workers/index.md
@@ -1,13 +1,22 @@
 # Off-chain Workers
 
-> Before learning how to build your own off-chain worker, you may want to learn about what off-chain workers are, why you want to use them, and what kinds of problems they can solve best. These topics are covered in [our guide](https://substrate.dev/docs/en/conceptual/core/off-chain-workers). Here, we will focus on using off-chain workers in Substrate.
+> Before learning how to build your own off-chain worker, you may want to learn about what off-chain
+> workers are, why you want to use them, and what kinds of problems they can solve best. These
+> topics are covered in
+> [our guide](https://substrate.dev/docs/en/conceptual/core/off-chain-workers). Here, we will focus
+> on using off-chain workers in Substrate.
 
-Off-chain workers contain a set of powerful tools allowing your Substrate node to offload tasks that take too long or too much CPU / memory resources to compute, or have non-deterministic result. In particular we have a set of helpers allowing fetching of HTTP requests and using a community-contributed tool for parsing the returned JSON. It also provides its own storage that is unique to the particular off-chain worker node and not synchronized across the network.
+Off-chain workers contain a set of powerful tools allowing your Substrate node to offload tasks that
+take too long or too much CPU / memory resources to compute, or have non-deterministic result. In
+particular we have a set of helpers allowing fetching of HTTP requests and using a
+community-contributed tool for parsing the returned JSON. It also provides its own storage that is
+unique to the particular off-chain worker node and not synchronized across the network.
 
-Once the off-chain computation is completed, off-chain workers can submit either signed or unsigned transactions back on-chain.
+Once the off-chain computation is completed, off-chain workers can submit either signed or unsigned
+transactions back on-chain.
 
 We will deep-dive into each of the topics below.
 
-- [Signed and Unsigned Transactions](./transactions.md)
-- [HTTP fetching and JSON parsing](./http-json.md)
-- [Local storage in Off-chain Workers](./storage.md)
+-   [Signed and Unsigned Transactions](./transactions.md)
+-   [HTTP fetching and JSON parsing](./http-json.md)
+-   [Local storage in Off-chain Workers](./storage.md)

--- a/text/3-entrees/off-chain-workers/storage.md
+++ b/text/3-entrees/off-chain-workers/storage.md
@@ -1,18 +1,32 @@
 # Local Storage in Off-chain Workers
 
-*[`pallets/offchain-demo`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/offchain-demo)*
+_[`pallets/offchain-demo`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/offchain-demo)_
 
-Remember we mentioned that off-chain workers (short for **ocw** below) cannot write directly to the on-chain storage, that is why they have to submit transactions back on-chain to modify the state.
+Remember we mentioned that off-chain workers (short for **ocw** below) cannot write directly to the
+on-chain storage, that is why they have to submit transactions back on-chain to modify the state.
 
-Fortunately, there is also a local storage that persist across runs in off-chain workers. Storage is local within off-chain workers and not passed within network. Storage of off-chain workers is persisted across runs of off-chain workers and blockchain re-organizations.
+Fortunately, there is also a local storage that persist across runs in off-chain workers. Storage is
+local within off-chain workers and not passed within network. Storage of off-chain workers is
+persisted across runs of off-chain workers and blockchain re-organizations.
 
-Off-chain workers are asynchronously run during block import. Since ocws are not limited by how long they run, at any single instance there could be multiple ocws running, being initiated by previous block imports. See diagram below.
+Off-chain workers are asynchronously run during block import. Since ocws are not limited by how long
+they run, at any single instance there could be multiple ocws running, being initiated by previous
+block imports. See diagram below.
 
 ![More than one off-chain workers at a single instance](/img/multiple-ocws.png)
 
-The storage has a similar API usage as on-chain [`StorageValue`](/2-appetizers/2-storage-values.html) with `get`, `set`, and `mutate`. `mutate` is using a [`compare-and-set`](https://en.wikipedia.org/wiki/Compare-and-swap) pattern. It compares the contents of a memory location with a given value and, only if they are the same, modifies the contents of that memory location to a new given value. This is done as a single atomic operation. The atomicity guarantees that the new value is calculated based on up-to-date information; if the value had been updated by another thread in the meantime, the write would fail.
+The storage has a similar API usage as on-chain
+[`StorageValue`](/2-appetizers/2-storage-values.html) with `get`, `set`, and `mutate`. `mutate` is
+using a [`compare-and-set`](https://en.wikipedia.org/wiki/Compare-and-swap) pattern. It compares the
+contents of a memory location with a given value and, only if they are the same, modifies the
+contents of that memory location to a new given value. This is done as a single atomic operation.
+The atomicity guarantees that the new value is calculated based on up-to-date information; if the
+value had been updated by another thread in the meantime, the write would fail.
 
-In this recipe, we will add a cache and lock over our previous [http fetching example](./http-json.html). If the cached value existed, we will return using the cached value. Otherwise we acquire the lock and then fetch from github public API and save it to the cache.
+In this recipe, we will add a cache and lock over our previous
+[http fetching example](./http-json.html). If the cached value existed, we will return using the
+cached value. Otherwise we acquire the lock and then fetch from github public API and save it to the
+cache.
 
 ## Setup
 
@@ -28,7 +42,8 @@ use sp_runtime::{
 }
 ```
 
-Then, in the `fetch_if_needed()` function, we first define a storage reference used by the off-chain worker.
+Then, in the `fetch_if_needed()` function, we first define a storage reference used by the off-chain
+worker.
 
 ```rust
 fn fetch_if_needed() -> Result<(), Error<T>> {
@@ -42,11 +57,18 @@ fn fetch_if_needed() -> Result<(), Error<T>> {
 }
 ```
 
-Looking at the [API doc](https://crates.parity.io/sp_runtime/offchain/storage/struct.StorageValueRef.html), we see there are two type of StorageValueRef, created via `::persistent()` and `::local()`. `::local()` is not fully implemented yet and `::persistent()` is enough for this use cases. We passed in a key as our storage key. As storage keys are namespaced globally, a good practice would be to prepend our pallet name in front of our storage key.
+Looking at the
+[API doc](https://crates.parity.io/sp_runtime/offchain/storage/struct.StorageValueRef.html), we see
+there are two type of StorageValueRef, created via `::persistent()` and `::local()`. `::local()` is
+not fully implemented yet and `::persistent()` is enough for this use cases. We passed in a key as
+our storage key. As storage keys are namespaced globally, a good practice would be to prepend our
+pallet name in front of our storage key.
 
 ## Access
 
-Once we have the storage reference, we can access the storage via `get`, `set`, and `mutate`. Let's demonstrate the `mutate` function as the usage of the remaining two functions are pretty self-explanatory.
+Once we have the storage reference, we can access the storage via `get`, `set`, and `mutate`. Let's
+demonstrate the `mutate` function as the usage of the remaining two functions are pretty
+self-explanatory.
 
 First we fetch to see if github info has been fetched and cached. If yes, we return early.
 
@@ -62,7 +84,9 @@ fn fetch_if_needed() -> Result<(), Error<T>> {
 }
 ```
 
-As with general on-chain storage, if we have a storage access pattern of **get-check-set**, it is a good indicator we should use `mutate`. This makes sure that multiple off-chain workers running concurrently does not modify the same storage entry.
+As with general on-chain storage, if we have a storage access pattern of **get-check-set**, it is a
+good indicator we should use `mutate`. This makes sure that multiple off-chain workers running
+concurrently does not modify the same storage entry.
 
 We then try to acquire the lock in order to fetch github info.
 
@@ -90,15 +114,22 @@ fn fetch_if_needed() -> Result<(), Error<T>> {
 }
 ```
 
-We use the `mutate` function to get and set the lock value, taking advantages of its compare-and-set access pattern. If the lock is being held by another ocw (with `s` equals value of `Some(Some(true))`), we return an error indicating the fetching is done by another ocw.
+We use the `mutate` function to get and set the lock value, taking advantages of its compare-and-set
+access pattern. If the lock is being held by another ocw (with `s` equals value of
+`Some(Some(true))`), we return an error indicating the fetching is done by another ocw.
 
-The return value of the `mutate` has a type of `Result<Result<T, T>, E>`, to indicate one of the following cases:
+The return value of the `mutate` has a type of `Result<Result<T, T>, E>`, to indicate one of the
+following cases:
 
-* `Ok(Ok(T))` - the value has been successfully set in the `mutate` closure and saved to the storage.
-* `Ok(Err(T))` - the value has been successfully set in the `mutate` closure, but failed to save to the storage.
-* `Err(_)` - the value has **NOT** been set successfully in the `mutate` closure.
+-   `Ok(Ok(T))` - the value has been successfully set in the `mutate` closure and saved to the
+    storage.
+-   `Ok(Err(T))` - the value has been successfully set in the `mutate` closure, but failed to save
+    to the storage.
+-   `Err(_)` - the value has **NOT** been set successfully in the `mutate` closure.
 
-Now we check the returned value of the `mutate` function. If fetching is done by another ocw (returning `Err(<Error<T>>)`), or cannot acquire the lock (returning `Ok(Err(true))`), we skip the fetching.
+Now we check the returned value of the `mutate` function. If fetching is done by another ocw
+(returning `Err(<Error<T>>)`), or cannot acquire the lock (returning `Ok(Err(true))`), we skip the
+fetching.
 
 ```rust
 fn fetch_if_needed() -> Result<(), Error<T>> {
@@ -128,9 +159,10 @@ fn fetch_if_needed() -> Result<(), Error<T>> {
 }
 ```
 
-Finally, whether the `fetch_n_parse()` function success or not, we release the lock by setting it to `false`.
+Finally, whether the `fetch_n_parse()` function success or not, we release the lock by setting it to
+`false`.
 
 ## Reference
 
-* [`StorageValueRef` API doc](https://crates.parity.io/sp_runtime/offchain/storage/struct.StorageValueRef.html)
-* [`example-offchain-worker` pallet in Substrate repo](https://github.com/paritytech/substrate/tree/master/frame/example-offchain-worker)
+-   [`StorageValueRef` API doc](https://crates.parity.io/sp_runtime/offchain/storage/struct.StorageValueRef.html)
+-   [`example-offchain-worker` pallet in Substrate repo](https://github.com/paritytech/substrate/tree/master/frame/example-offchain-worker)

--- a/text/3-entrees/off-chain-workers/transactions.md
+++ b/text/3-entrees/off-chain-workers/transactions.md
@@ -1,12 +1,15 @@
 # Transactions in Off-chain Workers
 
-*[`pallets/offchain-demo`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/offchain-demo)*
+_[`pallets/offchain-demo`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/offchain-demo)_
 
 ## Compiling this Pallet
 
-This `offchain-demo` pallet is included in the [ocw-runtime](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/ocw-runtime). That runtime can be used in the kitchen node.
+This `offchain-demo` pallet is included in the
+[ocw-runtime](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/ocw-runtime).
+That runtime can be used in the kitchen node.
 
-In order to use the Offchain worker, the node must inject some keys into its keystore, and that is enabled with a feature flag.
+In order to use the Offchain worker, the node must inject some keys into its keystore, and that is
+enabled with a feature flag.
 
 First, edit `nodes/kitchen-node/Cargo.toml` to enable the `ocw-runtime`.
 
@@ -22,7 +25,8 @@ cargo build --release --features ocw
 
 ## Life-cycle of Off-chain Worker
 
-Running the `kitchen-node`, you will see the off-chain worker is run after each block generation phase, as shown by `Entering off-chain workers` in the node output message:
+Running the `kitchen-node`, you will see the off-chain worker is run after each block generation
+phase, as shown by `Entering off-chain workers` in the node output message:
 
 ```
 ...
@@ -40,17 +44,27 @@ Running the `kitchen-node`, you will see the off-chain worker is run after each 
 ...
 ```
 
-Referring to the code at [`pallets/offchain-demo/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/offchain-demo/src/lib.rs), there is an `offchain_worker` function inside `decl_module!`. This is the entry point of the off-chain worker that is executed once after each block generation, so we put all the off-chain logic here.
+Referring to the code at
+[`pallets/offchain-demo/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/offchain-demo/src/lib.rs),
+there is an `offchain_worker` function inside `decl_module!`. This is the entry point of the
+off-chain worker that is executed once after each block generation, so we put all the off-chain
+logic here.
 
-Two kinds of transactions can be sent back on-chain from off-chain workers, **Signed Transactions** and **Unsigned Transactions**. Signed transactions are used if the transaction requires the sender to be specified. Unsigned transactions are used when the sender does not need to be known, and additional logic is written in the code to provide extra data verification. Let's walk through how to set up each one.
+Two kinds of transactions can be sent back on-chain from off-chain workers, **Signed Transactions**
+and **Unsigned Transactions**. Signed transactions are used if the transaction requires the sender
+to be specified. Unsigned transactions are used when the sender does not need to be known, and
+additional logic is written in the code to provide extra data verification. Let's walk through how
+to set up each one.
 
 ## Signed Transactions
 
 ### Setup
 
-For signed transactions, the first thing you will notice is that we have defined another sub-module here:
+For signed transactions, the first thing you will notice is that we have defined another sub-module
+here:
 
-src: [`pallets/offchain-demo/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/offchain-demo/src/lib.rs)
+src:
+[`pallets/offchain-demo/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/offchain-demo/src/lib.rs)
 
 ```rust
 pub const KEY_TYPE: KeyTypeId = KeyTypeId(*b"demo");
@@ -66,7 +80,8 @@ This is the application key to be used as the prefix for this pallet in underlyi
 
 Second, we have added an additional associated type `AuthorityId`.
 
-src: [`pallets/offchain-demo/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/offchain-demo/src/lib.rs)
+src:
+[`pallets/offchain-demo/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/offchain-demo/src/lib.rs)
 
 ```rust
 pub trait Trait: system::Trait {
@@ -75,11 +90,19 @@ pub trait Trait: system::Trait {
 }
 ```
 
-This associated type needs to be specified by the runtime when the runtime is to include this pallet (implement this pallet trait).
+This associated type needs to be specified by the runtime when the runtime is to include this pallet
+(implement this pallet trait).
 
-Now if we build the `kitchen-node`, we will see the compiler complain that there are three trait bounds `Runtime: frame_system::offchain::CreateSignedTransaction`, `frame_system::offchain::SigningTypes`, and `frame_system::offchain::SendTransactionTypes` are not satisfied. We learn that when using `SubmitSignedTransaction`, we also need to have our runtime implement the [`CreateSignedTransaction` trait](https://crates.parity.io/frame_system/offchain/trait.CreateSignedTransaction.html). So let's implement this in our runtime.
+Now if we build the `kitchen-node`, we will see the compiler complain that there are three trait
+bounds `Runtime: frame_system::offchain::CreateSignedTransaction`,
+`frame_system::offchain::SigningTypes`, and `frame_system::offchain::SendTransactionTypes` are not
+satisfied. We learn that when using `SubmitSignedTransaction`, we also need to have our runtime
+implement the
+[`CreateSignedTransaction` trait](https://crates.parity.io/frame_system/offchain/trait.CreateSignedTransaction.html).
+So let's implement this in our runtime.
 
-src: [`runtimes/ocw-runtime/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/ocw-runtime/src/lib.rs)
+src:
+[`runtimes/ocw-runtime/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/ocw-runtime/src/lib.rs)
 
 ```rust
 impl<LocalCall> frame_system::offchain::CreateSignedTransaction<LocalCall> for Runtime
@@ -129,12 +152,14 @@ where
 
 There is a lot happening in the code. But basically we are:
 
-- Signing the `call` and `extra`, also called signed extension, and
-- Making the call(`call`, which includes the call paramters) and passing the sender `address`, signature of the data `signature`, and its signed extension `extra` on-chain as a transaction.
+-   Signing the `call` and `extra`, also called signed extension, and
+-   Making the call(`call`, which includes the call paramters) and passing the sender `address`,
+    signature of the data `signature`, and its signed extension `extra` on-chain as a transaction.
 
 `SignedExtra` data type is defined later in the runtime.
 
-src: [`runtimes/ocw-runtime/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/ocw-runtime/src/lib.rs)
+src:
+[`runtimes/ocw-runtime/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/ocw-runtime/src/lib.rs)
 
 ```rust
 /// The SignedExtension to the basic transaction logic.
@@ -165,12 +190,12 @@ where
 }
 ```
 
-
 ### Sending Signed Transactions
 
 A signed transaction is sent with `T::SubmitSignedTransaction::submit_signed`, as shown below:
 
-src: [`pallets/offchain-demo/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/offchain-demo/src/lib.rs)
+src:
+[`pallets/offchain-demo/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/offchain-demo/src/lib.rs)
 
 ```rust
 fn send_signed(block_number: T::BlockNumber) -> Result<(), Error<T>> {
@@ -196,15 +221,25 @@ fn send_signed(block_number: T::BlockNumber) -> Result<(), Error<T>> {
 }
 ```
 
-We have a function reference to `Call::submit_number_signed(submission)`. This is the function we are going to submit back to on-chain, and passing it to `T::SubmitSignedTransaction::submit_signed(call)`.
+We have a function reference to `Call::submit_number_signed(submission)`. This is the function we
+are going to submit back to on-chain, and passing it to
+`T::SubmitSignedTransaction::submit_signed(call)`.
 
-You will notice that we run a for loop in the returned result. This implies that this call may make multiple transactions and return multiple results. It is because this call actually signs and sends the transaction with each of the accounts that can be found locally under the application crypto (which we defined earlier in `pub mod crypto {...}`). You can view this as the local accounts that are managed under this pallet namespace. Right now, we only have one key in the app crypto, so only one signed transaction is made.
+You will notice that we run a for loop in the returned result. This implies that this call may make
+multiple transactions and return multiple results. It is because this call actually signs and sends
+the transaction with each of the accounts that can be found locally under the application crypto
+(which we defined earlier in `pub mod crypto {...}`). You can view this as the local accounts that
+are managed under this pallet namespace. Right now, we only have one key in the app crypto, so only
+one signed transaction is made.
 
-Eventually, the `call` transaction is made on-chain via the `create_transaction` function we defined earlier when we implemented `CreateTransaction` trait in our runtime.
+Eventually, the `call` transaction is made on-chain via the `create_transaction` function we defined
+earlier when we implemented `CreateTransaction` trait in our runtime.
 
-If you are wondering where we insert the local account in the pallet app crypto, it is actually in the outer node's [service](https://crates.parity.io/sc_service/index.html).
+If you are wondering where we insert the local account in the pallet app crypto, it is actually in
+the outer node's [service](https://crates.parity.io/sc_service/index.html).
 
-src: [`nodes/kitchen-node/src/service.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/nodes/kitchen-node/src/service.rs)
+src:
+[`nodes/kitchen-node/src/service.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/nodes/kitchen-node/src/service.rs)
 
 ```rust
 pub fn new_full(config: Configuration<GenesisConfig>)
@@ -233,9 +268,12 @@ pub fn new_full(config: Configuration<GenesisConfig>)
 
 ### Setup
 
-By default, unsigned transactions are rejected by the Substrate runtime unless they are explicitly allowed. So we need to write the logic to allow unsigned transactions for certain particular dispatched functions as follows:
+By default, unsigned transactions are rejected by the Substrate runtime unless they are explicitly
+allowed. So we need to write the logic to allow unsigned transactions for certain particular
+dispatched functions as follows:
 
-src: [`pallets/offchain-demo/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/offchain-demo/src/lib.rs)
+src:
+[`pallets/offchain-demo/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/offchain-demo/src/lib.rs)
 
 ```rust
 impl<T: Trait> support::unsigned::ValidateUnsigned for Module<T> {
@@ -258,21 +296,35 @@ impl<T: Trait> support::unsigned::ValidateUnsigned for Module<T> {
 }
 ```
 
-We implement `ValidateUnsigned`, and the allowance logic is added inside the `validate_unsigned` function. We check if the call is to `Call::submit_number_unsigned` and returns `Ok()` if this is the case. Otherwise, `InvalidTransaction::Call`.
+We implement `ValidateUnsigned`, and the allowance logic is added inside the `validate_unsigned`
+function. We check if the call is to `Call::submit_number_unsigned` and returns `Ok()` if this is
+the case. Otherwise, `InvalidTransaction::Call`.
 
-The `ValidTransaction` object has some fields that touch on concepts that we have not discussed before:
+The `ValidTransaction` object has some fields that touch on concepts that we have not discussed
+before:
 
-- `priority`: Ordering of two transactions, given their dependencies are satisfied.
-- `requires`: List of tags this transaction depends on. Not shown in the above code as it is not necessary in this case.
-- `provides`: List of tags provided by this transaction. Successfully importing the transaction will enable other transactions that depend on these tags to be included as well. `provides` and `requires` tags allow Substrate to build a dependency graph of transactions and import them in the right order.
-- `longevity`: Transaction longevity, which describes the minimum number of blocks the transaction is valid for. After this period the transaction should be removed from the pool or revalidated.
-- `propagate`: Indication if the transaction should be propagated to other peers. By setting to `false` the transaction will still be considered for inclusion in blocks that are authored on the current node, but will never be sent to other peers.
+-   `priority`: Ordering of two transactions, given their dependencies are satisfied.
+-   `requires`: List of tags this transaction depends on. Not shown in the above code as it is not
+    necessary in this case.
+-   `provides`: List of tags provided by this transaction. Successfully importing the transaction
+    will enable other transactions that depend on these tags to be included as well. `provides` and
+    `requires` tags allow Substrate to build a dependency graph of transactions and import them in
+    the right order.
+-   `longevity`: Transaction longevity, which describes the minimum number of blocks the transaction
+    is valid for. After this period the transaction should be removed from the pool or revalidated.
+-   `propagate`: Indication if the transaction should be propagated to other peers. By setting to
+    `false` the transaction will still be considered for inclusion in blocks that are authored on
+    the current node, but will never be sent to other peers.
 
-We are using the [builder pattern](https://github.com/rust-unofficial/patterns/blob/master/patterns/builder.md) to build up this object.
+We are using the
+[builder pattern](https://github.com/rust-unofficial/patterns/blob/master/patterns/builder.md) to
+build up this object.
 
-Finally, to tell the runtime that we have our own `ValidateUnsigned` logic, we also need to pass this as a parameter when constructing the runtime.
+Finally, to tell the runtime that we have our own `ValidateUnsigned` logic, we also need to pass
+this as a parameter when constructing the runtime.
 
-src: [`runtimes/ocw-runtime/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/ocw-runtime/src/lib.rs)
+src:
+[`runtimes/ocw-runtime/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/ocw-runtime/src/lib.rs)
 
 ```rust
 construct_runtime!(
@@ -289,9 +341,11 @@ construct_runtime!(
 
 ### Sending Unsigned Transactions
 
-We can now make an unsigned transaction from offchain worker with the `T::SubmitUnsignedTransaction::submit_unsigned` function, as shown in the code.
+We can now make an unsigned transaction from offchain worker with the
+`T::SubmitUnsignedTransaction::submit_unsigned` function, as shown in the code.
 
-src: [`pallets/offchain-demo/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/offchain-demo/src/lib.rs)
+src:
+[`pallets/offchain-demo/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/offchain-demo/src/lib.rs)
 
 ```rust
 fn send_unsigned(block_number: T::BlockNumber) -> Result<(), Error<T>> {
@@ -308,8 +362,10 @@ fn send_unsigned(block_number: T::BlockNumber) -> Result<(), Error<T>> {
 }
 ```
 
-As in signed transactions, we prepare a function reference with its parameters and then call `T::SubmitUnsignedTransaction::submit_unsigned`.
+As in signed transactions, we prepare a function reference with its parameters and then call
+`T::SubmitUnsignedTransaction::submit_unsigned`.
 
 ## Testing
 
-For writing test cases for off-chain worker, refer to our [testing section](/3-entrees/testing/off-chain-workers.md).
+For writing test cases for off-chain worker, refer to our
+[testing section](/3-entrees/testing/off-chain-workers.md).

--- a/text/3-entrees/permissioned-methods.md
+++ b/text/3-entrees/permissioned-methods.md
@@ -1,10 +1,14 @@
 ## Permissioned Methods
-*[pallets/check-membership](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/check-membership)*
 
-It is often useful to designate some functions as permissioned and, therefore, accessible only to a defined group. In this case, we check that the transaction that invokes the runtime function is signed before verifying that the signature corresponds to a member of the permissioned set.
+_[pallets/check-membership](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/check-membership)_
 
-To manage the set of members allowed to access the methods in question, we may store a vector in runtime storage. Without access to the standard library, it is necessary to use the [`Vec` struct](https://crates.parity.io/sp_std/vec/struct.Vec.html) from the `sp-std` crate.
+It is often useful to designate some functions as permissioned and, therefore, accessible only to a
+defined group. In this case, we check that the transaction that invokes the runtime function is
+signed before verifying that the signature corresponds to a member of the permissioned set.
 
+To manage the set of members allowed to access the methods in question, we may store a vector in
+runtime storage. Without access to the standard library, it is necessary to use the
+[`Vec` struct](https://crates.parity.io/sp_std/vec/struct.Vec.html) from the `sp-std` crate.
 
 ```rust, ignore
 use sp_std::vec::Vec;
@@ -22,7 +26,8 @@ decl_storage! {
 
 ## Permissionless Membership
 
-If the membership is permissionless such anyone can join, an `add_member` function could be expressed as follows
+If the membership is permissionless such anyone can join, an `add_member` function could be
+expressed as follows
 
 ```rust, ignore
 fn add_member(origin) -> DispatchResult {
@@ -37,9 +42,13 @@ fn add_member(origin) -> DispatchResult {
 }
 ```
 
-Here we've used the [`append` method](https://crates.parity.io/frame_support/storage/trait.StorageValue.html#tymethod.append) to add the new member to the list. This allows a quick way to add data to the end of the vector without decoding the entire vector.
+Here we've used the
+[`append` method](https://crates.parity.io/frame_support/storage/trait.StorageValue.html#tymethod.append)
+to add the new member to the list. This allows a quick way to add data to the end of the vector
+without decoding the entire vector.
 
-To increase the readability of the code, the membership check is extracted into its own auxiliary runtime method.
+To increase the readability of the code, the membership check is extracted into its own auxiliary
+runtime method.
 
 ```rust, ignore
 impl<T: Trait> Module<T> {

--- a/text/3-entrees/randomness.md
+++ b/text/3-entrees/randomness.md
@@ -1,34 +1,60 @@
 # Generating Randomness
-*[pallets/randomness](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/randomness/)*
 
-Randomness is useful in computer programs for everything from gambling, to generating DNA for digital kitties, to selecting block authors. Randomness is hard to come by in deterministic computers as explained at [random.org](https://www.random.org/randomness/). This is particularly true in the context of a blockchain when all the nodes in the network must agree on the state of the chain. Some techniques have been developed to address this problem including [RanDAO](https://github.com/randao/randao) and [Verifiable Random Functions](https://en.wikipedia.org/wiki/Verifiable_random_function). Substrate abstracts the implementation of a randomness source using the [`Randomness` trait](https://crates.parity.io/frame_support/traits/trait.Randomness.html), and provides a few implementations. This recipe will demonstrate using the `Randomness` trait and two concrete implementations.
+_[pallets/randomness](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/randomness/)_
+
+Randomness is useful in computer programs for everything from gambling, to generating DNA for
+digital kitties, to selecting block authors. Randomness is hard to come by in deterministic
+computers as explained at [random.org](https://www.random.org/randomness/). This is particularly
+true in the context of a blockchain when all the nodes in the network must agree on the state of the
+chain. Some techniques have been developed to address this problem including
+[RanDAO](https://github.com/randao/randao) and
+[Verifiable Random Functions](https://en.wikipedia.org/wiki/Verifiable_random_function). Substrate
+abstracts the implementation of a randomness source using the
+[`Randomness` trait](https://crates.parity.io/frame_support/traits/trait.Randomness.html), and
+provides a few implementations. This recipe will demonstrate using the `Randomness` trait and two
+concrete implementations.
 
 ## Disclaimer
 
-All of the randomness sources described here have limitations on their usefulness and security. This recipe shows how to use these randomness sources and makes an effort to explain their trade-offs. However, the author of this recipe is a blockchain chef, **not a trained cryptographer**. It is your responsibility to understand the security implications of using any of the techniques described in this recipe, before putting them to use. When in doubt, consult a trustworthy cryptographer.
+All of the randomness sources described here have limitations on their usefulness and security. This
+recipe shows how to use these randomness sources and makes an effort to explain their trade-offs.
+However, the author of this recipe is a blockchain chef, **not a trained cryptographer**. It is your
+responsibility to understand the security implications of using any of the techniques described in
+this recipe, before putting them to use. When in doubt, consult a trustworthy cryptographer.
 
-The resources linked at the end of this recipe may be helpful in assessing the security and limitations of these randomness sources.
+The resources linked at the end of this recipe may be helpful in assessing the security and
+limitations of these randomness sources.
 
 ## Randomness Trait
 
-The randomness trait provides two methods, `random_seed`, and `random`, both of which provide a pesudo-random value of the type specified in the traits type parameter.
+The randomness trait provides two methods, `random_seed`, and `random`, both of which provide a
+pesudo-random value of the type specified in the traits type parameter.
 
 ### `random_seed`
 
-The `random_seed` method takes no parameters and returns a random seed which changes once per block. If you call this method twice in the same block you will get the same result. This method is typically not as useful as its counterpart.
+The `random_seed` method takes no parameters and returns a random seed which changes once per block.
+If you call this method twice in the same block you will get the same result. This method is
+typically not as useful as its counterpart.
 
 ### `random`
 
-The `random` method takes a byte array, `&[u8]`, known as the subject, and uses the subject's bytes along with the random seed described in the previous section to calculate a final random value. Using a subject in this way allows pallet (or multiple pallets) to seek randomness in the same block and get different results. The subject does not add entropy or security to the generation process, it merely prevents each call from returning identical values.
+The `random` method takes a byte array, `&[u8]`, known as the subject, and uses the subject's bytes
+along with the random seed described in the previous section to calculate a final random value.
+Using a subject in this way allows pallet (or multiple pallets) to seek randomness in the same block
+and get different results. The subject does not add entropy or security to the generation process,
+it merely prevents each call from returning identical values.
 
 Common values to use for a subject include:
-* The block number
-* The caller's accountId
-* A Nonce
-* A pallet-specific identifier
-* A tuple containing several of the above
 
-To bring a randomness source into scope, we include it in our configuration trait with the appropriate trait bound. This pallet, being a demo, will use two different sources. Using multiple sources is not necessary in practice.
+-   The block number
+-   The caller's accountId
+-   A Nonce
+-   A pallet-specific identifier
+-   A tuple containing several of the above
+
+To bring a randomness source into scope, we include it in our configuration trait with the
+appropriate trait bound. This pallet, being a demo, will use two different sources. Using multiple
+sources is not necessary in practice.
 
 ```rust, ignore
 pub trait Trait: system::Trait {
@@ -44,9 +70,16 @@ We've provided the `Output` type as [`H256`](https://crates.parity.io/sp_core/st
 
 ## Collective Coin Flipping
 
-Substrate's [Randomness Collective Flip pallet](https://crates.parity.io/pallet_randomness_collective_flip/index.html) uses a safe mixing algorithm to generate randomness using the entropy of previous block hashes. Because it is dependent on previous blocks, it can take many blocks for the seed to change.
+Substrate's
+[Randomness Collective Flip pallet](https://crates.parity.io/pallet_randomness_collective_flip/index.html)
+uses a safe mixing algorithm to generate randomness using the entropy of previous block hashes.
+Because it is dependent on previous blocks, it can take many blocks for the seed to change.
 
-A naive randomness source based on block hashes would take the hash of the previous block and use it as a random seed. Such a technique has the significant disadvantage that the block author can preview the random seed, and choose to discard the block choosing a slightly modified block with a more desirable hash. This pallet is subject to similar manipulation by the previous 81 block authors rather than just the previous 1.
+A naive randomness source based on block hashes would take the hash of the previous block and use it
+as a random seed. Such a technique has the significant disadvantage that the block author can
+preview the random seed, and choose to discard the block choosing a slightly modified block with a
+more desirable hash. This pallet is subject to similar manipulation by the previous 81 block authors
+rather than just the previous 1.
 
 Calling the randomness source from rust code is straightforward.
 
@@ -55,26 +88,36 @@ let random_seed = T::CollectiveFlipRandomnessSource::random_seed();
 let random_result = T::CollectiveFlipRandomnessSource::random(&subject);
 ```
 
-Although it may _seem_ harmless, **you should not hash the result** of the randomness provided by the collective flip pallet. Secure hash functions satisfy the [Avalance effect](https://en.wikipedia.org/wiki/Avalanche_effect) which means that each bit of input is equally likely to affect a given bit of the output. Hashing will negate the low-influence property provided by the pallet.
+Although it may _seem_ harmless, **you should not hash the result** of the randomness provided by
+the collective flip pallet. Secure hash functions satisfy the
+[Avalance effect](https://en.wikipedia.org/wiki/Avalanche_effect) which means that each bit of input
+is equally likely to affect a given bit of the output. Hashing will negate the low-influence
+property provided by the pallet.
 
 ## Babe VRF Output
 
-Substrate's [Babe pallet](https://crates.parity.io/pallet_babe/index.html) which is primarily responsible for managing validator rotation in Babe consensus, also collects the VRF outputs that Babe validators publish to demonstrate that they are permitted to author a block. These VRF outputs can be used to provide a random seed.
+Substrate's [Babe pallet](https://crates.parity.io/pallet_babe/index.html) which is primarily
+responsible for managing validator rotation in Babe consensus, also collects the VRF outputs that
+Babe validators publish to demonstrate that they are permitted to author a block. These VRF outputs
+can be used to provide a random seed.
 
-Because we are accessing the randomness via the `Randomness` trait, the calls look the same as before.
+Because we are accessing the randomness via the `Randomness` trait, the calls look the same as
+before.
 
 ```rust, ignore
 let random_seed = T::BabeRandomnessSource::random_seed();
 let random_result = T::BabeRandomnessSource::random(&subject);
 ```
 
-In production networks, Babe VRF output is preferable to Collective Flip. Collective Flip provides essentially no real security.
+In production networks, Babe VRF output is preferable to Collective Flip. Collective Flip provides
+essentially no real security.
 
 ## Down the Rabbit Hole
 
-As mentioned previously, there are many tradeoffs and security concerns to be aware of when using these randomness sources. If you'd like to get into the research, here are some jumping off points.
+As mentioned previously, there are many tradeoffs and security concerns to be aware of when using
+these randomness sources. If you'd like to get into the research, here are some jumping off points.
 
-* [https://github.com/paritytech/ink/issues/57](https://github.com/paritytech/ink/issues/57)
-* [https://wiki.polkadot.network/docs/en/learn-randomness](https://wiki.polkadot.network/docs/en/learn-randomness)
-* [http://www.cse.huji.ac.il/~nati/PAPERS/coll_coin_fl.pdf](http://www.cse.huji.ac.il/~nati/PAPERS/coll_coin_fl.pdf)
-* [https://eccc.weizmann.ac.il/report/2018/140/](https://eccc.weizmann.ac.il/report/2018/140/)
+-   [https://github.com/paritytech/ink/issues/57](https://github.com/paritytech/ink/issues/57)
+-   [https://wiki.polkadot.network/docs/en/learn-randomness](https://wiki.polkadot.network/docs/en/learn-randomness)
+-   [http://www.cse.huji.ac.il/~nati/PAPERS/coll_coin_fl.pdf](http://www.cse.huji.ac.il/~nati/PAPERS/coll_coin_fl.pdf)
+-   [https://eccc.weizmann.ac.il/report/2018/140/](https://eccc.weizmann.ac.il/report/2018/140/)

--- a/text/3-entrees/runtime-api.md
+++ b/text/3-entrees/runtime-api.md
@@ -1,10 +1,20 @@
 # Runtime APIs
-*[`pallets/sum-storage`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/sum-storage)*
-*[`runtimes/api-runtime`](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/api-runtime)*
 
-Each Substrate node contains a runtime. The runtime contains the business logic of the chain. It defines what transactions are valid and invalid and determines how the chain's state changes in response to transactions. The runtime is compiled to Wasm to facilitate runtime upgrades. The "outer node", everything other than the runtime, does not compile to Wasm, only to native. The outer node is responsible for handling peer discovery, transaction pooling, block and transaction gossiping, consensus, and answering RPC calls from the outside world. While performing these tasks, the outer node sometimes needs to query the runtime for information, or provide information to the runtime. A Runtime API facilitates this kind of communication between the outer node and the runtime. In this recipe, we will write our own minimal runtime API.
+_[`pallets/sum-storage`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/sum-storage)_
+_[`runtimes/api-runtime`](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/api-runtime)_
+
+Each Substrate node contains a runtime. The runtime contains the business logic of the chain. It
+defines what transactions are valid and invalid and determines how the chain's state changes in
+response to transactions. The runtime is compiled to Wasm to facilitate runtime upgrades. The "outer
+node", everything other than the runtime, does not compile to Wasm, only to native. The outer node
+is responsible for handling peer discovery, transaction pooling, block and transaction gossiping,
+consensus, and answering RPC calls from the outside world. While performing these tasks, the outer
+node sometimes needs to query the runtime for information, or provide information to the runtime. A
+Runtime API facilitates this kind of communication between the outer node and the runtime. In this
+recipe, we will write our own minimal runtime API.
 
 ## Our Example
+
 For this example, we will write a pallet called `sum-storage` with two storage items, both `u32`s.
 
 ```rust
@@ -16,7 +26,11 @@ decl_storage! {
 }
 ```
 
-Substrate already comes with a runtime API for querying storage values, which is why we can easily query our two storage values from a front-end. In this example we imagine that the outer node is interested in knowing the _sum_ of the two values, rather than either individual value. Our runtime API will provide a way for the outer node to query the runtime for this sum. Before we define the actual runtime API, let's write a public helper function in the pallet to do the summing.
+Substrate already comes with a runtime API for querying storage values, which is why we can easily
+query our two storage values from a front-end. In this example we imagine that the outer node is
+interested in knowing the _sum_ of the two values, rather than either individual value. Our runtime
+API will provide a way for the outer node to query the runtime for this sum. Before we define the
+actual runtime API, let's write a public helper function in the pallet to do the summing.
 
 ```rust
 impl<T: Trait> Module<T> {
@@ -26,12 +40,21 @@ impl<T: Trait> Module<T> {
 }
 ```
 
-So far, nothing we've done is specific to runtime APIs. In the coming sections, we will use this helper function in our runtime API's implementation.
+So far, nothing we've done is specific to runtime APIs. In the coming sections, we will use this
+helper function in our runtime API's implementation.
 
 ## Defining the API
-The first step in adding a runtime API to your runtime is defining its interface using a Rust trait. This is done in the `sum-storage/runtime-api/src/lib.rs` file. This file can live anywhere you like, but because it defines an API that is closely related to a particular pallet, it makes sense to include the API definition in the pallet's directory.
 
-The code to define the API is quite simple, and looks almost like any old Rust trait. The one addition is that it must be placed in the [`decl_runtime_apis!` macro](https://crates.parity.io/sp_api/macro.decl_runtime_apis.html). This macro allows the outer node to query the runtime API at specific blocks. Although this runtime API only provides a single function, you may write as many as you like.
+The first step in adding a runtime API to your runtime is defining its interface using a Rust trait.
+This is done in the `sum-storage/runtime-api/src/lib.rs` file. This file can live anywhere you like,
+but because it defines an API that is closely related to a particular pallet, it makes sense to
+include the API definition in the pallet's directory.
+
+The code to define the API is quite simple, and looks almost like any old Rust trait. The one
+addition is that it must be placed in the
+[`decl_runtime_apis!` macro](https://crates.parity.io/sp_api/macro.decl_runtime_apis.html). This
+macro allows the outer node to query the runtime API at specific blocks. Although this runtime API
+only provides a single function, you may write as many as you like.
 
 ```rust
 sp_api::decl_runtime_apis! {
@@ -42,9 +65,18 @@ sp_api::decl_runtime_apis! {
 ```
 
 ## Implementing the API
-With our pallet written and our runtime API defined, we may now implement the API for our runtime. This happens in the main runtime aggregation file. In our case we've provided the `api-runtime` in `runtimes/api-runtime/src/lib.rs`.
 
-As with defining the API, implementing a runtime API looks similar to implementing any old Rust trait with the exception that the implementation must go inside of the [`impl_runtime_apis!` macro](https://crates.parity.io/sp_api/macro.impl_runtime_apis.html). Every runtime must use `iml_runtime_apis!` because the [`Core` API](https://crates.parity.io/sp_api/trait.Core.html) is required. We will add an implementation for our own API alongside the others in this macro. Our implementation is straight-forward as it merely calls the pallet's helper function that we wrote previously.
+With our pallet written and our runtime API defined, we may now implement the API for our runtime.
+This happens in the main runtime aggregation file. In our case we've provided the `api-runtime` in
+`runtimes/api-runtime/src/lib.rs`.
+
+As with defining the API, implementing a runtime API looks similar to implementing any old Rust
+trait with the exception that the implementation must go inside of the
+[`impl_runtime_apis!` macro](https://crates.parity.io/sp_api/macro.impl_runtime_apis.html). Every
+runtime must use `iml_runtime_apis!` because the
+[`Core` API](https://crates.parity.io/sp_api/trait.Core.html) is required. We will add an
+implementation for our own API alongside the others in this macro. Our implementation is
+straight-forward as it merely calls the pallet's helper function that we wrote previously.
 
 ```rust
 impl_runtime_apis! {
@@ -58,13 +90,23 @@ impl_runtime_apis! {
 }
 ```
 
-You may be wondering about the `Block` type parameter which is present here, but not in our definition. This type parameter is added by the macros along with a few other features. All runtime APIs have this type parameter to facilitate querying the runtime at arbitrary blocks. Read more about this in the docs for [`impl_runtime_apis!`](https://crates.parity.io/sp_api/macro.impl_runtime_apis.html).
+You may be wondering about the `Block` type parameter which is present here, but not in our
+definition. This type parameter is added by the macros along with a few other features. All runtime
+APIs have this type parameter to facilitate querying the runtime at arbitrary blocks. Read more
+about this in the docs for
+[`impl_runtime_apis!`](https://crates.parity.io/sp_api/macro.impl_runtime_apis.html).
 
 ## Calling the Runtime API
-We've now successfully added a runtime API to our runtime. The outer node can now call this API to query the runtime for the sum of two storage values. Given a reference to a ['client'](https://crates.parity.io/sc_service/client/struct.Client.html) we can make the call like this.
+
+We've now successfully added a runtime API to our runtime. The outer node can now call this API to
+query the runtime for the sum of two storage values. Given a reference to a
+['client'](https://crates.parity.io/sc_service/client/struct.Client.html) we can make the call like
+this.
 
 ```rust
 let sum_at_block_fifty = client.runtime_api().get_sum(&50);
 ```
 
-This recipe was about defining and implementing a custom runtime API. To see an example of calling this API in practice, see the recipe on [custom RPCs](./custom-rpc.md), where we connect this runtime API to an RPC that can be called by an end user.
+This recipe was about defining and implementing a custom runtime API. To see an example of calling
+this API in practice, see the recipe on [custom RPCs](./custom-rpc.md), where we connect this
+runtime API to an RPC that can be called by an end user.

--- a/text/3-entrees/safemath.md
+++ b/text/3-entrees/safemath.md
@@ -1,6 +1,13 @@
 # Safe Math
 
-We can use the `checked` traits in [substrate-primitives](https://crates.parity.io/sp_runtime/traits/index.html) to protect against [overflow/underflow](https://medium.com/@taabishm2/integer-overflow-underflow-and-floating-point-imprecision-6ba869a99033) when incrementing/decrementing objects in our runtime. To follow the [Substrat collectable tutorial example](https://shawntabrizi.com/substrate-collectables-workshop/#/2/tracking-all-kitties?id=checking-for-overflowunderflow), use [`checked_add()`](https://crates.parity.io/sp_runtime/traits/trait.CheckedAdd.html) to safely handle the possibility of overflow when incremementing a global counter. *Note that this check is similar to [`SafeMath`](https://ethereumdev.io/safemath-protect-overflows/) in Solidity*. 
+We can use the `checked` traits in
+[substrate-primitives](https://crates.parity.io/sp_runtime/traits/index.html) to protect against
+[overflow/underflow](https://medium.com/@taabishm2/integer-overflow-underflow-and-floating-point-imprecision-6ba869a99033)
+when incrementing/decrementing objects in our runtime. To follow the
+[Substrat collectable tutorial example](https://shawntabrizi.com/substrate-collectables-workshop/#/2/tracking-all-kitties?id=checking-for-overflowunderflow),
+use [`checked_add()`](https://crates.parity.io/sp_runtime/traits/trait.CheckedAdd.html) to safely
+handle the possibility of overflow when incremementing a global counter. _Note that this check is
+similar to [`SafeMath`](https://ethereumdev.io/safemath-protect-overflows/) in Solidity_.
 
 ```rust, ignore
 use runtime_primitives::traits::CheckedAdd;
@@ -10,7 +17,10 @@ let all_people_count = Self::num_of_people();
 let new_all_people_count = all_people_count.checked_add(1).ok_or("Overflow adding a new person")?;
 ```
 
-[`ok_or()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.ok_or) transforms an `Option` from `Some(value)` to `Ok(value)` or `None` to `Err(error)`. The [`?` operator](https://doc.rust-lang.org/nightly/edition-guide/rust-2018/error-handling-and-panics/the-question-mark-operator-for-easier-error-handling.html) facilitates error propagation. In this case, using `ok_or()` is the same as writing
+[`ok_or()`](https://doc.rust-lang.org/std/option/enum.Option.html#method.ok_or) transforms an
+`Option` from `Some(value)` to `Ok(value)` or `None` to `Err(error)`. The
+[`?` operator](https://doc.rust-lang.org/nightly/edition-guide/rust-2018/error-handling-and-panics/the-question-mark-operator-for-easier-error-handling.html)
+facilitates error propagation. In this case, using `ok_or()` is the same as writing
 
 ```rust, ignore
 let new_all_people_count = match all_people_count.checked_add(1) {
@@ -20,7 +30,10 @@ let new_all_people_count = match all_people_count.checked_add(1) {
 ```
 
 ## todo
-* `?` for error propagation
-* Permill, Perbill, Fixed64 types for large arithmetic
-* `quantization` benchmarks in the `treasury` tests to verify that large arithmetic stays in a comfortable error bound
-* ADD BACK IN NEW RECIPE: `collide` and the question of whether maps prevent key collisions? could discuss `sort`, `sort_unstable`, and the ordering traits here...
+
+-   `?` for error propagation
+-   Permill, Perbill, Fixed64 types for large arithmetic
+-   `quantization` benchmarks in the `treasury` tests to verify that large arithmetic stays in a
+    comfortable error bound
+-   ADD BACK IN NEW RECIPE: `collide` and the question of whether maps prevent key collisions? could
+    discuss `sort`, `sort_unstable`, and the ordering traits here...

--- a/text/3-entrees/sha3-pow-consensus.md
+++ b/text/3-entrees/sha3-pow-consensus.md
@@ -1,11 +1,19 @@
 # Sha3 Proof of Work Algorithms
-*[`consensus/sha3pow`](https://github.com/substrate-developer-hub/recipes/tree/master/consensus/sha3pow)*
 
-[Proof of Work](https://en.wikipedia.org/wiki/Proof_of_work) is not a single consensus algorithm. Rather it is a class of algorithms represented in Substrate by the [`PowAlgorithm` trait](https://crates.parity.io/sc_consensus_pow/trait.PowAlgorithm.html). Before we can build a PoW node we must specify a concrete PoW algorithm by implementing this trait. In this recipe we specify two concrete PoW algorithms, both of which are based on the [sha3 hashing algorithm](https://en.wikipedia.org/wiki/SHA-3).
+_[`consensus/sha3pow`](https://github.com/substrate-developer-hub/recipes/tree/master/consensus/sha3pow)_
+
+[Proof of Work](https://en.wikipedia.org/wiki/Proof_of_work) is not a single consensus algorithm.
+Rather it is a class of algorithms represented in Substrate by the
+[`PowAlgorithm` trait](https://crates.parity.io/sc_consensus_pow/trait.PowAlgorithm.html). Before we
+can build a PoW node we must specify a concrete PoW algorithm by implementing this trait. In this
+recipe we specify two concrete PoW algorithms, both of which are based on the
+[sha3 hashing algorithm](https://en.wikipedia.org/wiki/SHA-3).
 
 ## Minimal Sha3 PoW
 
-First we turn our attention to a minimal working implementation. This consensus engine is kept intentionally simple. It omits some features that make Proof of Work practical for real-world use such as difficulty adjustment.
+First we turn our attention to a minimal working implementation. This consensus engine is kept
+intentionally simple. It omits some features that make Proof of Work practical for real-world use
+such as difficulty adjustment.
 
 Begin by creating a struct that will implement the `PowAlgorithm Trait`.
 
@@ -16,11 +24,18 @@ Begin by creating a struct that will implement the `PowAlgorithm Trait`.
 pub struct MinimalSha3Algorithm;
 ```
 
-Because this is a _minimal_ PoW algorithm, our struct can also be quite simple. In fact, it is a [unit struct](https://doc.rust-lang.org/rust-by-example/custom_types/structs.html). A more complex PoW algorithm that interfaces with the runtime would need to hold a reference to the client. An example of this (on an older Substrate codebase) can be seen in [Kulupu](https://github.com/kulupu/kulupu/)'s [RandomXAlgorithm](https://github.com/kulupu/kulupu/blob/3500b7f62fdf90be7608b2d813735a063ad1c458/pow/src/lib.rs#L137-L145).
+Because this is a _minimal_ PoW algorithm, our struct can also be quite simple. In fact, it is a
+[unit struct](https://doc.rust-lang.org/rust-by-example/custom_types/structs.html). A more complex
+PoW algorithm that interfaces with the runtime would need to hold a reference to the client. An
+example of this (on an older Substrate codebase) can be seen in
+[Kulupu](https://github.com/kulupu/kulupu/)'s
+[RandomXAlgorithm](https://github.com/kulupu/kulupu/blob/3500b7f62fdf90be7608b2d813735a063ad1c458/pow/src/lib.rs#L137-L145).
 
 ### Difficulty
 
-The first function we must provide returns the difficulty of the next block to be mined. In our minimal sha3 algorithm, this function is quite simple. The difficulty is fixed. This means that as more mining power joins the network, the block time will become faster.
+The first function we must provide returns the difficulty of the next block to be mined. In our
+minimal sha3 algorithm, this function is quite simple. The difficulty is fixed. This means that as
+more mining power joins the network, the block time will become faster.
 
 ```rust, ignore
 impl<B: BlockT<Hash=H256>> PowAlgorithm<B> for Sha3Algorithm {
@@ -38,7 +53,11 @@ impl<B: BlockT<Hash=H256>> PowAlgorithm<B> for Sha3Algorithm {
 
 ### Verification
 
-Our PoW algorithm must also be able to verify blocks provided by other authors. We are first given the pre-hash, which is a hash of the block before the proof of work seal is attached. We are also given the seal, which testifies that the work has been done, and the difficulty that the block author needed to meet. This function first confirms that the provided seal actually meets the target difficulty, then it confirms that the seal is actually valid for the given pre-hash.
+Our PoW algorithm must also be able to verify blocks provided by other authors. We are first given
+the pre-hash, which is a hash of the block before the proof of work seal is attached. We are also
+given the seal, which testifies that the work has been done, and the difficulty that the block
+author needed to meet. This function first confirms that the provided seal actually meets the target
+difficulty, then it confirms that the seal is actually valid for the given pre-hash.
 
 ```rust, ignore
 fn verify(
@@ -115,17 +134,26 @@ fn mine(
 }
 ```
 
-Notice that this function takes a parameter for the number of rounds of mining it should attempt. If no block has been successfully mined in this time, the method will return. This gives the service a chance to check whether any new blocks have been received from other authors since the mining started. If a valid block has been received, then we will start mining on it. If no such block has been received, we will go in for another try at mining on the same block as before.
-
-
+Notice that this function takes a parameter for the number of rounds of mining it should attempt. If
+no block has been successfully mined in this time, the method will return. This gives the service a
+chance to check whether any new blocks have been received from other authors since the mining
+started. If a valid block has been received, then we will start mining on it. If no such block has
+been received, we will go in for another try at mining on the same block as before.
 
 ## Realistic Sha3 PoW
 
-Having understood the fundamentals, we can now build a more realistic sha3 algorithm. The primary difference here is that this algorithm will fetch the difficulty from the runtime via a [runtime api](./runtime-api.md). This change allows the runtime to dynamically adjust the difficulty based on block time. So if more mining power joins the network, the diffculty adjusts, and the blocktime remains constant.
+Having understood the fundamentals, we can now build a more realistic sha3 algorithm. The primary
+difference here is that this algorithm will fetch the difficulty from the runtime via a
+[runtime api](./runtime-api.md). This change allows the runtime to dynamically adjust the difficulty
+based on block time. So if more mining power joins the network, the diffculty adjusts, and the
+blocktime remains constant.
 
 ### Defining the `Sha3Algorithm` Struct
 
-We begin as before by defining a struct that will implement the `PowAlgorithm` trait. Unlike before, this struct must hold a reference to the [`Client`](https://crates.parity.io/sc_service/client/struct.Client.html) so it can call the appropriate runtime APIs.
+We begin as before by defining a struct that will implement the `PowAlgorithm` trait. Unlike before,
+this struct must hold a reference to the
+[`Client`](https://crates.parity.io/sc_service/client/struct.Client.html) so it can call the
+appropriate runtime APIs.
 
 ```rust, ignore
 /// A complete PoW Algorithm that uses Sha3 hashing.
@@ -145,7 +173,8 @@ impl<C> Sha3Algorithm<C> {
 }
 ```
 
-And finally we manually implement `Clone`. We cannot derive clone as we did for the `MinimalSha3Algorithm`.
+And finally we manually implement `Clone`. We cannot derive clone as we did for the
+`MinimalSha3Algorithm`.
 
 ```rust, ignore
 // Manually implement clone. Deriving doesn't work because
@@ -157,11 +186,15 @@ impl<C> Clone for Sha3Algorithm<C> {
 }
 ```
 
-> It isn't critical to understand _why_ the manual `Clone` implementation is necessary, just that it is necessary.
+> It isn't critical to understand _why_ the manual `Clone` implementation is necessary, just that it
+> is necessary.
 
 ### Implementing the `PowAlgorithm` trait
 
-As before we implement the `PowAlgorithm` trait for out `Sha3Algorithm`. This time we supply more complex trait bounds to ensure that the client the algorithm holds a reference to actually provides the [`DifficultyAPI`](https://crates.parity.io/sp_consensus_pow/trait.DifficultyApi.html) necessary to fetch the PoW difficulty from the runtime.
+As before we implement the `PowAlgorithm` trait for out `Sha3Algorithm`. This time we supply more
+complex trait bounds to ensure that the client the algorithm holds a reference to actually provides
+the [`DifficultyAPI`](https://crates.parity.io/sp_consensus_pow/trait.DifficultyApi.html) necessary
+to fetch the PoW difficulty from the runtime.
 
 ```rust, ignore
 // Here we implement the general PowAlgorithm trait for our concrete Sha3Algorithm
@@ -177,7 +210,9 @@ impl<B: BlockT<Hash=H256>, C> PowAlgorithm<B> for Sha3Algorithm<C> where
 
 ### Difficulty
 
-The implementation of `PowAlgorithm`'s `difficulty` function, no longer returns a fxed value, but rather calls into the runtime API which is guaranteed to exist because of the trait bounds. It also maps any errors that may have occurred when using the API.
+The implementation of `PowAlgorithm`'s `difficulty` function, no longer returns a fxed value, but
+rather calls into the runtime API which is guaranteed to exist because of the trait bounds. It also
+maps any errors that may have occurred when using the API.
 
 ```rust, ignore
 fn difficulty(&self, parent: B::Hash) -> Result<Self::Difficulty, Error<B>> {

--- a/text/3-entrees/storage-api/cache.md
+++ b/text/3-entrees/storage-api/cache.md
@@ -1,7 +1,9 @@
 # Cache Multiple Calls
-*[`pallets/storage-cache`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/storage-cache)*
 
-Calls to runtime storage have an associated cost. With this in mind, multiple calls to storage values should be avoided when possible.
+_[`pallets/storage-cache`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/storage-cache)_
+
+Calls to runtime storage have an associated cost. With this in mind, multiple calls to storage
+values should be avoided when possible.
 
 ```rust, ignore
 decl_storage! {
@@ -18,7 +20,9 @@ decl_storage! {
 
 ## Copy Types
 
-For [`Copy`](https://doc.rust-lang.org/std/marker/trait.Copy.html) types, it is easy to reuse previous storage calls by simply reusing the value (which is automatically cloned upon reuse). With this in mind, the second call in the following code is unnecessary:
+For [`Copy`](https://doc.rust-lang.org/std/marker/trait.Copy.html) types, it is easy to reuse
+previous storage calls by simply reusing the value (which is automatically cloned upon reuse). With
+this in mind, the second call in the following code is unnecessary:
 
 ```rust, ignore
 fn increase_value_no_cache(origin, some_val: u32) -> DispatchResult {
@@ -36,7 +40,9 @@ fn increase_value_no_cache(origin, some_val: u32) -> DispatchResult {
 }
 ```
 
-Instead, the initial call value should be reused. In this example, the `SomeCopyValue` value is [`Copy`](https://doc.rust-lang.org/std/marker/trait.Copy.html) so we should prefer the following code without the unnecessary second call to storage:
+Instead, the initial call value should be reused. In this example, the `SomeCopyValue` value is
+[`Copy`](https://doc.rust-lang.org/std/marker/trait.Copy.html) so we should prefer the following
+code without the unnecessary second call to storage:
 
 ```rust, ignore
 fn increase_value_w_copy(origin, some_val: u32) -> DispatchResult {
@@ -54,13 +60,18 @@ fn increase_value_w_copy(origin, some_val: u32) -> DispatchResult {
 
 ## Clone Types
 
-If the type was not `Copy`, but was [`Clone`](https://doc.rust-lang.org/std/clone/trait.Clone.html), then it is still preferred to clone the value in the method than to make another call to runtime storage.
+If the type was not `Copy`, but was [`Clone`](https://doc.rust-lang.org/std/clone/trait.Clone.html),
+then it is still preferred to clone the value in the method than to make another call to runtime
+storage.
 
 The runtime methods enable the calling account to swap the `T::AccountId` value in storage if
+
 1. the existing storage value is not in `GroupMembers` AND
 2. the calling account is in `GroupMembers`
 
-The first implementation makes a second unnecessary call to runtime storage instead of cloning the call for `existing_key`:
+The first implementation makes a second unnecessary call to runtime storage instead of cloning the
+call for `existing_key`:
+
 ```rust, ignore
 fn swap_king_no_cache(origin) -> DispatchResult {
 	let new_king = ensure_signed(origin)?;
@@ -82,7 +93,8 @@ fn swap_king_no_cache(origin) -> DispatchResult {
 }
 ```
 
-If the `existing_key` is used without a `clone` in the event emission instead of `old_king`, then the compiler returns the following error
+If the `existing_key` is used without a `clone` in the event emission instead of `old_king`, then
+the compiler returns the following error
 
 ```bash
 error[E0382]: use of moved value: `existing_king`
@@ -129,4 +141,6 @@ fn swap_king_with_cache(origin) -> DispatchResult {
 }
 ```
 
-Not all types implement [`Copy`](https://doc.rust-lang.org/std/marker/trait.Copy.html) or [`Clone`](https://doc.rust-lang.org/std/clone/trait.Clone.html), so it is important to discern other patterns that minimize and alleviate the cost of calls to storage.
+Not all types implement [`Copy`](https://doc.rust-lang.org/std/marker/trait.Copy.html) or
+[`Clone`](https://doc.rust-lang.org/std/clone/trait.Clone.html), so it is important to discern other
+patterns that minimize and alleviate the cost of calls to storage.

--- a/text/3-entrees/storage-api/childtries.md
+++ b/text/3-entrees/storage-api/childtries.md
@@ -1,18 +1,28 @@
 # Child Tries
-*[`pallets/child-trie`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/child-trie)*, *[`pallets/simple-crowdfund`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/simple-crowdfund)*
 
-* [Runtime Child Storage](#storj)
-* [Crowdfund Example](#smplcrwd)
+_[`pallets/child-trie`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/child-trie)_,
+_[`pallets/simple-crowdfund`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/simple-crowdfund)_
 
-A [trie](https://en.wikipedia.org/wiki/Trie) is an ordered tree structure for managing dynamic sets. For any given parent node, all descendants (children) share a common prefix associated with the parent.
+-   [Runtime Child Storage](#storj)
+-   [Crowdfund Example](#smplcrwd)
 
-This construction lends itself to efficient removal of subgroups of a dataset (similar to [`double_map`](./double.md)). By associating a common prefix with related data, the dataset can be partitioned to effectively batch deletions.
+A [trie](https://en.wikipedia.org/wiki/Trie) is an ordered tree structure for managing dynamic sets.
+For any given parent node, all descendants (children) share a common prefix associated with the
+parent.
 
-Every change in the leaves percolates up to the root, thereby providing a complete, succinct history of all changes to the underlying data structure in the form of the trie root hash.
+This construction lends itself to efficient removal of subgroups of a dataset (similar to
+[`double_map`](./double.md)). By associating a common prefix with related data, the dataset can be
+partitioned to effectively batch deletions.
+
+Every change in the leaves percolates up to the root, thereby providing a complete, succinct history
+of all changes to the underlying data structure in the form of the trie root hash.
 
 ## Runtime Child Storage <a name = "storj"></a>
 
-To interact with child tries, there are methods exposed in [runtime child storage](https://crates.parity.io/frame_support/storage/child/index.html). Of the methods listed in the documentation, it is worth emphasizing the method associated with batch deletion.
+To interact with child tries, there are methods exposed in
+[runtime child storage](https://crates.parity.io/frame_support/storage/child/index.html). Of the
+methods listed in the documentation, it is worth emphasizing the method associated with batch
+deletion.
 
 ```rust, ignore
 pub fn kill_trie(index: ObjectCount) {
@@ -24,7 +34,9 @@ pub fn kill_trie(index: ObjectCount) {
 }
 ```
 
-[`kill_storage`](https://crates.parity.io/frame_support/storage/child/fn.kill_storage.html) deletes all  `(key, value)` pairs associated with the `storage_key`. The basic API for interacting with a given child trie follows this format:
+[`kill_storage`](https://crates.parity.io/frame_support/storage/child/fn.kill_storage.html) deletes
+all `(key, value)` pairs associated with the `storage_key`. The basic API for interacting with a
+given child trie follows this format:
 
 ```rust, ignore
 // pseudocode
@@ -45,7 +57,12 @@ pub fn kv_put(index: ObjectCount, who: &T::AccountId, value_to_put: ValAppended)
 }
 ```
 
-The code in [`pallets/child-trie`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/child-trie) demonstrates a minimal way of organizing the basic child-trie api methods (as done in [`polkadot/runtime/crowdfund`](https://github.com/paritytech/polkadot/blob/c003d73c65cdcc0367340db09522c91d1d3851fc/runtime/common/src/crowdfund.rs)). It separates out the generation of the child trie id from the index with a runtime method `id_from_index`.
+The code in
+[`pallets/child-trie`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/child-trie)
+demonstrates a minimal way of organizing the basic child-trie api methods (as done in
+[`polkadot/runtime/crowdfund`](https://github.com/paritytech/polkadot/blob/c003d73c65cdcc0367340db09522c91d1d3851fc/runtime/common/src/crowdfund.rs)).
+It separates out the generation of the child trie id from the index with a runtime method
+`id_from_index`.
 
 ```rust, ignore
 pub fn id_from_index(index: ObjectCount) -> Vec<u8> {
@@ -65,15 +82,23 @@ pub fn id_from_index(index: ObjectCount) -> Vec<u8> {
 This results in less code for each method.
 
 ## smpl-crowdfund <a name = "smplcrwd"></a>
-*[`pallets/simple-crowdfund`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/simple-crowdfund)*
 
-Child tries are useful for batch deletion of `(key, value)` pairs associated with a specific `trie_id`. This is relevant to the [polkadot/crowdfund](https://github.com/paritytech/polkadot/blob/master/runtime/common/src/crowdfund.rs) pallet, which tracks `(AccountId, BalanceOf<T>)` associated with a specific crowdfund. `BalanceOf<T>` represents the contributions of an `AccountId`. The identifier for each crowdfund is defined
+_[`pallets/simple-crowdfund`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/simple-crowdfund)_
+
+Child tries are useful for batch deletion of `(key, value)` pairs associated with a specific
+`trie_id`. This is relevant to the
+[polkadot/crowdfund](https://github.com/paritytech/polkadot/blob/master/runtime/common/src/crowdfund.rs)
+pallet, which tracks `(AccountId, BalanceOf<T>)` associated with a specific crowdfund.
+`BalanceOf<T>` represents the contributions of an `AccountId`. The identifier for each crowdfund is
+defined
 
 ```rust, ignore
 type FundIndex = u32
 ```
 
-With these three types, this storage item effectively manages `(FundIndex, AccountId, BalanceOf<T>)`. By maintaining a separate `child` for every `FundIndex`, this api allows for efficient batch deletions when crowdfunds are ended and dissolved.
+With these three types, this storage item effectively manages
+`(FundIndex, AccountId, BalanceOf<T>)`. By maintaining a separate `child` for every `FundIndex`,
+this api allows for efficient batch deletions when crowdfunds are ended and dissolved.
 
 ```rust, ignore
 // polkadot/runtime/crowdfund
@@ -83,8 +108,12 @@ pub fn crowdfund_kill(index: FundIndex) {
 }
 ```
 
-The child trie api is useful when data associated with an identifier needs to be isolated to facilitate efficient batch removal. In this case, all the information associated with a given crowdfund should be removed when the crowdfund is dissolved.
+The child trie api is useful when data associated with an identifier needs to be isolated to
+facilitate efficient batch removal. In this case, all the information associated with a given
+crowdfund should be removed when the crowdfund is dissolved.
 
 ### caveat coder
 
-Each individual call to read/write to the child trie is more expensive than it would be for `map` or `double_map`. This cost is poorly amortized over a large number of calls, but can be significantly reduced by following a proper batch execution strategy.
+Each individual call to read/write to the child trie is more expensive than it would be for `map` or
+`double_map`. This cost is poorly amortized over a large number of calls, but can be significantly
+reduced by following a proper batch execution strategy.

--- a/text/3-entrees/storage-api/double.md
+++ b/text/3-entrees/storage-api/double.md
@@ -1,7 +1,11 @@
 # Efficent Subgroup Removal by Subkey: Double Maps
-*[`pallets/double-map`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/double-map)*
 
-For some runtimes, it may be necessary to remove a subset of values in a key-value mapping. If the subset maintain an associated identifier type, this can be done in a clean way with the [`double_map`](https://crates.parity.io/frame_support/storage/trait.StorageDoubleMap.html) via the `remove_prefix` api.
+_[`pallets/double-map`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/double-map)_
+
+For some runtimes, it may be necessary to remove a subset of values in a key-value mapping. If the
+subset maintain an associated identifier type, this can be done in a clean way with the
+[`double_map`](https://crates.parity.io/frame_support/storage/trait.StorageDoubleMap.html) via the
+`remove_prefix` api.
 
 ```rust, ignore
 pub type GroupIndex = u32; // this is Encode (which is necessary for double_map)
@@ -19,7 +23,9 @@ decl_storage! {
 }
 ```
 
-For the purposes of this example, store the scores of each members in a map that associates this `u32` value with two keys: (1) a `GroupIndex` identifier, and (2) the member's `AccountId`. This allows for efficient removal of all values associated with a specific `GroupIndex` identifier.
+For the purposes of this example, store the scores of each members in a map that associates this
+`u32` value with two keys: (1) a `GroupIndex` identifier, and (2) the member's `AccountId`. This
+allows for efficient removal of all values associated with a specific `GroupIndex` identifier.
 
 ```rust, ignore
 fn remove_group_score(origin, group: GroupIndex) -> DispatchResult {

--- a/text/3-entrees/storage-api/index.md
+++ b/text/3-entrees/storage-api/index.md
@@ -1,19 +1,30 @@
 # Storage API
 
-We've already encountered the [`decl_storage!` macro](https://crates.parity.io/frame_support/macro.decl_storage.html) in the appetizer on [storage items](../../2-appetizers/2-storage-values.md). There is a rich storage API in Substrate which we will explore in this section.
+We've already encountered the
+[`decl_storage!` macro](https://crates.parity.io/frame_support/macro.decl_storage.html) in the
+appetizer on [storage items](../../2-appetizers/2-storage-values.md). There is a rich storage API in
+Substrate which we will explore in this section.
 
-For crypto*currencies*, storage might consist of a mapping between account keys and corresponding balances.
+For crypto*currencies*, storage might consist of a mapping between account keys and corresponding
+balances.
 
-More generally, blockchains provide an interface to store and interact with data in a verifiable and globally irreversible way. In this context, data is stored in a series of snapshots, each of which may be accessed at a later point in time, but, once created, snapshots are considered irreversible.
+More generally, blockchains provide an interface to store and interact with data in a verifiable and
+globally irreversible way. In this context, data is stored in a series of snapshots, each of which
+may be accessed at a later point in time, but, once created, snapshots are considered irreversible.
 
-Arbitrary data may be stored, as long as its data type is serializable in Substrate i.e. implements [`Encode`](https://docs.rs/parity-scale-codec/1.3.0/parity_scale_codec/#encode) and [`Decode`](https://docs.rs/parity-scale-codec/1.3.0/parity_scale_codec/#decode) traits.
+Arbitrary data may be stored, as long as its data type is serializable in Substrate i.e. implements
+[`Encode`](https://docs.rs/parity-scale-codec/1.3.0/parity_scale_codec/#encode) and
+[`Decode`](https://docs.rs/parity-scale-codec/1.3.0/parity_scale_codec/#decode) traits.
 
-The previous *[single-value storage recipe](../../2-appetizers/2-storage-values.md)* showed how a single value can be stored in runtime storage. In this section, we cover
-- [caching values rather than calling to storage multiple times](./cache.md)
-- [storing sets, checking membership, and iteration](./sets-vecs-iteration.md)
-- [efficient subgroup removal by key prefix with double maps](./double.md)
-- [storing custom structs](./structs.md)
+The previous _[single-value storage recipe](../../2-appetizers/2-storage-values.md)_ showed how a
+single value can be stored in runtime storage. In this section, we cover
 
-*in-progress*
-- [cheap inclusion proofs with child tries](./childtries.md)
-- [transient storage adapters by example of a ringbuffer queue](./ringbuffer.md)
+-   [caching values rather than calling to storage multiple times](./cache.md)
+-   [storing sets, checking membership, and iteration](./sets-vecs-iteration.md)
+-   [efficient subgroup removal by key prefix with double maps](./double.md)
+-   [storing custom structs](./structs.md)
+
+_in-progress_
+
+-   [cheap inclusion proofs with child tries](./childtries.md)
+-   [transient storage adapters by example of a ringbuffer queue](./ringbuffer.md)

--- a/text/3-entrees/storage-api/ringbuffer.md
+++ b/text/3-entrees/storage-api/ringbuffer.md
@@ -1,14 +1,26 @@
 # Ringbuffer Queue
-*[`pallets/ringbuffer-queue`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/ringbuffer-queue)*
+
+_[`pallets/ringbuffer-queue`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/ringbuffer-queue)_
+
 > Building a transient adapter on top of storage.
 
-This pallet provides a trait and implementation for a [ringbuffer](https://en.wikipedia.org/wiki/Circular_buffer) that abstracts over storage items and presents them as a [FIFO](https://en.wikipedia.org/wiki/FIFO_(computing_and_electronics)) queue.
+This pallet provides a trait and implementation for a
+[ringbuffer](https://en.wikipedia.org/wiki/Circular_buffer) that abstracts over storage items and
+presents them as a [FIFO](<https://en.wikipedia.org/wiki/FIFO_(computing_and_electronics)>) queue.
 
-When building more sophisticated pallets you might notice a need for more complex data structures stored in storage. This recipe shows how to build a transient storage adapter by walking through the implementation of a ringbuffer FIFO queue. The adapter in this recipe manages a queue that is persisted as a `StorageMap` and a `(start, end)` range in storage.
+When building more sophisticated pallets you might notice a need for more complex data structures
+stored in storage. This recipe shows how to build a transient storage adapter by walking through the
+implementation of a ringbuffer FIFO queue. The adapter in this recipe manages a queue that is
+persisted as a `StorageMap` and a `(start, end)` range in storage.
 
-The [`ringbuffer-queue/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/ringbuffer-queue/src/lib.rs) file contains the [usage](#usage) of the transient storage adapter while [`ringbuffer-queue/src/ringbuffer.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/ringbuffer-queue/src/ringbuffer.rs) contains the implementation.
+The
+[`ringbuffer-queue/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/ringbuffer-queue/src/lib.rs)
+file contains the [usage](#usage) of the transient storage adapter while
+[`ringbuffer-queue/src/ringbuffer.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/ringbuffer-queue/src/ringbuffer.rs)
+contains the implementation.
 
 ## Defining the RingBuffer Trait <a name = "trait"></a>
+
 First we define the queue interface we want to use:
 
 ```rust, ignore
@@ -27,10 +39,13 @@ where
 }
 ```
 
-It defines the usual `push`, `pop` and `is_empty` functions we expect from a queue as well as a `commit` function that will be used to sync the changes made to the underlying storage.
+It defines the usual `push`, `pop` and `is_empty` functions we expect from a queue as well as a
+`commit` function that will be used to sync the changes made to the underlying storage.
 
 ## Specifying the RingBuffer Transient <a name = "transient"></a>
-Now we want to add an implementation of the trait. We will be storing the start and end of the ringbuffer separately from the actual items and will thus need to store these in our struct:
+
+Now we want to add an implementation of the trait. We will be storing the start and end of the
+ringbuffer separately from the actual items and will thus need to store these in our struct:
 
 ```rust, ignore
 pub struct RingBufferTransient<Index>
@@ -43,8 +58,11 @@ where
 ```
 
 ### Defining the Storage Interface
-In order to access the underlying storage we will also need to include the bounds (we will call the type `B`) and the item storage (whose type will be `M`). In order to specify the constraints on the storage map (`M`) we will also need to specify the `Item` type.
-This results in the following struct definition:
+
+In order to access the underlying storage we will also need to include the bounds (we will call the
+type `B`) and the item storage (whose type will be `M`). In order to specify the constraints on the
+storage map (`M`) we will also need to specify the `Item` type. This results in the following struct
+definition:
 
 ```rust, ignore
 pub struct RingBufferTransient<Item, B, M, Index>
@@ -60,13 +78,20 @@ where
 }
 ```
 
-The bounds `B` will be a `StorageValue` storing a tuple of indices `(Index, Index)`. The item storage will be a `StorageMap` mapping from our `Index` type to the `Item` type. We specify the associated `Query` type for both of them to help with type inference (because the value returned can be different from the stored representation).
+The bounds `B` will be a `StorageValue` storing a tuple of indices `(Index, Index)`. The item
+storage will be a `StorageMap` mapping from our `Index` type to the `Item` type. We specify the
+associated `Query` type for both of them to help with type inference (because the value returned can
+be different from the stored representation).
 
-The [`Codec`](https://docs.rs/parity-scale-codec/1.3.0/parity_scale_codec/trait.Codec.html) and [`EncodeLike`](https://docs.rs/parity-scale-codec/1.3.0/parity_scale_codec/trait.EncodeLike.html) type constraints make sure that both items and indices can be stored in storage.
+The [`Codec`](https://docs.rs/parity-scale-codec/1.3.0/parity_scale_codec/trait.Codec.html) and
+[`EncodeLike`](https://docs.rs/parity-scale-codec/1.3.0/parity_scale_codec/trait.EncodeLike.html)
+type constraints make sure that both items and indices can be stored in storage.
 
-We need the [`PhantomData`](https://doc.rust-lang.org/std/marker/struct.PhantomData.html) in order to "hold on to" the types during the lifetime of the transient object.
+We need the [`PhantomData`](https://doc.rust-lang.org/std/marker/struct.PhantomData.html) in order
+to "hold on to" the types during the lifetime of the transient object.
 
 ### The Complete Type
+
 There are two more alterations we will make to our struct to make it work well:
 
 ```rust, ignore
@@ -84,12 +109,17 @@ where
 }
 ```
 
-We specify a default type for `Index` and define it as `u16` to allow for 65536 entries in the ringbuffer per default. We also add the `WrappingOps` and `From<u8>` type bounds to enable the kind of operations we need in our implementation. More details in the [implementation](#implementation) section, especially in the [`WrappingOps`](#wrapping_ops) subsection.
+We specify a default type for `Index` and define it as `u16` to allow for 65536 entries in the
+ringbuffer per default. We also add the `WrappingOps` and `From<u8>` type bounds to enable the kind
+of operations we need in our implementation. More details in the [implementation](#implementation)
+section, especially in the [`WrappingOps`](#wrapping_ops) subsection.
 
 ## Implementation of the RingBuffer <a name = "implementation"></a>
+
 Now that we have the type definition for `RingBufferTransient` we need to write the implementation.
 
 ### Instantiating the Transient
+
 First we need to specify how to create a new instance by providing a `new` function:
 
 ```rust, ignore
@@ -107,11 +137,14 @@ where // ... same where clause as the type, elided here
 
 Here we access the bounds stored in storage to initialize the transient.
 
-> **Aside**: Of course we could also provide a `with_bounds` function that takes the bounds as a parameter. Feel free to add that function as an exercise.
+> **Aside**: Of course we could also provide a `with_bounds` function that takes the bounds as a
+> parameter. Feel free to add that function as an exercise.
 
->**Second Aside**: This `B::get()` is one of the reasons for specifying the `Query` associated type on the `StorageValue` type constraint.
+> **Second Aside**: This `B::get()` is one of the reasons for specifying the `Query` associated type
+> on the `StorageValue` type constraint.
 
 ### Implementing the `RingBufferTrait`
+
 We will now implement the `RingBufferTrait`:
 
 ```rust, ignore
@@ -127,7 +160,8 @@ where // same as the struct definition
 	}
 ```
 
-`commit` just consists of putting the potentially changed bounds into storage. You will notice that we don't update the bounds' storage when changing them in the other functions.
+`commit` just consists of putting the potentially changed bounds into storage. You will notice that
+we don't update the bounds' storage when changing them in the other functions.
 
 ```rust, ignore
 	fn is_empty(&self) -> bool {
@@ -135,7 +169,9 @@ where // same as the struct definition
 	}
 ```
 
-The `is_empty` function just checks whether the start and end bounds have the same value to determine whether the queue is empty, thus avoiding expensive storage accesses. This means we need to uphold the corresponding invariant in the other (notably the `push`) functions.
+The `is_empty` function just checks whether the start and end bounds have the same value to
+determine whether the queue is empty, thus avoiding expensive storage accesses. This means we need
+to uphold the corresponding invariant in the other (notably the `push`) functions.
 
 ```rust, ignore
 	fn push(&mut self, item: Item) {
@@ -152,12 +188,23 @@ The `is_empty` function just checks whether the start and end bounds have the sa
 	}
 ```
 
-In the `push` function, we insert the pushed `item` into the map and calculate the new bounds by using the `wrapping_add` function. This way our ringbuffer will wrap around when reaching `max_value` of the `Index` type. This is why we need the `WrappingOps` type trait for `Index`.
+In the `push` function, we insert the pushed `item` into the map and calculate the new bounds by
+using the `wrapping_add` function. This way our ringbuffer will wrap around when reaching
+`max_value` of the `Index` type. This is why we need the `WrappingOps` type trait for `Index`.
 
-The `if` is necessary because we need to keep the invariant that `start == end` means that the queue is empty, otherwise we would need to keep track of this state separately. We thus "toss away" the oldest item in the queue if a new item is pushed into a full queue by incrementing the start index.
+The `if` is necessary because we need to keep the invariant that `start == end` means that the queue
+is empty, otherwise we would need to keep track of this state separately. We thus "toss away" the
+oldest item in the queue if a new item is pushed into a full queue by incrementing the start index.
 
 > ##### Note: The `WrappingOps` Trait <a name = "wrapping_ops"></a>
-> The ringbuffer should be agnostic to the concrete `Index` type used. In order to be able to decrement and increment the start and end index, though, any concrete type needs to implement `wrapping_add` and `wrapping_sub`. Because `std` does not provide such a trait, we need another way to require this behavior. One possbility would be using the [`num_traits` crate](https://crates.io/crates/num-traits), but to keep things simple here we just implement our own trait `WrappingOps` for the types we want to support (`u8`, `u16`, `u32` and `u64`).
+>
+> The ringbuffer should be agnostic to the concrete `Index` type used. In order to be able to
+> decrement and increment the start and end index, though, any concrete type needs to implement
+> `wrapping_add` and `wrapping_sub`. Because `std` does not provide such a trait, we need another
+> way to require this behavior. One possbility would be using the
+> [`num_traits` crate](https://crates.io/crates/num-traits), but to keep things simple here we just
+> implement our own trait `WrappingOps` for the types we want to support (`u8`, `u16`, `u32` and
+> `u64`).
 
 The last function we implement is `pop`:
 
@@ -173,10 +220,16 @@ The last function we implement is `pop`:
 	}
 ```
 
-We can return `None` on `is_empty` because we are upholding the invariant. If the queue is not empty we `take` the value at `self.start` from storage, i.e. the first value is removed from storage and passed to us. We then increment `self.start` to point to the new first item of the queue, again using the `wrapping_add` to get the ringbuffer behavior.
+We can return `None` on `is_empty` because we are upholding the invariant. If the queue is not empty
+we `take` the value at `self.start` from storage, i.e. the first value is removed from storage and
+passed to us. We then increment `self.start` to point to the new first item of the queue, again
+using the `wrapping_add` to get the ringbuffer behavior.
 
 ### Implementing Drop
-In order to make the usage more ergonomic and to avoid synchronization errors (where the storage map diverges from the bounds) we also implement the [`Drop` trait](https://doc.rust-lang.org/std/ops/trait.Drop.html):
+
+In order to make the usage more ergonomic and to avoid synchronization errors (where the storage map
+diverges from the bounds) we also implement the
+[`Drop` trait](https://doc.rust-lang.org/std/ops/trait.Drop.html):
 
 ```rust, ignore
 impl<Item, B, M, Index> Drop for RingBufferTransient<Item, B, M, Index>
@@ -188,10 +241,15 @@ where // ... same where clause elided
 }
 ```
 
-On `drop`, we `commit` the bounds to storage. With this implementation of `Drop`, `commit` is called when our transient goes out of scope, making sure that the storage state is consistent for the next call to the using pallet.
+On `drop`, we `commit` the bounds to storage. With this implementation of `Drop`, `commit` is called
+when our transient goes out of scope, making sure that the storage state is consistent for the next
+call to the using pallet.
 
 ## Typical Usage <a name = "usage"></a>
-The [`lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/ringbuffer-queue/src/lib.rs) file of the pallet shows typical usage of the transient.
+
+The
+[`lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/ringbuffer-queue/src/lib.rs)
+file of the pallet shows typical usage of the transient.
 
 ```rust, ignore
 impl<T: Trait> Module<T> {
@@ -206,8 +264,12 @@ impl<T: Trait> Module<T> {
 }
 ```
 
-First we define a constructor function (`queue_transient`) so we don't have to specify the types every time we want to access the transient. This function constructs a ringbuffer transient and returns it as a boxed trait object.
-See the Rust book's section on [trait objects](https://doc.rust-lang.org/book/ch17-02-trait-objects.html#trait-objects-perform-dynamic-dispatch) for an explanation of why we need a boxed trait object (defined with the syntax `dyn TraitName`) when using dynamic dispatch.
+First we define a constructor function (`queue_transient`) so we don't have to specify the types
+every time we want to access the transient. This function constructs a ringbuffer transient and
+returns it as a boxed trait object. See the Rust book's section on
+[trait objects](https://doc.rust-lang.org/book/ch17-02-trait-objects.html#trait-objects-perform-dynamic-dispatch)
+for an explanation of why we need a boxed trait object (defined with the syntax `dyn TraitName`)
+when using dynamic dispatch.
 
 The `add_multiple` function shows the actual typical usage of our transient:
 
@@ -222,5 +284,6 @@ pub fn add_multiple(origin, integers: Vec<i32>, boolean: bool) -> DispatchResult
 } // commit happens on drop
 ```
 
-Here we use the `queue_transient` function defined above to get a `queue` object. We then `push` into it repeatedly with `commit` happening on `drop` of the `queue` object at the end of the function.
-`pop` works analogously and can of course be intermixed with `push`es.
+Here we use the `queue_transient` function defined above to get a `queue` object. We then `push`
+into it repeatedly with `commit` happening on `drop` of the `queue` object at the end of the
+function. `pop` works analogously and can of course be intermixed with `push`es.

--- a/text/3-entrees/storage-api/sets-vecs-iteration.md
+++ b/text/3-entrees/storage-api/sets-vecs-iteration.md
@@ -1,15 +1,18 @@
 # Set Storage and Iteration
-*[`pallets/vec-set`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/vec-set)*
 
-Storing a vector in the runtime can often be useful for managing groups and verifying membership. This recipe discusses common patterns encounted when storing vectors in runtime storage.
+_[`pallets/vec-set`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/vec-set)_
 
-* [verifying group membership](#group)
-* [Append vs Mutate](#append)
-* [Iteration in the Runtime](#iterate)
+Storing a vector in the runtime can often be useful for managing groups and verifying membership.
+This recipe discusses common patterns encounted when storing vectors in runtime storage.
+
+-   [verifying group membership](#group)
+-   [Append vs Mutate](#append)
+-   [Iteration in the Runtime](#iterate)
 
 ## Verifying Group Membership <a name = "group"></a>
 
-To maintain a set of `AccountId` to establish group ownership of decisions, it is straightforward to store a vector in the runtime of `AccountId`.
+To maintain a set of `AccountId` to establish group ownership of decisions, it is straightforward to
+store a vector in the runtime of `AccountId`.
 
 ```rust, ignore
 decl_storage! {
@@ -29,7 +32,10 @@ impl<T: Trait> Module<T> {
 }
 ```
 
-This helper method can be placed in other runtime methods to restrict certain changes to runtime storage to privileged groups. Depending on the incentive structure of the network/chain, the members in these groups may have earned membership and the subsequent access rights through loyal contributions to the system.
+This helper method can be placed in other runtime methods to restrict certain changes to runtime
+storage to privileged groups. Depending on the incentive structure of the network/chain, the members
+in these groups may have earned membership and the subsequent access rights through loyal
+contributions to the system.
 
 ```rust, ignore
 // use support::ensure
@@ -41,9 +47,12 @@ fn member_action(origin) -> Result {
 }
 ```
 
-In this example, the helper method facilitates isolation of runtime storage access rights according to membership. In general, **place `ensure!` checks at the top of each runtime function's logic to verify that all of the requisite checks pass before performing any storage changes.**
+In this example, the helper method facilitates isolation of runtime storage access rights according
+to membership. In general, **place `ensure!` checks at the top of each runtime function's logic to
+verify that all of the requisite checks pass before performing any storage changes.**
 
-> NOTE: *[child trie](https://github.com/substrate-developer-hub/recipes/issues/35) storage provides a more efficient data structure for tracking group membership*
+> NOTE: _[child trie](https://github.com/substrate-developer-hub/recipes/issues/35) storage provides
+> a more efficient data structure for tracking group membership_
 
 ## Append vs. Mutate
 
@@ -56,7 +65,10 @@ decl_storage! {
 }
 ```
 
-Before [3071](https://github.com/paritytech/substrate/pull/3071) was merged, it was necessary to call [`mutate`](https://crates.parity.io/frame_support/storage/trait.StorageValue.html#tymethod.mutate) to push new values to a vector stored in runtime storage.
+Before [3071](https://github.com/paritytech/substrate/pull/3071) was merged, it was necessary to
+call
+[`mutate`](https://crates.parity.io/frame_support/storage/trait.StorageValue.html#tymethod.mutate)
+to push new values to a vector stored in runtime storage.
 
 ```rust, ignore
 fn mutate_to_append(origin) -> Result {
@@ -69,8 +81,11 @@ fn mutate_to_append(origin) -> Result {
 }
 ```
 
-For vectors stored in the runtime, mutation can be relatively expensive. This follows from the fact that `mutate` entails decoding the vector, making changes, and re-encoding the whole vector. It seems wasteful to decode the entire vector, push a new item, and then re-encode the whole thing. This provides sufficient motivation for [`append`](https://crates.parity.io/frame_support/storage/trait.StorageValue.html#tymethod.append):
-
+For vectors stored in the runtime, mutation can be relatively expensive. This follows from the fact
+that `mutate` entails decoding the vector, making changes, and re-encoding the whole vector. It
+seems wasteful to decode the entire vector, push a new item, and then re-encode the whole thing.
+This provides sufficient motivation for
+[`append`](https://crates.parity.io/frame_support/storage/trait.StorageValue.html#tymethod.append):
 
 ```rust, ignore
 fn append_new_entries(origin) -> Result {
@@ -84,10 +99,24 @@ fn append_new_entries(origin) -> Result {
 }
 ```
 
-`append` encodes the new values, and pushes them to the already encoded vector without decoding the existing entries. This method removes the unnecessary steps for decoding and re-encoding the unchanged elements.
+`append` encodes the new values, and pushes them to the already encoded vector without decoding the
+existing entries. This method removes the unnecessary steps for decoding and re-encoding the
+unchanged elements.
 
 ## Iteration in the Runtime <a name = "iterate"></a>
 
-In general, iteration in the runtime should be avoided. *In the future*, [offchain-workers](https://github.com/substrate-developer-hub/recipes/issues/45) may provide a less expensive way to iterate over runtime storage items. Moreover, *[child tries](https://github.com/substrate-developer-hub/recipes/issues/35)* enable cheap inclusion proofs without the same lookup costs associated with vectors.
+In general, iteration in the runtime should be avoided. _In the future_,
+[offchain-workers](https://github.com/substrate-developer-hub/recipes/issues/45) may provide a less
+expensive way to iterate over runtime storage items. Moreover,
+_[child tries](https://github.com/substrate-developer-hub/recipes/issues/35)_ enable cheap inclusion
+proofs without the same lookup costs associated with vectors.
 
-Even so, there are a few tricks to alleviate the costs of iterating over runtime storage items like vectors. For example, it is [cheaper to iterate over a slice](https://twitter.com/heinz_gies/status/1121490424739303425) than a vector. With this in mind, store items in the runtime as vectors and transform them into slices after making storage calls. [3041](https://github.com/paritytech/substrate/pull/3041) introduced `insert_ref` and `put_ref` in order to allow equivalent reference-style types to be placed without copy (e.g. a storage item of `Vec<AccountId>` can now be written from a `&[AccountId]`). This enables greater flexibility when working with slices that are associated with vectors stored in the runtime.
+Even so, there are a few tricks to alleviate the costs of iterating over runtime storage items like
+vectors. For example, it is
+[cheaper to iterate over a slice](https://twitter.com/heinz_gies/status/1121490424739303425) than a
+vector. With this in mind, store items in the runtime as vectors and transform them into slices
+after making storage calls. [3041](https://github.com/paritytech/substrate/pull/3041) introduced
+`insert_ref` and `put_ref` in order to allow equivalent reference-style types to be placed without
+copy (e.g. a storage item of `Vec<AccountId>` can now be written from a `&[AccountId]`). This
+enables greater flexibility when working with slices that are associated with vectors stored in the
+runtime.

--- a/text/3-entrees/storage-api/storage-maps.md
+++ b/text/3-entrees/storage-api/storage-maps.md
@@ -1,7 +1,11 @@
 # Storage Maps
-*[`pallets/simple-map`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/simple-map)*
 
-In the appetizer on [storage values](../../2-appetizers/2-storage-values.md) we learned to store a single value in blockchain storage to be persisted between blocks. In this recipe, we will see how to store a mapping from keys to values, similar to Rust's own [`HashMap`](https://doc.rust-lang.org/std/collections/struct.HashMap.html).
+_[`pallets/simple-map`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/simple-map)_
+
+In the appetizer on [storage values](../../2-appetizers/2-storage-values.md) we learned to store a
+single value in blockchain storage to be persisted between blocks. In this recipe, we will see how
+to store a mapping from keys to values, similar to Rust's own
+[`HashMap`](https://doc.rust-lang.org/std/collections/struct.HashMap.html).
 
 ## Declaring a `StorageMap`
 
@@ -15,31 +19,56 @@ decl_storage! {
 }
 ```
 
-Much of this should look familiar to you from storage values. Reading the line from left to right we have:
-* `SimpleMap` - the name of the storage map
-* `get(fn simple_map)` - the name of a getter function that will return values from the map.
-* `: map hasher(blake2_128_concat)` - beginning of the type declaration. This is a map and it will use the [`blake2_128_concat`](https://crates.parity.io/frame_support/trait.Hashable.html#tymethod.blake2_128_concat) hasher. More on this below.
-* `T::AccountId => u32` - The specific key and value tyes of the map. This is a map from `AccountId`s to `u32`s.
+Much of this should look familiar to you from storage values. Reading the line from left to right we
+have:
+
+-   `SimpleMap` - the name of the storage map
+-   `get(fn simple_map)` - the name of a getter function that will return values from the map.
+-   `: map hasher(blake2_128_concat)` - beginning of the type declaration. This is a map and it will
+    use the
+    [`blake2_128_concat`](https://crates.parity.io/frame_support/trait.Hashable.html#tymethod.blake2_128_concat)
+    hasher. More on this below.
+-   `T::AccountId => u32` - The specific key and value tyes of the map. This is a map from
+    `AccountId`s to `u32`s.
 
 ## Choosing a Hasher
 
-Although the syntax above is complex, most of it should be straightforward if you've understood the recipe on storage values. The last unfamiliar piece of writing a storage map is choosing which hasher to use. In general you should choose one of the three following hashers. The choice of hasher will affect the performance and security of your chain. If you don't want to think much about this, just choose `blake2_128_concat` and skip to the next section.
+Although the syntax above is complex, most of it should be straightforward if you've understood the
+recipe on storage values. The last unfamiliar piece of writing a storage map is choosing which
+hasher to use. In general you should choose one of the three following hashers. The choice of hasher
+will affect the performance and security of your chain. If you don't want to think much about this,
+just choose `blake2_128_concat` and skip to the next section.
 
 ### `blake2_128_concat`
 
-This is a cryptographically secure hash function, and is always safe to use. It is reasonably efficient, and will keep your storage tree balanced. You _must_ choose this hasher if users of your chain have the ability to affect the storage keys. In this pallet, the keys are `AccountId`s. At first it may _seem_ that the user doesn't affect the `AccountId`, but in reality a malicious user can generate thousands of accounts and use the one that will affect the chain's storage tree in the way the attacker likes. For this reason, we have chosen to use the `blake2_128_concat` hasher.
+This is a cryptographically secure hash function, and is always safe to use. It is reasonably
+efficient, and will keep your storage tree balanced. You _must_ choose this hasher if users of your
+chain have the ability to affect the storage keys. In this pallet, the keys are `AccountId`s. At
+first it may _seem_ that the user doesn't affect the `AccountId`, but in reality a malicious user
+can generate thousands of accounts and use the one that will affect the chain's storage tree in the
+way the attacker likes. For this reason, we have chosen to use the `blake2_128_concat` hasher.
 
 ### `twox_64_concat`
 
-This hasher is _not_ cryptographically secure, but is more efficient than blake2. Thus it represents trading security for performance. You should _not_ use this hasher if chain users can affect the storage keys. However, it is perfectly safe to use this hasher to gain performance in scenarios where the users do not control the keys. For example, if the keys in your map are sequentially increasing indices and users cannot cause the indices to rapidly increase, then this is a perfectly reasonable choice.
+This hasher is _not_ cryptographically secure, but is more efficient than blake2. Thus it represents
+trading security for performance. You should _not_ use this hasher if chain users can affect the
+storage keys. However, it is perfectly safe to use this hasher to gain performance in scenarios
+where the users do not control the keys. For example, if the keys in your map are sequentially
+increasing indices and users cannot cause the indices to rapidly increase, then this is a perfectly
+reasonable choice.
 
 ### `identity`
 
-The `identity` "hasher" is really not a hasher at all, but merely an [identity function](https://en.wikipedia.org/wiki/Identity_function) that returns the same value it receives. This hasher is only an option when the key type in your storage map is _already_ a hash, and is not controllable by the user. If you're in doubt whether the user can influence the key just use blake2.
+The `identity` "hasher" is really not a hasher at all, but merely an
+[identity function](https://en.wikipedia.org/wiki/Identity_function) that returns the same value it
+receives. This hasher is only an option when the key type in your storage map is _already_ a hash,
+and is not controllable by the user. If you're in doubt whether the user can influence the key just
+use blake2.
 
 ## The Storage Map API
 
-This pallet demonstrated some of the most common methods available in a storage map including `insert`, `get`, `take`, and `contains_key`.
+This pallet demonstrated some of the most common methods available in a storage map including
+`insert`, `get`, `take`, and `contains_key`.
 
 ```rust, ignore
 // Insert
@@ -55,4 +84,7 @@ let entry = <SimpleMap<T>>::take(&user);
 <SimpleMap<T>>::contains_key(&user)
 ```
 
-The rest of the API is documented in the rustdocs on the [`StorageMap` trait](https://crates.parity.io/frame_support/storage/trait.StorageMap.html). You do not need to explicitly `use` this trait because the `decl_storage!` macro will do it for you if you use a storage map.
+The rest of the API is documented in the rustdocs on the
+[`StorageMap` trait](https://crates.parity.io/frame_support/storage/trait.StorageMap.html). You do
+not need to explicitly `use` this trait because the `decl_storage!` macro will do it for you if you
+use a storage map.

--- a/text/3-entrees/storage-api/structs.md
+++ b/text/3-entrees/storage-api/structs.md
@@ -1,9 +1,14 @@
 # Using and Storing Structs
-*[`pallets/struct-storage`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/struct-storage)*
 
-In Rust, a `struct`, or structure, is a custom data type that lets you name and package together multiple related values that make up a meaningful group. If you’re familiar with an object-oriented language, a `struct` is like an object’s data attributes (read more in [The Rust Book](https://doc.rust-lang.org/book/ch05-01-defining-structs.html)).
+_[`pallets/struct-storage`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/struct-storage)_
+
+In Rust, a `struct`, or structure, is a custom data type that lets you name and package together
+multiple related values that make up a meaningful group. If you’re familiar with an object-oriented
+language, a `struct` is like an object’s data attributes (read more in
+[The Rust Book](https://doc.rust-lang.org/book/ch05-01-defining-structs.html)).
 
 ## Defining a Struct
+
 To define a _simple_ custom struct for the runtime, the following syntax may be used:
 
 ```rust, ignore
@@ -14,7 +19,12 @@ pub struct MyStruct {
 }
 ```
 
-In the code snippet above, the [derive macro](https://doc.rust-lang.org/rust-by-example/trait/derive.html) is declared to ensure `MyStruct` conforms to shared behavior according to the specified [traits](https://doc.rust-lang.org/book/ch10-02-traits.html): `Encode, Decode, Default, Clone, PartialEq`. If you wish the store this struct in blockchain storage, you will need to derive (or manually ipmlement) each of these traits.
+In the code snippet above, the
+[derive macro](https://doc.rust-lang.org/rust-by-example/trait/derive.html) is declared to ensure
+`MyStruct` conforms to shared behavior according to the specified
+[traits](https://doc.rust-lang.org/book/ch10-02-traits.html):
+`Encode, Decode, Default, Clone, PartialEq`. If you wish the store this struct in blockchain
+storage, you will need to derive (or manually ipmlement) each of these traits.
 
 To use the `Encode` and `Decode` traits, it is necessary to import them.
 
@@ -24,7 +34,10 @@ use frame_support::codec::{Encode, Decode};
 
 ## Structs with Generic Fields
 
-The simple struct shown earlier only uses Rust primitive types for its fields. In the common case where you want to store types that come from your pallet's configuration trait (or the configuration trait of another pallet in your runtime), you must use generic type parameters in your struct's definition.
+The simple struct shown earlier only uses Rust primitive types for its fields. In the common case
+where you want to store types that come from your pallet's configuration trait (or the configuration
+trait of another pallet in your runtime), you must use generic type parameters in your struct's
+definition.
 
 ```rust, ignore
 #[derive(Encode, Decode, Clone, Default, RuntimeDebug)]
@@ -35,9 +48,12 @@ pub struct InnerThing<Hash, Balance> {
 }
 ```
 
-Here you can see that we want to store items of type `Hash` and `Balance` in the struct. Because these types come from the system and balances pallets' configuration traits, we must specify them as generics when declaring the struct.
+Here you can see that we want to store items of type `Hash` and `Balance` in the struct. Because
+these types come from the system and balances pallets' configuration traits, we must specify them as
+generics when declaring the struct.
 
-It is often convenient to make a type alias that takes `T`, your pallet's configuration trait, as a single type parameter. Doing so simply saves you typing in the future.
+It is often convenient to make a type alias that takes `T`, your pallet's configuration trait, as a
+single type parameter. Doing so simply saves you typing in the future.
 
 ```rust, ignore
 type InnerThingOf<T> = InnerThing<<T as system::Trait>::Hash, <T as balances::Trait>::Balance>;
@@ -45,7 +61,11 @@ type InnerThingOf<T> = InnerThing<<T as system::Trait>::Hash, <T as balances::Tr
 
 ## Structs in Storage
 
-Using one of our structs as a storage item is not significantly different than using a primitive type. When using a generic struct, we must supply all of the generic type parameters. This snippet shows how to supply thos parameters when you have a type alias (like we do for `InnerThing`) as well as when you don't. Whether to include the type alias is a matter of style and taste, but it is generally preferred when the entire type exceeds the preferred line length.
+Using one of our structs as a storage item is not significantly different than using a primitive
+type. When using a generic struct, we must supply all of the generic type parameters. This snippet
+shows how to supply thos parameters when you have a type alias (like we do for `InnerThing`) as well
+as when you don't. Whether to include the type alias is a matter of style and taste, but it is
+generally preferred when the entire type exceeds the preferred line length.
 
 ```rust, ignore
 decl_storage! {
@@ -76,7 +96,9 @@ fn insert_inner_thing(origin, number: u32, hash: T::Hash, balance: T::Balance) -
 
 ## Nested Structs
 
-Structs can also contain other structs as their fields. We have demonstrated this with the type `SuperThing`. As you see, any generic types needed by the inner struct must also be supplied to the outer.
+Structs can also contain other structs as their fields. We have demonstrated this with the type
+`SuperThing`. As you see, any generic types needed by the inner struct must also be supplied to the
+outer.
 
 ```rust, ignore
 #[derive(Encode, Decode, Default, RuntimeDebug)]

--- a/text/3-entrees/testing/common.md
+++ b/text/3-entrees/testing/common.md
@@ -1,15 +1,24 @@
 # Common Tests
 
-To verify that our pallet code behaves as expected, it is necessary to check a few conditions with unit tests. Intuitively, the order of the testing may resemble the structure of runtime method development.
-1. Within each runtime method, declarative checks are made prior to any state change. These checks ensure that any required conditions are met before all changes occur; need to ensure that [panics panic](#panicspanic).
+To verify that our pallet code behaves as expected, it is necessary to check a few conditions with
+unit tests. Intuitively, the order of the testing may resemble the structure of runtime method
+development.
+
+1. Within each runtime method, declarative checks are made prior to any state change. These checks
+   ensure that any required conditions are met before all changes occur; need to ensure that
+   [panics panic](#panicspanic).
 2. Next, verify that the [expected storage changes occurred](#storage).
 3. Finally, check that the [expected events were emitted](#events) with correct values.
 
 ### Checks before Changes are Enforced (i.e. Panics Panic) <a name = "panicspanic"></a>
 
-The `Verify First, Write Last` paradigm encourages verifying certain conditions before changing storage values. In tests, it might be desirable to verify that invalid inputs return the expected error message.
+The `Verify First, Write Last` paradigm encourages verifying certain conditions before changing
+storage values. In tests, it might be desirable to verify that invalid inputs return the expected
+error message.
 
-In [`pallets/adding-machine`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/adding-machine), the runtime method `add` checks for overflow
+In
+[`pallets/adding-machine`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/adding-machine),
+the runtime method `add` checks for overflow
 
 ```rust, ignore
 decl_module! {
@@ -44,7 +53,8 @@ fn overflow_fails() {
 }
 ```
 
-This requires importing the `assert_err` macro from `support`. With all the previous imported objects,
+This requires importing the `assert_err` macro from `support`. With all the previous imported
+objects,
 
 ```rust, ignore
 #[cfg(test)]
@@ -54,13 +64,16 @@ mod tests {
 }
 ```
 
-For more examples, see [Substrate's own pallets](https://github.com/paritytech/substrate/tree/master/frame) -- `mock.rs` for mock runtime scaffolding and `test.rs` for unit tests.
+For more examples, see
+[Substrate's own pallets](https://github.com/paritytech/substrate/tree/master/frame) -- `mock.rs`
+for mock runtime scaffolding and `test.rs` for unit tests.
 
 ### Expected Changes to Storage are Triggered <a name = "storage"></a>
 
-*[pallets/single-value](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/single-value)*
+_[pallets/single-value](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/single-value)_
 
-Changes to storage can be checked by direct calls to the storage values. The syntax is the same as it would be in the pallet's runtime methods.
+Changes to storage can be checked by direct calls to the storage values. The syntax is the same as
+it would be in the pallet's runtime methods.
 
 ```rust, ignore
 use crate::*;
@@ -90,13 +103,16 @@ decl_storage! {
 
 ### Expected Events are Emitted <a name = "events"></a>
 
-The common way of testing expected event emission behavior requires importing `support`'s [`impl_outer_event!`](https://crates.parity.io/frame_support/macro.impl_outer_event.html) macro
+The common way of testing expected event emission behavior requires importing `support`'s
+[`impl_outer_event!`](https://crates.parity.io/frame_support/macro.impl_outer_event.html) macro
 
 ```rust, ignore
 use support::impl_outer_event;
 ```
 
-The `TestEvent` enum imports and uses the pallet's `Event` enum. The new local pallet, `hello_substrate`, re-exports the contents of the root to give a name for the current crate to `impl_outer_event!`.
+The `TestEvent` enum imports and uses the pallet's `Event` enum. The new local pallet,
+`hello_substrate`, re-exports the contents of the root to give a name for the current crate to
+`impl_outer_event!`.
 
 ```rust, ignore
 mod hello_substrate {
@@ -114,7 +130,10 @@ impl Trait for TestRuntime {
 }
 ```
 
-Testing the correct emission of events compares constructions of expected events with the entries in the [`System::events`](https://crates.parity.io/frame_system/struct.Module.html#method.events) vector of `EventRecord`s. In [`pallets/adding-machine`](https://github.com/substrate-developer-hub/recipes/tree/master//pallets/adding-machine),
+Testing the correct emission of events compares constructions of expected events with the entries in
+the [`System::events`](https://crates.parity.io/frame_system/struct.Module.html#method.events)
+vector of `EventRecord`s. In
+[`pallets/adding-machine`](https://github.com/substrate-developer-hub/recipes/tree/master//pallets/adding-machine),
 
 ```rust, ignore
 #[test]
@@ -142,7 +161,10 @@ This check requires importing from `system`
 use system::{EventRecord, Phase};
 ```
 
-A more ergonomic way of testing whether a specific event was emitted might use the `System::events().iter()`. This pattern doesn't require the previous imports, but it does require importing `RawEvent` (or `Event`) from the pallet and `ensure_signed` from `system` to convert signed extrinsics to the underlying `AccountId`,
+A more ergonomic way of testing whether a specific event was emitted might use the
+`System::events().iter()`. This pattern doesn't require the previous imports, but it does require
+importing `RawEvent` (or `Event`) from the pallet and `ensure_signed` from `system` to convert
+signed extrinsics to the underlying `AccountId`,
 
 ```rust, ignore
 #[cfg(test)]
@@ -154,7 +176,8 @@ mod tests {
 }
 ```
 
-In [`pallets/hello-substrate`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/hello-substrate),
+In
+[`pallets/hello-substrate`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/hello-substrate),
 
 ```rust, ignore
 #[test]
@@ -172,4 +195,7 @@ fn last_value_updates() {
 }
 ```
 
-This test constructs an `expected_event1` based on the event that the developer expects will be emitted upon the successful execution of logic in `HelloSubstrate::set_value`. The `assert!()` statement checks if the `expected_event1` matches the `.event` field for any `EventRecord` in the `System::events()` vector.
+This test constructs an `expected_event1` based on the event that the developer expects will be
+emitted upon the successful execution of logic in `HelloSubstrate::set_value`. The `assert!()`
+statement checks if the `expected_event1` matches the `.event` field for any `EventRecord` in the
+`System::events()` vector.

--- a/text/3-entrees/testing/externalities.md
+++ b/text/3-entrees/testing/externalities.md
@@ -1,6 +1,9 @@
 # Custom Test Environment
 
-[`execution-schedule`](../execution-schedule.md)'s configuration trait has three [configurable constants](../constants.md). For this mock runtime, the `ExtBuilder` defines setters to enable the `TestExternalities` instance for each unit test to configure the local test runtime environment with different value assignments. For context, the `Trait` for `execution-schedule`,
+[`execution-schedule`](../execution-schedule.md)'s configuration trait has three
+[configurable constants](../constants.md). For this mock runtime, the `ExtBuilder` defines setters
+to enable the `TestExternalities` instance for each unit test to configure the local test runtime
+environment with different value assignments. For context, the `Trait` for `execution-schedule`,
 
 ```rust, ignore
 // other type aliases
@@ -21,9 +24,12 @@ pub trait Trait: system::Trait {
 }
 ```
 
-The mock runtime environment extends the [previously discussed](./mock.md) `ExtBuilder` pattern with fields for each configurable constant and a default implementation.
+The mock runtime environment extends the [previously discussed](./mock.md) `ExtBuilder` pattern with
+fields for each configurable constant and a default implementation.
 
-> This completes the [builder](https://youtu.be/geovSK3wMB8?t=729) pattern by defining a default configuraton to be used in a plurality of test cases while also providing setter methods to overwrite the values for each field.
+> This completes the [builder](https://youtu.be/geovSK3wMB8?t=729) pattern by defining a default
+> configuraton to be used in a plurality of test cases while also providing setter methods to
+> overwrite the values for each field.
 
 ```rust, ignore
 pub struct ExtBuilder {
@@ -42,7 +48,8 @@ impl Default for ExtBuilder {
 }
 ```
 
-The setter methods for each configurable constant are defined in the `ExtBuilder` methods. This allows each instance of `ExtBuilder` to set the constant parameters for the unit test in question.
+The setter methods for each configurable constant are defined in the `ExtBuilder` methods. This
+allows each instance of `ExtBuilder` to set the constant parameters for the unit test in question.
 
 ```rust, ignore
 impl ExtBuilder {
@@ -62,7 +69,9 @@ impl ExtBuilder {
 }
 ```
 
-To allow for separate copies of the constant objects to be used in each thread, the variables assigned as constants are declared as [`thread_local!`](https://crates.parity.io/thread_local/index.html),
+To allow for separate copies of the constant objects to be used in each thread, the variables
+assigned as constants are declared as
+[`thread_local!`](https://crates.parity.io/thread_local/index.html),
 
 ```rust, ignore
 thread_local! {
@@ -72,7 +81,8 @@ thread_local! {
 }
 ```
 
-Each configurable constant type also maintains unit structs with implementation of `Get<T>` from the type `T` assigned to the pallet constant in the mock runtime implementation.
+Each configurable constant type also maintains unit structs with implementation of `Get<T>` from the
+type `T` assigned to the pallet constant in the mock runtime implementation.
 
 ```rust, ignore
 pub struct SignalQuota;
@@ -96,7 +106,9 @@ impl Get<u32> for TaskLimit {
     }
 }
 ```
-The build method on `ExtBuilder` sets the associated constants before building the default storage configuration.
+
+The build method on `ExtBuilder` sets the associated constants before building the default storage
+configuration.
 
 ```rust, ignore
 impl ExtBuilder {
@@ -123,7 +135,9 @@ fn fake_test() {
 }
 ```
 
-To configure a test environment in which the `execution_frequency` is set to `2`, the `eras_change_correctly` test invokes the `execution_frequency` setter declared in as a method on `ExtBuilder`,
+To configure a test environment in which the `execution_frequency` is set to `2`, the
+`eras_change_correctly` test invokes the `execution_frequency` setter declared in as a method on
+`ExtBuilder`,
 
 ```rust, ignore
 #[test]
@@ -137,6 +151,10 @@ fn fake_test2() {
 }
 ```
 
-The test environment mocked above is actually used for the cursory and incomplete test `eras_change_correctly`. This test guided the structure of the if condition in `on_initialize` to periodically reset the `SignalBank` and increment the `Era`.
+The test environment mocked above is actually used for the cursory and incomplete test
+`eras_change_correctly`. This test guided the structure of the if condition in `on_initialize` to
+periodically reset the `SignalBank` and increment the `Era`.
 
-For more examples of the mock runtime scaffolding pattern used in [`execution-schedule`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/execution-schedule), see `balances/mock.rs` and `contract/tests.rs`.
+For more examples of the mock runtime scaffolding pattern used in
+[`execution-schedule`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/execution-schedule),
+see `balances/mock.rs` and `contract/tests.rs`.

--- a/text/3-entrees/testing/index.md
+++ b/text/3-entrees/testing/index.md
@@ -1,28 +1,36 @@
 # Testing
 
-Although the Rust compiler ensures safe memory management, it cannot formally verify the correctness of a program's logic. Fortunately, Rust also comes with great libraries and documentation for writing unit and integration tests. When you initiate code with Cargo, test scaffolding is automatically generated to simplify the developer experience. Basic testing concepts and syntax are covered in depth in [Chapter 11 of the Rust Book](https://doc.rust-lang.org/book/ch11-00-testing.html).
+Although the Rust compiler ensures safe memory management, it cannot formally verify the correctness
+of a program's logic. Fortunately, Rust also comes with great libraries and documentation for
+writing unit and integration tests. When you initiate code with Cargo, test scaffolding is
+automatically generated to simplify the developer experience. Basic testing concepts and syntax are
+covered in depth in
+[Chapter 11 of the Rust Book](https://doc.rust-lang.org/book/ch11-00-testing.html).
 
-* [Basic Test Environments](./mock.md)
-* [Common Tests](./common.md)
-* [Off-chain Worker Test Environment](./off-chain-workers.md)
-* [Custom Test Environment](./externalities.md)
+-   [Basic Test Environments](./mock.md)
+-   [Common Tests](./common.md)
+-   [Off-chain Worker Test Environment](./off-chain-workers.md)
+-   [Custom Test Environment](./externalities.md)
 
-There's also more rigorous testing systems ranging from mocking and fuzzing to formal verification. See [quickcheck](https://docs.rs/quickcheck/0.9.0/quickcheck/) for an example of a property-based testing framework ported from Haskell to Rust.
+There's also more rigorous testing systems ranging from mocking and fuzzing to formal verification.
+See [quickcheck](https://docs.rs/quickcheck/0.9.0/quickcheck/) for an example of a property-based
+testing framework ported from Haskell to Rust.
 
 ## Kitchen Pallets with Unit Tests
 
 The following modules in the kitchen have partial unit test coverage
-- [`adding-machine`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/adding-machine)
-- [`constant-config`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/constant-config)
-- [`double-map`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/double-map)
-- [`generic-event`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/generic-event)
-- [`offchain-demo](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/offchain-demo)
-- [`simple-event`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/simple-event)
-- [`simple-map`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/simple-map)
-- [`single-value`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/single-value)
-- [`storage-cache`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/storage-cache)
-- [`struct-storage`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/struct-storage)
-- [`vec-set`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/vec-set)
+
+-   [`adding-machine`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/adding-machine)
+-   [`constant-config`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/constant-config)
+-   [`double-map`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/double-map)
+-   [`generic-event`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/generic-event)
+-   [`offchain-demo](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/offchain-demo)
+-   [`simple-event`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/simple-event)
+-   [`simple-map`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/simple-map)
+-   [`single-value`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/single-value)
+-   [`storage-cache`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/storage-cache)
+-   [`struct-storage`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/struct-storage)
+-   [`vec-set`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/vec-set)
 
 ### Cooking in the Kitchen (Running Tests)
 
@@ -38,11 +46,14 @@ Enter the path to the pallet to be tested
 $ cd pallets/<some-module>
 ```
 
-For example, to test `constant-config`, used in [Configurable Constants](https://substrate.dev/recipes/3-entrees/constants.html),
+For example, to test `constant-config`, used in
+[Configurable Constants](https://substrate.dev/recipes/3-entrees/constants.html),
 
 ```bash
 $ cd pallets/constant-config/
 $ cargo test
 ```
 
-Writing unit tests is one of the best ways to understand the code. Although unit tests are not comprehensive, they provide a first check to verify that the programmer's basic invariants are not violated in the presence of obvious, expected state changes.
+Writing unit tests is one of the best ways to understand the code. Although unit tests are not
+comprehensive, they provide a first check to verify that the programmer's basic invariants are not
+violated in the presence of obvious, expected state changes.

--- a/text/3-entrees/testing/mock.md
+++ b/text/3-entrees/testing/mock.md
@@ -1,24 +1,26 @@
 # Mock Runtime for Unit Testing
 
-*See [Testing](./index.html) page for list of kitchen pallets with unit test coverage.*
+_See [Testing](./index.html) page for list of kitchen pallets with unit test coverage._
 
 There are two main patterns on writing tests for pallets. We can put the tests:
 
-1. At the bottom of the pallet, place unit tests in a separate Rust module with a special compilation flag
+1. At the bottom of the pallet, place unit tests in a separate Rust module with a special
+   compilation flag
 
-	```rust, ignore
-	#[cfg(test)]
-	mod tests {
-		// -- snip --
-	}
-	```
+    ```rust, ignore
+    #[cfg(test)]
+    mod tests {
+    	// -- snip --
+    }
+    ```
 
-2. In a separate file called `tests.rs` inside `src` folder, and conditionally include tests inside the main `lib.rs`. At the top of the `lib.rs`
+2. In a separate file called `tests.rs` inside `src` folder, and conditionally include tests inside
+   the main `lib.rs`. At the top of the `lib.rs`
 
-	```rust, ignore
-	#[cfg(test)]
-	mod tests;
-	```
+    ```rust, ignore
+    #[cfg(test)]
+    mod tests;
+    ```
 
 Now, to use the logic from the pallet under test, bring `Module` and `Trait` into scope.
 
@@ -69,9 +71,12 @@ Now, declare the mock runtime as a unit structure
 pub struct TestRuntime;
 ```
 
-The `derive` macro attribute provides implementations of the `Clone + PartialEq + Eq + Debug` traits for the `TestRuntime` struct.
+The `derive` macro attribute provides implementations of the `Clone + PartialEq + Eq + Debug` traits
+for the `TestRuntime` struct.
 
-The mock runtime also needs to implement the tested pallet's `Trait`. If it is unnecessary to test the pallet's `Event` type, the type can be set to `()`. See further below to test the pallet's `Event` enum.
+The mock runtime also needs to implement the tested pallet's `Trait`. If it is unnecessary to test
+the pallet's `Event` type, the type can be set to `()`. See further below to test the pallet's
+`Event` enum.
 
 ```rust, ignore
 impl Trait for TestRuntime {
@@ -85,7 +90,8 @@ Next, we create a new type that wraps the mock `TestRuntime` in the pallet's `Mo
 pub type TestPallet = Module<TestRuntime>;
 ```
 
-It may be helpful to read this as type aliasing our configured mock runtime to work with the pallet's `Module`, which is what is ultimately being tested.
+It may be helpful to read this as type aliasing our configured mock runtime to work with the
+pallet's `Module`, which is what is ultimately being tested.
 
 In many cases, the pallet's `Trait` is further bound by `system::Trait` like:
 
@@ -95,8 +101,8 @@ pub trait Trait: system::Trait {
 }
 ```
 
-The mock runtime must inherit and define the `system::Trait` associated types. To do so, `impl` the `system::Trait`
-for `TestRuntime` with types created previously and imported from other crates.
+The mock runtime must inherit and define the `system::Trait` associated types. To do so, `impl` the
+`system::Trait` for `TestRuntime` with types created previously and imported from other crates.
 
 ```rust, ignore
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -144,7 +150,9 @@ pub type System = system::Module<TestRuntime>;
 pub type TestPallet = Module<TestRuntime>;
 ```
 
-With this, it is possible to use this type in the unit tests. For example, the block number can be set with [`set_block_number`](https://crates.parity.io/frame_system/struct.Module.html#method.set_block_number)
+With this, it is possible to use this type in the unit tests. For example, the block number can be
+set with
+[`set_block_number`](https://crates.parity.io/frame_system/struct.Module.html#method.set_block_number)
 
 ```rust, ignore
 #[test]
@@ -165,7 +173,8 @@ To build the test runtime environment, import `runtime_io`
 use runtime_io;
 ```
 
-In the `Cargo.toml`, this only needs to be imported under `dev-dependencies` since it is only used in the `tests` module. It also doesn't need to be feature gated in the `std` feature.
+In the `Cargo.toml`, this only needs to be imported under `dev-dependencies` since it is only used
+in the `tests` module. It also doesn't need to be feature gated in the `std` feature.
 
 ```
 [dev-dependencies.sp-io]
@@ -174,14 +183,24 @@ default-features = false
 version = '2.0.0-alpha.7'
 ```
 
-There is more than one pattern for building a mock runtime environment for testing pallet logic. Two patterns are presented below. The latter is generally favored for reasons discussed in [custom test environment](./externalities.md)
-* [`new_test_ext`](#newext) -  consolidates all the logic for building the environment to a single public method, but isn't relatively configurable (i.e. uses one set of pallet constants)
-* [`ExtBuilder`](#extbuilder) - define methods on the unit struct `ExtBuilder` to facilitate a flexible environment for tests (i.e. can reconfigure pallet constants in every test if necessary)
+There is more than one pattern for building a mock runtime environment for testing pallet logic. Two
+patterns are presented below. The latter is generally favored for reasons discussed in
+[custom test environment](./externalities.md)
+
+-   [`new_test_ext`](#newext) - consolidates all the logic for building the environment to a single
+    public method, but isn't relatively configurable (i.e. uses one set of pallet constants)
+-   [`ExtBuilder`](#extbuilder) - define methods on the unit struct `ExtBuilder` to facilitate a
+    flexible environment for tests (i.e. can reconfigure pallet constants in every test if
+    necessary)
 
 ## new_test_ext <a name = "newext"><a/>
-*[`pallets/smpl-treasury`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/charity)*
 
-In [`smpl-treasury`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/charity), use the `balances::GenesisConfig` and the pallet's `Genesis::<TestRuntime>` to set the balances of the test accounts and establish council membership in the returned test environment.
+_[`pallets/smpl-treasury`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/charity)_
+
+In
+[`smpl-treasury`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/charity),
+use the `balances::GenesisConfig` and the pallet's `Genesis::<TestRuntime>` to set the balances of
+the test accounts and establish council membership in the returned test environment.
 
 ```rust, ignore
 pub fn new_test_ext() -> runtime_io::TestExternalities {
@@ -218,7 +237,9 @@ pub fn new_test_ext() -> runtime_io::TestExternalities {
 }
 ```
 
-More specifically, this sets the `AccountId`s in the range of `[1, 7]` inclusive as the members of the `council`. This is expressed in the `decl_module` block with the addition of an `add_extra_genesis` block,
+More specifically, this sets the `AccountId`s in the range of `[1, 7]` inclusive as the members of
+the `council`. This is expressed in the `decl_module` block with the addition of an
+`add_extra_genesis` block,
 
 ```rust, ignore
 add_extra_genesis {
@@ -229,7 +250,9 @@ add_extra_genesis {
 }
 ```
 
-To use `new_test_ext` in a runtime test, we call the method and call [`execute_with`](https://crates.parity.io/sp_state_machine/struct.TestExternalities.html#method.execute_with) on the returned `runtime_io::TestExternalities`
+To use `new_test_ext` in a runtime test, we call the method and call
+[`execute_with`](https://crates.parity.io/sp_state_machine/struct.TestExternalities.html#method.execute_with)
+on the returned `runtime_io::TestExternalities`
 
 ```rust, ignore
 #[test]
@@ -240,20 +263,29 @@ fn fake_test() {
 }
 ```
 
-`execute_with` executes all logic expressed in the closure within the configured runtime test environment specified in `new_test_ext`
+`execute_with` executes all logic expressed in the closure within the configured runtime test
+environment specified in `new_test_ext`
 
 ## ExtBuilder <a name = "extbuilder"></a>
-*[`pallets/struct-storage`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/struct-storage)*
 
-Another approach for a more flexible runtime test environment instantiates a unit struct `ExtBuilder`,
+_[`pallets/struct-storage`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/struct-storage)_
+
+Another approach for a more flexible runtime test environment instantiates a unit struct
+`ExtBuilder`,
 
 ```rust, ignore
 pub struct ExtBuilder;
 ```
 
-The behavior for constructing the test environment is contained the methods on the `ExtBuilder` unit structure. This fosters multiple levels of configuration depending on if the test requires a common default instance of the environment or a more specific edge case configuration. The latter is explored in more detail in [Custom Test Environment](./externalities.md).
+The behavior for constructing the test environment is contained the methods on the `ExtBuilder` unit
+structure. This fosters multiple levels of configuration depending on if the test requires a common
+default instance of the environment or a more specific edge case configuration. The latter is
+explored in more detail in [Custom Test Environment](./externalities.md).
 
-Like `new_test_ext`, the `build()` method on the `ExtBuilder` object returns an instance of [`TestExternalities`](https://crates.parity.io/sp_state_machine/struct.TestExternalities.html). [Externalities](https://crates.parity.io/sp_externalities/index.html) are an abstraction that allows the runtime to access features of the outer node such as storage or offchain workers.
+Like `new_test_ext`, the `build()` method on the `ExtBuilder` object returns an instance of
+[`TestExternalities`](https://crates.parity.io/sp_state_machine/struct.TestExternalities.html).
+[Externalities](https://crates.parity.io/sp_externalities/index.html) are an abstraction that allows
+the runtime to access features of the outer node such as storage or offchain workers.
 
 In this case, create a mock storage from the default genesis configuration.
 
@@ -277,7 +309,10 @@ fn fake_test_example() {
 }
 ```
 
-While testing in this environment, runtimes that require signed extrinsics (aka take `origin` as a parameter) will require transactions coming from an `Origin`. This requires importing the [`impl_outer_origin`](https://crates.parity.io/frame_support/macro.impl_outer_origin.html) macro from `support`
+While testing in this environment, runtimes that require signed extrinsics (aka take `origin` as a
+parameter) will require transactions coming from an `Origin`. This requires importing the
+[`impl_outer_origin`](https://crates.parity.io/frame_support/macro.impl_outer_origin.html) macro
+from `support`
 
 ```rust, ignore
 use support::{impl_outer_origin};
@@ -287,7 +322,10 @@ impl_outer_origin!{
 }
 ```
 
-It is possible to placed signed transactions as parameters in runtime methods that require the `origin` input. See the [full code in the kitchen](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/hello-substrate), but this looks like
+It is possible to placed signed transactions as parameters in runtime methods that require the
+`origin` input. See the
+[full code in the kitchen](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/hello-substrate),
+but this looks like
 
 ```rust, ignore
 #[test]
@@ -299,9 +337,13 @@ fn last_value_updates() {
 }
 ```
 
-Run these tests with `cargo test`, an optional parameter is the test's name to only run that test and not all tests.
+Run these tests with `cargo test`, an optional parameter is the test's name to only run that test
+and not all tests.
 
-Note that the input to `Origin::signed` is the `system::Trait`'s `AccountId` type which was set to `u64` for the `TestRuntime` implementation. In theory, this could be set to some other type as long as it conforms to the [trait bound](https://crates.parity.io/frame_system/trait.Trait.html#associatedtype.AccountId),
+Note that the input to `Origin::signed` is the `system::Trait`'s `AccountId` type which was set to
+`u64` for the `TestRuntime` implementation. In theory, this could be set to some other type as long
+as it conforms to the
+[trait bound](https://crates.parity.io/frame_system/trait.Trait.html#associatedtype.AccountId),
 
 ```rust, ignore
 pub trait Trait: 'static + Eq + Clone {
@@ -313,8 +355,8 @@ pub trait Trait: 'static + Eq + Clone {
 
 ### Setting for Testing Event Emittances
 
-Events are not emitted on block 0. So when testing for whether events are emitted, we manually
-set the block number in the test environment from 0 to 1 as the following:
+Events are not emitted on block 0. So when testing for whether events are emitted, we manually set
+the block number in the test environment from 0 to 1 as the following:
 
 ```rust
 impl ExtBuilder {

--- a/text/3-entrees/testing/off-chain-workers.md
+++ b/text/3-entrees/testing/off-chain-workers.md
@@ -1,12 +1,16 @@
 # Off-chain Worker Test Environment
 
-Learn more about how to set up and use offchain-workers in the [offchain-demo entree](/3-entrees/off-chain-workers/index.md).
+Learn more about how to set up and use offchain-workers in the
+[offchain-demo entree](/3-entrees/off-chain-workers/index.md).
 
 ## Mock Runtime Setup
 
-In addition to everything we need to set up in [Basic Test Environment](./mock.md), we also need to set up the mock for `SubmitTransaction`, and implement the `CreateTransaction` trait for the runtime.
+In addition to everything we need to set up in [Basic Test Environment](./mock.md), we also need to
+set up the mock for `SubmitTransaction`, and implement the `CreateTransaction` trait for the
+runtime.
 
-src: [`pallets/offchain-demo/src/tests.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/offchain-demo/src/tests.rs)
+src:
+[`pallets/offchain-demo/src/tests.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/offchain-demo/src/tests.rs)
 
 ```rust
 type TestExtrinsic = TestXt<Call<TestRuntime>, ()>;
@@ -42,9 +46,14 @@ impl system::offchain::CreateTransaction<TestRuntime, TestExtrinsic> for TestRun
 
 ## Getting the Transaction Pool and Off-chain State
 
-When writing test cases for off-chain workers, we need to look into the transaction pool and current off-chain state to ensure a certain transaction has made its way, and was passed with the right parameters and signature. So in addition to the regular test environment `TestExternalities`, we also need to return references to the transaction pool state and off-chain state for future inspection.
+When writing test cases for off-chain workers, we need to look into the transaction pool and current
+off-chain state to ensure a certain transaction has made its way, and was passed with the right
+parameters and signature. So in addition to the regular test environment `TestExternalities`, we
+also need to return references to the transaction pool state and off-chain state for future
+inspection.
 
-src: [`pallets/offchain-demo/src/tests.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/offchain-demo/src/tests.rs)
+src:
+[`pallets/offchain-demo/src/tests.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/offchain-demo/src/tests.rs)
 
 ```rust
 pub struct ExtBuilder;
@@ -83,11 +92,16 @@ impl ExtBuilder {
 
 ## Testing Off-chain Worker
 
-When we write tests for off-chain workers, we should test only what our off-chain workers do. For example, when our off-chain workers will eventually make a signed transaction to dispatch function A, which does B, C, and D, we write our test for the off-chain worker to test only if function A is dispatched. But whether function A actually does B, C, and D should be tested separately in another test case. This way we keep our tests more robust.
+When we write tests for off-chain workers, we should test only what our off-chain workers do. For
+example, when our off-chain workers will eventually make a signed transaction to dispatch function
+A, which does B, C, and D, we write our test for the off-chain worker to test only if function A is
+dispatched. But whether function A actually does B, C, and D should be tested separately in another
+test case. This way we keep our tests more robust.
 
 This is how we write our test cases.
 
-src: [`pallets/offchain-demo/src/tests.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/offchain-demo/src/tests.rs)
+src:
+[`pallets/offchain-demo/src/tests.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/offchain-demo/src/tests.rs)
 
 ```rust
 #[test]
@@ -115,8 +129,10 @@ fn offchain_send_signed_tx() {
 
 We test that when `OffchainDemo::send_signed(num)` function is being called,
 
-- There is only one transaction made to the transaction pool.
-- The transaction is signed.
-- The transaction is calling the `Call::submit_number_signed` on-chain function with the parameter `num`.
+-   There is only one transaction made to the transaction pool.
+-   The transaction is signed.
+-   The transaction is calling the `Call::submit_number_signed` on-chain function with the parameter
+    `num`.
 
-What's performed by the `Call::submit_number_signed` on-chain function is tested in another test case, which would be similar to how you [test for dispatched extrinsic calls](./common.md).
+What's performed by the `Call::submit_number_signed` on-chain function is tested in another test
+case, which would be similar to how you [test for dispatched extrinsic calls](./common.md).

--- a/text/3-entrees/weights.md
+++ b/text/3-entrees/weights.md
@@ -1,13 +1,20 @@
 # Computational Resources and Weights
-*[`pallets/weights`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/weights)*
 
-Any computational resources used by a transaction must be accounted for so that appropriate fees can be applied, and it is a pallet author's job to ensure that this accounting happens. Substrate provides a mechanism known as transaction weighting to quantify the resources consumed while executing a transaction.
+_[`pallets/weights`](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/weights)_
 
-*Indeed, mispriced EVM operations have shown how operations that underestimate cost can open economic DOS attack vectors: [Onwards; Underpriced EVM Operations](https://www.parity.io/onwards/), [Under-Priced DOS Attacks on Ethereum](https://www4.comp.polyu.edu.hk/~csxluo/DoSEVM.pdf)*
+Any computational resources used by a transaction must be accounted for so that appropriate fees can
+be applied, and it is a pallet author's job to ensure that this accounting happens. Substrate
+provides a mechanism known as transaction weighting to quantify the resources consumed while
+executing a transaction.
 
+_Indeed, mispriced EVM operations have shown how operations that underestimate cost can open
+economic DOS attack vectors: [Onwards; Underpriced EVM Operations](https://www.parity.io/onwards/),
+[Under-Priced DOS Attacks on Ethereum](https://www4.comp.polyu.edu.hk/~csxluo/DoSEVM.pdf)_
 
 ## Assigning Transaction Weights
+
 Pallet authors can annotate their dispatchable function with a weight using syntax like this,
+
 ```rust, ignore
 #[weight = <Some Weighting Instance>]
 fn some_call(...) -> Result {
@@ -15,7 +22,9 @@ fn some_call(...) -> Result {
 }
 ```
 
-For simple transactions a fixed weight will do. Substrate allows simply specifying a constant integer in cases situations like this.
+For simple transactions a fixed weight will do. Substrate allows simply specifying a constant
+integer in cases situations like this.
+
 ```rust, ignore
 decl_module! {
 	pub struct Module<T: Trait> for enum Call {
@@ -27,8 +36,12 @@ decl_module! {
 		}
 ```
 
-For more complex transactions, custom weight calculations can be performed that consider the parameters passed to the call. This snippet shows a weighting struct that weighs transactions where the first parameter
-is a `boo`l. If the first parameter is `true`, then the weight is linear in the second parameter. Otherwise the weight is constant. A transaction where this weighting scheme makes sense is demonstrated in the kitchen.
+For more complex transactions, custom weight calculations can be performed that consider the
+parameters passed to the call. This snippet shows a weighting struct that weighs transactions where
+the first parameter is a `boo`l. If the first parameter is `true`, then the weight is linear in the
+second parameter. Otherwise the weight is constant. A transaction where this weighting scheme makes
+sense is demonstrated in the kitchen.
+
 ```rust, ignore
 pub struct Conditional(u32);
 
@@ -45,12 +58,11 @@ impl WeighData<(&bool, &u32)> for Conditional {
 }
 ```
 
-In addition to the [`WeightData`
-Trait](https://crates.parity.io/frame_support/weights/trait.WeighData.html), shown
+In addition to the
+[`WeightData` Trait](https://crates.parity.io/frame_support/weights/trait.WeighData.html), shown
 above, types that are used to calculate transaction weights, must also implement
 [`ClassifyDispatch`](https://crates.parity.io/frame_support/weights/trait.ClassifyDispatch.html),
 and [`PaysFee`](https://crates.parity.io/frame_support/weights/trait.PaysFee.html).
-
 
 ```rust,ignore
 impl<T> ClassifyDispatch<T> for Conditional {
@@ -73,13 +85,15 @@ The complete code for this example as well as several others can be found in the
 
 ## Cautions
 
-While you can make reasonable estimates of resource consumption at
-design time, it is always best to actually measure the resources
-required of your functions through an empirical process. Failure to
-perform such rigorous measurement may result in an economically
-insecure chain.
+While you can make reasonable estimates of resource consumption at design time, it is always best to
+actually measure the resources required of your functions through an empirical process. Failure to
+perform such rigorous measurement may result in an economically insecure chain.
 
-While it isn't enforced, calculating a transaction's weight should itself be a cheap operation. If the weight calculation itself is expensive, your chain will be insecure.
+While it isn't enforced, calculating a transaction's weight should itself be a cheap operation. If
+the weight calculation itself is expensive, your chain will be insecure.
 
 ## What About Fees?
-Weights are used only to describe the computational resources consumed by a transaction, and enable accounting of these resources. To learn how to turn these weights into actual fees charged to transactors, continue to the recipe on [Fees](./fees.md).
+
+Weights are used only to describe the computational resources consumed by a transaction, and enable
+accounting of these resources. To learn how to turn these weights into actual fees charged to
+transactors, continue to the recipe on [Fees](./fees.md).

--- a/text/SUMMARY.md
+++ b/text/SUMMARY.md
@@ -1,53 +1,49 @@
 # Summary
 
 [Introduction](./introduction.md)
-- [Preparing Your Kitchen](./1-prepare-kitchen/index.md)
-	- [Building A Node](./1-prepare-kitchen/1-build-node.md)
-	- [Interacting with a Node](./1-prepare-kitchen/2-interact-node.md)
-	- [Kitchen Organization](./1-prepare-kitchen/3-kitchen-organization.md)
-- [Appetizers](./2-appetizers/index.md)
-	- [Hello Substrate](./2-appetizers/1-hello-substrate.md)
-	- [Single Value Storage](./2-appetizers/2-storage-values.md)
-	- [Handling Errors](./2-appetizers/3-errors.md)
-	- [Events Verify Execution](./2-appetizers/4-events.md)
-- [Entrees](./3-entrees/index.md)
-	- [Runtime Storage API](./3-entrees/storage-api/index.md)
-		- [Storage Maps](./3-entrees/storage-api/storage-maps.md)
-		- [Cache Locally > Storage Calls](./3-entrees/storage-api/cache.md)
-		- [Sets, Vectors, Iteration](./3-entrees/storage-api/sets-vecs-iteration.md)
-		- [Subgroup Removal by Subkey: Double Maps](./3-entrees/storage-api/double.md)
-		- [Efficient Subgroup Removal by Subkey: Child Tries](./3-entrees/storage-api/childtries.md)
-		- [Storing custom structs](./3-entrees/storage-api/structs.md)
-		- [Ringbuffer Queue](./3-entrees/storage-api/ringbuffer.md)
-	- [Basic Token](./3-entrees/basic-token.md)
-	- [Configurable Constants](./3-entrees/constants.md)
-	- [Instantiable Pallets](./3-entrees/instantiable.md)
-	- [Weights for Resource Accounting](./3-entrees/weights.md)
-	- [Transaction Fees for Economic Security](./3-entrees/fees.md)
-	- [Charity and Imbalances](./3-entrees/charity.md)
-	- [Fixed Point Arithmetic](./3-entrees/fixed-point.md)
-	- [Off-chain Workers](./3-entrees/off-chain-workers/index.md)
-		- [Transactions](./3-entrees/off-chain-workers/transactions.md)
-		- [HTTP Fetching & JSON Parsing](./3-entrees/off-chain-workers/http-json.md)
-		- [Local Storage](./3-entrees/off-chain-workers/storage.md)
-	- [Runtime APIs](./3-entrees/runtime-api.md)
-	- [Custom RPCs](./3-entrees/custom-rpc.md)
-	- [Sha3 Pow Consensus Algorithms](./3-entrees/sha3-pow-consensus.md)
-	- [Basic Proof of Work Node](./3-entrees/basic-pow.md)
-	- [Hybrid PoW/PoS Consensus Node](./3-entrees/hybrid-consensus.md)
-	- [Manual Seal Consensus](./3-entrees/manual-seal.md)
-	- [Kitchen Node - An reusable instant seal node](./3-entrees/kitchen-node.md)
-	- [Currency Types](./3-entrees/currency.md)
-	- [Generating Randomness](./3-entrees/randomness.md)
-	- [Execution Schedule](./3-entrees/execution-schedule.md)
-	- [Permissioned Methods](./3-entrees/permissioned-methods.md)
-	- [Testing](./3-entrees/testing/index.md)
-		- [Basic Test Environments](./3-entrees/testing/mock.md)
-		- [Common Tests](./3-entrees/testing/common.md)
-		- [Off-chain Worker Test Environment](./3-entrees/testing/off-chain-workers.md)
-		- [Custom Test Environment](./3-entrees/testing/externalities.md)
-	- [Safe Math](./3-entrees/safemath.md)
 
------------
+-   [Preparing Your Kitchen](./1-prepare-kitchen/index.md) -
+    [Building A Node](./1-prepare-kitchen/1-build-node.md) -
+    [Interacting with a Node](./1-prepare-kitchen/2-interact-node.md) -
+    [Kitchen Organization](./1-prepare-kitchen/3-kitchen-organization.md)
+-   [Appetizers](./2-appetizers/index.md) - [Hello Substrate](./2-appetizers/1-hello-substrate.md) -
+    [Single Value Storage](./2-appetizers/2-storage-values.md) -
+    [Handling Errors](./2-appetizers/3-errors.md) -
+    [Events Verify Execution](./2-appetizers/4-events.md)
+-   [Entrees](./3-entrees/index.md) - [Runtime Storage API](./3-entrees/storage-api/index.md) -
+    [Storage Maps](./3-entrees/storage-api/storage-maps.md) -
+    [Cache Locally > Storage Calls](./3-entrees/storage-api/cache.md) -
+    [Sets, Vectors, Iteration](./3-entrees/storage-api/sets-vecs-iteration.md) -
+    [Subgroup Removal by Subkey: Double Maps](./3-entrees/storage-api/double.md) -
+    [Efficient Subgroup Removal by Subkey: Child Tries](./3-entrees/storage-api/childtries.md) -
+    [Storing custom structs](./3-entrees/storage-api/structs.md) -
+    [Ringbuffer Queue](./3-entrees/storage-api/ringbuffer.md) -
+    [Basic Token](./3-entrees/basic-token.md) - [Configurable Constants](./3-entrees/constants.md) -
+    [Instantiable Pallets](./3-entrees/instantiable.md) -
+    [Weights for Resource Accounting](./3-entrees/weights.md) -
+    [Transaction Fees for Economic Security](./3-entrees/fees.md) -
+    [Charity and Imbalances](./3-entrees/charity.md) -
+    [Fixed Point Arithmetic](./3-entrees/fixed-point.md) -
+    [Off-chain Workers](./3-entrees/off-chain-workers/index.md) -
+    [Transactions](./3-entrees/off-chain-workers/transactions.md) -
+    [HTTP Fetching & JSON Parsing](./3-entrees/off-chain-workers/http-json.md) -
+    [Local Storage](./3-entrees/off-chain-workers/storage.md) -
+    [Runtime APIs](./3-entrees/runtime-api.md) - [Custom RPCs](./3-entrees/custom-rpc.md) -
+    [Sha3 Pow Consensus Algorithms](./3-entrees/sha3-pow-consensus.md) -
+    [Basic Proof of Work Node](./3-entrees/basic-pow.md) -
+    [Hybrid PoW/PoS Consensus Node](./3-entrees/hybrid-consensus.md) -
+    [Manual Seal Consensus](./3-entrees/manual-seal.md) -
+    [Kitchen Node - An reusable instant seal node](./3-entrees/kitchen-node.md) -
+    [Currency Types](./3-entrees/currency.md) - [Generating Randomness](./3-entrees/randomness.md) -
+    [Execution Schedule](./3-entrees/execution-schedule.md) -
+    [Permissioned Methods](./3-entrees/permissioned-methods.md) -
+    [Testing](./3-entrees/testing/index.md) -
+    [Basic Test Environments](./3-entrees/testing/mock.md) -
+    [Common Tests](./3-entrees/testing/common.md) -
+    [Off-chain Worker Test Environment](./3-entrees/testing/off-chain-workers.md) -
+    [Custom Test Environment](./3-entrees/testing/externalities.md) -
+    [Safe Math](./3-entrees/safemath.md)
+
+---
 
 [More Resources](./more-resources.md)

--- a/text/drafts/chainspec.md
+++ b/text/drafts/chainspec.md
@@ -1,6 +1,8 @@
 # Minimal Blockchain Configuration
 
-[Substate Node](https://github.com/paritytech/substrate/tree/master/node) is Substrate's pre-baked blockchain client. By creating and modifying a Substrate Node chain specification file, it is easy to configure a new chain and launch a corresponding testnet.
+[Substate Node](https://github.com/paritytech/substrate/tree/master/node) is Substrate's pre-baked
+blockchain client. By creating and modifying a Substrate Node chain specification file, it is easy
+to configure a new chain and launch a corresponding testnet.
 
 To use the default chain that comes pre-configured with Substrate Node, enter the following command:
 
@@ -8,7 +10,9 @@ To use the default chain that comes pre-configured with Substrate Node, enter th
 substrate build-spec --chain=staging > ~/chainspec.json
 ```
 
-Now, it is simple to modify `~/chainspec.json` in your editor. There are a lot of individual fields for each pallet, and one very large one which contains the WASM code blob for this chain. The most intuitive field to edit is the block `period`. Change it to 10 (seconds):
+Now, it is simple to modify `~/chainspec.json` in your editor. There are a lot of individual fields
+for each pallet, and one very large one which contains the WASM code blob for this chain. The most
+intuitive field to edit is the block `period`. Change it to 10 (seconds):
 
 ```json
     "timestamp": {
@@ -28,10 +32,13 @@ To feed this into Substrate
 substrate --chain ~/mychain.json
 ```
 
-Until a validator starts producing blocks, noting will happen. To start producing blocks, pass the `--validator` option alongside the seed for the account(s) that are configured as initial authorities.
+Until a validator starts producing blocks, noting will happen. To start producing blocks, pass the
+`--validator` option alongside the seed for the account(s) that are configured as initial
+authorities.
 
 ```bash
 substrate --chain ~/mychain.json --validator --key ...
 ```
 
-Now, distribute `mychain.json` to the relevant authorities to synchronize and, depending on the list of authorities, validate the chain.
+Now, distribute `mychain.json` to the relevant authorities to synchronize and, depending on the list
+of authorities, validate the chain.

--- a/text/drafts/collide.md
+++ b/text/drafts/collide.md
@@ -1,8 +1,11 @@
 # Checking for Collisions
 
-When using unique identifiers that depend on an absence of key collision, it is best to check for key collision before adding new entries. 
+When using unique identifiers that depend on an absence of key collision, it is best to check for
+key collision before adding new entries.
 
-For example, assume an object's hash the unique identifier (key) in a map defined in the `decl_storage` block. Before adding a new `(key, value)` pair to the map, verify that the key (hash) does not already have an associated value in the map.
+For example, assume an object's hash the unique identifier (key) in a map defined in the
+`decl_storage` block. Before adding a new `(key, value)` pair to the map, verify that the key (hash)
+does not already have an associated value in the map.
 
 ```rust, ignore
 fn insert_value(origin, hash: Hash, value: u32) {
@@ -14,6 +17,9 @@ fn insert_value(origin, hash: Hash, value: u32) {
 }
 ```
 
- If it does, it is necessary to decide between the new item and the existing item to prevent an inadvertent key collision.
+If it does, it is necessary to decide between the new item and the existing item to prevent an
+inadvertent key collision.
 
-*See how the [Substrate Collectables Tutorial](https://shawntabrizi.com/substrate-collectables-workshop/#/2/generating-random-data?id=checking-for-collision) covers this pattern.*
+_See how the
+[Substrate Collectables Tutorial](https://shawntabrizi.com/substrate-collectables-workshop/#/2/generating-random-data?id=checking-for-collision)
+covers this pattern._

--- a/text/drafts/cryptography-hashing.md
+++ b/text/drafts/cryptography-hashing.md
@@ -1,9 +1,11 @@
 # Tutorial Series for Using Cryptography on Substrate
+
 > just an idea
 
 ## Hashing
 
-Substrate provides in-built support for hashing data with BlakeTwo256 algorithm. We can get this from the `system` trait.
+Substrate provides in-built support for hashing data with BlakeTwo256 algorithm. We can get this
+from the `system` trait.
 
 ```
 use runtime_primitives::traits::Hash;
@@ -22,6 +24,8 @@ decl_module! {
 }
 ```
 
-The Hashing type under the system trait expoises a function called `hash`. This function takes a reference of a byte array (`Vec<u8>`) and produces a BlakeTwo256 hash digest of it.
+The Hashing type under the system trait expoises a function called `hash`. This function takes a
+reference of a byte array (`Vec<u8>`) and produces a BlakeTwo256 hash digest of it.
 
-The code from above contained a function `get_hash` which takes a `Vec<u8>` parameter `data` and calls the `hash` function on it.
+The code from above contained a function `get_hash` which takes a `Vec<u8>` parameter `data` and
+calls the `hash` function on it.

--- a/text/drafts/cryptography-nonce.md
+++ b/text/drafts/cryptography-nonce.md
@@ -1,6 +1,10 @@
 ## Salt
 
-Sometimes we require a unique identifier for items that may take the exact same form, but have different block numbers. In the [`utxo-workshop`](https://github.com/nczhu/utxo-workshop), the UTXO set included a `salt` field for UTXO output to establish uniqueness for every transaction. This ensures that, as long as the outputs are validated in different blocks, they can both be invoked independently without leaking information regarding the `TransactionInput`'s `Signature`.
+Sometimes we require a unique identifier for items that may take the exact same form, but have
+different block numbers. In the [`utxo-workshop`](https://github.com/nczhu/utxo-workshop), the UTXO
+set included a `salt` field for UTXO output to establish uniqueness for every transaction. This
+ensures that, as long as the outputs are validated in different blocks, they can both be invoked
+independently without leaking information regarding the `TransactionInput`'s `Signature`.
 
 ```rust, ignore
 TransactionOutput {
@@ -10,15 +14,19 @@ TransactionOutput {
 }
 ```
 
-Setting `salt` to something as inconspicuous as `BlockNumber` still ensures that there arent enough of the same output in each block to open the *replay attack* vector described above.
+Setting `salt` to something as inconspicuous as `BlockNumber` still ensures that there arent enough
+of the same output in each block to open the _replay attack_ vector described above.
 
 ## Encrypted Nonce Pattern
 
 > also known as epoch reclamation
 
-Peer to peer nodes connect over an encrypted communication channels referred to as *privatization* in protocols like Libp2p. An encrypted connection can simply be bootstrapped from simple public key cryptography.
+Peer to peer nodes connect over an encrypted communication channels referred to as _privatization_
+in protocols like Libp2p. An encrypted connection can simply be bootstrapped from simple public key
+cryptography.
 
-I think we'll see this value used increasingly often in Layer 2 solutions which invoke the encrypted nonce to prove the order of off-chain messages. For this reason, I'll provide a sample here.
+I think we'll see this value used increasingly often in Layer 2 solutions which invoke the encrypted
+nonce to prove the order of off-chain messages. For this reason, I'll provide a sample here.
 
-* examples in the codebases (`Cumulus`, `Substrate`, `Polkadot`, `Rust-Libp2p`)
-* `evmap` uses this pattern...go through that...
+-   examples in the codebases (`Cumulus`, `Substrate`, `Polkadot`, `Rust-Libp2p`)
+-   `evmap` uses this pattern...go through that...

--- a/text/drafts/declarative-syntax.md
+++ b/text/drafts/declarative-syntax.md
@@ -1,17 +1,31 @@
 # Declarative Syntax
 
-Unlike conventional software development kits that abstract away low-level decisions, Substrate grants developers fine-grain control over the underlying implementation. This approach fosters high-performance, modular applications. At the same time, it also demands increased attention from developers. **With great power comes great responsibility**.
+Unlike conventional software development kits that abstract away low-level decisions, Substrate
+grants developers fine-grain control over the underlying implementation. This approach fosters
+high-performance, modular applications. At the same time, it also demands increased attention from
+developers. **With great power comes great responsibility**.
 
-Indeed, Substrate developers have to exercise incredible caution. The bare-metal control that they maintain over the runtime logic introduces new attack vectors. In the context of blockchains, the cost of bugs scale with the amount of capital secured by the application. Likewise, developers should generally abide by a few *[rules](#criteria)* when building with Substrate. These rules may not hold in every situation; Substrate offers optimization in context.
+Indeed, Substrate developers have to exercise incredible caution. The bare-metal control that they
+maintain over the runtime logic introduces new attack vectors. In the context of blockchains, the
+cost of bugs scale with the amount of capital secured by the application. Likewise, developers
+should generally abide by a few _[rules](#criteria)_ when building with Substrate. These rules may
+not hold in every situation; Substrate offers optimization in context.
 
 Each of the recipes in this section are oriented around increasing
-- [Verify First, Write Last](./ensure.md)
-- [Safe Math](./safemath.md)
-- [Permissioned Methods](./permissioned.md)
+
+-   [Verify First, Write Last](./ensure.md)
+-   [Safe Math](./safemath.md)
+-   [Permissioned Methods](./permissioned.md)
 <!-- * [checking for collisions](./collide.md) -->
 
 ## Pallet Development Criteria <a name = "criteria"></a>
 
-1. Pallets should be relatively independent pieces of code; if your pallet is tied to many other pallets, it should be a smart contract. See the [substrate-contracts-workshop](https://github.com/shawntabrizi/substrate-contracts-workshop) for more details with respect to smart contract programming on Substrate. Also, *use traits for abstracting shared behavior*.
+1. Pallets should be relatively independent pieces of code; if your pallet is tied to many other
+   pallets, it should be a smart contract. See the
+   [substrate-contracts-workshop](https://github.com/shawntabrizi/substrate-contracts-workshop) for
+   more details with respect to smart contract programming on Substrate. Also, _use traits for
+   abstracting shared behavior_.
 
-2. It should not be possible for your code to panic after storage changes. Poor error handling in Substrate can *brick* the blockchain, rendering it useless thereafter. With this in mind, it is very important to structure code according to declarative, condition-oriented design patterns.
+2. It should not be possible for your code to panic after storage changes. Poor error handling in
+   Substrate can _brick_ the blockchain, rendering it useless thereafter. With this in mind, it is
+   very important to structure code according to declarative, condition-oriented design patterns.

--- a/text/drafts/dessert.md
+++ b/text/drafts/dessert.md
@@ -1,12 +1,14 @@
-# Dessert 🍫  
+# Dessert 🍫
 
-Check out **[awesome-substrate](https://github.com/substrate-developer-hub/awesome-substrate)** for projects, events, and all the latest Substrate news!
+Check out **[awesome-substrate](https://github.com/substrate-developer-hub/awesome-substrate)** for
+projects, events, and all the latest Substrate news!
 
 ## <a href="https://github.com/substrate-developer-hub/">Featured Tutorials</a>
-* [Substrate Collectables Workshop](https://github.com/substrate-developer-hub/substrate-collectables-workshop)
-* [Substrate Verifiable Credentials Workshop](https://github.com/substrate-developer-hub/substrate-verifiable-credentials)
-* [Substrate TCR Tutorial](https://github.com/substrate-developer-hub/substrate-tcr)
-* [Substrate Contracts Workshop](https://github.com/substrate-developer-hub/substrate-contracts-workshop)
+
+-   [Substrate Collectables Workshop](https://github.com/substrate-developer-hub/substrate-collectables-workshop)
+-   [Substrate Verifiable Credentials Workshop](https://github.com/substrate-developer-hub/substrate-verifiable-credentials)
+-   [Substrate TCR Tutorial](https://github.com/substrate-developer-hub/substrate-tcr)
+-   [Substrate Contracts Workshop](https://github.com/substrate-developer-hub/substrate-contracts-workshop)
 
 <!--
 **Set Up**

--- a/text/drafts/ensure.md
+++ b/text/drafts/ensure.md
@@ -1,10 +1,17 @@
 # Verify First, Write Last
 
-Within each dispatchable function, it is important to perform requisite checks prior to any storage changes. Unlike existing smart contract platforms, Substrate requires greater attention to detail because mid-function panics will persist any prior changes made to storage.
+Within each dispatchable function, it is important to perform requisite checks prior to any storage
+changes. Unlike existing smart contract platforms, Substrate requires greater attention to detail
+because mid-function panics will persist any prior changes made to storage.
 
-**Place [`ensure!`](https://crates.parity.io/frame_support/macro.ensure.html) checks at the top of each runtime function's logic to verify that all requisite conditions are met before performing any storage changes.** This is similar to [`require()`](https://ethereum.stackexchange.com/questions/15166/difference-between-require-and-assert-and-the-difference-between-revert-and-thro) checks at the top of function bodies in Solidity contracts.
+**Place [`ensure!`](https://crates.parity.io/frame_support/macro.ensure.html) checks at the top of
+each runtime function's logic to verify that all requisite conditions are met before performing any
+storage changes.** This is similar to
+[`require()`](https://ethereum.stackexchange.com/questions/15166/difference-between-require-and-assert-and-the-difference-between-revert-and-thro)
+checks at the top of function bodies in Solidity contracts.
 
-In the [set storage and iteration](../storage/iterate.md), a vector was stored in the runtime to allow for simple membership checks for methods only available to members.
+In the [set storage and iteration](../storage/iterate.md), a vector was stored in the runtime to
+allow for simple membership checks for methods only available to members.
 
 ```rust, ignore
 decl_storage! {
@@ -20,8 +27,8 @@ impl<T: Trait> Module<T> {
 }
 ```
 
-
-"*By returning `bool`, we can easily use these methods in `ensure!` statements to verify relevant state conditions before making requests in the main runtime methods.*"
+"_By returning `bool`, we can easily use these methods in `ensure!` statements to verify relevant
+state conditions before making requests in the main runtime methods._"
 
 ```rust, ignore
 fn member_action(origin) -> Result {
@@ -32,10 +39,15 @@ fn member_action(origin) -> Result {
 }
 ```
 
-Indeed, this pattern of extracting runtime checks into separate functions and invoking the `ensure` macro in their place is useful. It produces readable code and encourages targeted testing to more easily identify the source of logic errors.
+Indeed, this pattern of extracting runtime checks into separate functions and invoking the `ensure`
+macro in their place is useful. It produces readable code and encourages targeted testing to more
+easily identify the source of logic errors.
 
-*This [github comment](https://github.com/substrate-developer-hub/substrate-collectables-workshop/pull/55#discussion_r258147961) might help when visualizing declarative patterns in practice.*
+_This
+[github comment](https://github.com/substrate-developer-hub/substrate-collectables-workshop/pull/55#discussion_r258147961)
+might help when visualizing declarative patterns in practice._
 
 **Bonus Reading**
-* [Design for Testability](https://blog.nelhage.com/2016/03/design-for-testability/)
-* [Condition-Oriented Programming](https://www.parity.io/condition-oriented-programming/)
+
+-   [Design for Testability](https://blog.nelhage.com/2016/03/design-for-testability/)
+-   [Condition-Oriented Programming](https://www.parity.io/condition-oriented-programming/)

--- a/text/drafts/enums.md
+++ b/text/drafts/enums.md
@@ -1,8 +1,13 @@
 # Ergonomic Enums
 
-In the [`utxo-workshop`](https://github.com/nczhu/utxo-workshop), the code utilizes an [enum](https://doc.rust-lang.org/rust-by-example/custom_types/enum.html) to manage a data race scenario in which a transaction could arrive before some transactions that it `require`s. 
+In the [`utxo-workshop`](https://github.com/nczhu/utxo-workshop), the code utilizes an
+[enum](https://doc.rust-lang.org/rust-by-example/custom_types/enum.html) to manage a data race
+scenario in which a transaction could arrive before some transactions that it `require`s.
 
-*Alice sends Bob 100 units and Bob sends Eve 80 of those units. Let's assume that Bob's transaction is dependent upon Alice's transaction. If Alice's transaction takes a few more seconds to arrive, we do not want to throw out Bob's transaction. Instead of panicking, we should place Bob's transaction in a temporary queue and lock it for some defined time period.*
+_Alice sends Bob 100 units and Bob sends Eve 80 of those units. Let's assume that Bob's transaction
+is dependent upon Alice's transaction. If Alice's transaction takes a few more seconds to arrive, we
+do not want to throw out Bob's transaction. Instead of panicking, we should place Bob's transaction
+in a temporary queue and lock it for some defined time period._
 
 To see this pattern in action, see the `check_transaction` runtime function:
 
@@ -10,7 +15,7 @@ To see this pattern in action, see the `check_transaction` runtime function:
 pub fn check_transaction(transaction: &Transaction) -> CheckResult<'_>
 ```
 
-This function  returns `CheckResult<'_>`. The type signature of `CheckResult<T>`:
+This function returns `CheckResult<'_>`. The type signature of `CheckResult<T>`:
 
 ```rust, ignore
 pub type CheckResult<'a> = rstd::result::Result<CheckInfo<'a>, &'static str>;
@@ -29,7 +34,10 @@ pub enum CheckInfo<'a> {
 }
 ```
 
-This reveals that in the event of a successful call, it returns either the `Total`s struct that can be easily decomposed to calculate leftover value and distribute it evenly among the authorities OR returns a wrapper around the missing UTXOs which were necessary for verification. Here's the code in `check_transaction` that expresses this logic:
+This reveals that in the event of a successful call, it returns either the `Total`s struct that can
+be easily decomposed to calculate leftover value and distribute it evenly among the authorities OR
+returns a wrapper around the missing UTXOs which were necessary for verification. Here's the code in
+`check_transaction` that expresses this logic:
 
 ```rust, ignore
 if missing_utxo.is_empty() {
@@ -46,4 +54,7 @@ if missing_utxo.is_empty() {
 }
 ```
 
-This pattern demonstrates one way to safely handle the common data race that occurs when a conditional transaction arrives in the transaction pool before the arrival of a transaction that it `require`s. *We can extract this pattern to safely handle conditional paths in our code for which panics are undesirable, but it is also preferrable to pause processing.*
+This pattern demonstrates one way to safely handle the common data race that occurs when a
+conditional transaction arrives in the transaction pool before the arrival of a transaction that it
+`require`s. _We can extract this pattern to safely handle conditional paths in our code for which
+panics are undesirable, but it is also preferrable to pause processing._

--- a/text/drafts/fuzzing.md
+++ b/text/drafts/fuzzing.md
@@ -1,9 +1,13 @@
 # Fuzzing
 
-In his 1972 essay “The Humble Programmer,” Edsger W. Dijkstra said that “Program testing can be a very effective way to show the presence of bugs, but it is hopelessly inadequate for showing their absence.” 
+In his 1972 essay “The Humble Programmer,” Edsger W. Dijkstra said that “Program testing can be a
+very effective way to show the presence of bugs, but it is hopelessly inadequate for showing their
+absence.”
 
-Formal verification is hard, but fuzzing allows us to test inputs beyond the specific cases that we think up while testing...
+Formal verification is hard, but fuzzing allows us to test inputs beyond the specific cases that we
+think up while testing...
 
 ## More Reading
-* [comparison of Rust mocking libraries](https://github.com/asomers/mock_shootout)
-* [fuzz.rs book](https://fuzz.rs/book/)
+
+-   [comparison of Rust mocking libraries](https://github.com/asomers/mock_shootout)
+-   [fuzz.rs book](https://fuzz.rs/book/)

--- a/text/drafts/maps.md
+++ b/text/drafts/maps.md
@@ -1,48 +1,61 @@
 # Hash Patterns
 
 When deciding how to store proposals in `decl_storage {}`, we can either
+
 1. hash each proposal and use the hash as a unique identifier for relevant maps
 2. use a unique proposalIndex for each
 
 ## Initial Implementation
+
 > [code](./old.rs)
 
 The first iteration of Molochameleon actually used a `type ProposalIndex = u32` to track proposals.
 
 > pick example code patterns and show why this is hard
 
-* technically it constrains the number of possible key-value pairs
-* moreso, there is head-of-line blocking and really awkard clean up
-    * it's a very synchronous, rigid pattern for managing proposals
+-   technically it constrains the number of possible key-value pairs
+-   moreso, there is head-of-line blocking and really awkard clean up
+    -   it's a very synchronous, rigid pattern for managing proposals
 
 ### Treasury (Frame Example)
 
-So why does Treasury use indexes? Well sometimes we want to closely limit proposal throughput instead of optimzing protocol flexibility.
+So why does Treasury use indexes? Well sometimes we want to closely limit proposal throughput
+instead of optimzing protocol flexibility.
 
-Also, using indexes may yield a more readable implementation. Readability and maintainability should always be regarded as key criteria when designing your pallet. This isn't some undergraduate CS project that you're hacking together to just run successfully; mistakes are expensive and ergonomic code is a necessity for careful audits.
+Also, using indexes may yield a more readable implementation. Readability and maintainability should
+always be regarded as key criteria when designing your pallet. This isn't some undergraduate CS
+project that you're hacking together to just run successfully; mistakes are expensive and ergonomic
+code is a necessity for careful audits.
 
 ## Migrating to Using Hashes as Unique Identifiers
 
-* sentence on the magic of hash functions
+-   sentence on the magic of hash functions
 
-Parity's hash functions operate on a bit digest so we need to first Encode our struct, then call encode on the local version and feed this to our hash function invocation.
+Parity's hash functions operate on a bit digest so we need to first Encode our struct, then call
+encode on the local version and feed this to our hash function invocation.
 
-* mention `derive` in this context as well...
+-   mention `derive` in this context as well...
 
-* much more ergonomic and idiomatic implementation; one in which the progress of each proposal is not contingent on the ones that come before it but instead focus on the unique state conditions (like ensuring that applicants don't have multple applications at once)
+-   much more ergonomic and idiomatic implementation; one in which the progress of each proposal is
+    not contingent on the ones that come before it but instead focus on the unique state conditions
+    (like ensuring that applicants don't have multple applications at once)
 
-* relieve fears of bad indexing causing errors where a late call references a different proposal than the one previously there...
+-   relieve fears of bad indexing causing errors where a late call references a different proposal
+    than the one previously there...
 
 **List Variants**
-* applicants can only have one application at a time
 
-When deciding on which fields of the Proposal to hash as the unique identifer, we should add just enough information to ensure uniqueness. In our case, we will choose
+-   applicants can only have one application at a time
+
+When deciding on which fields of the Proposal to hash as the unique identifer, we should add just
+enough information to ensure uniqueness. In our case, we will choose
 
 ### Council (Frame Example)
-* higher proposal throughput than `Treasury` but this can also be improved
 
+-   higher proposal throughput than `Treasury` but this can also be improved
 
 ### OPEN QUESTION
 
-* can we increase proposal throughput even more by using futures to provide a proxy to an eventual response (being the lookup for a map)?
-    * how much would that really increase throughput
+-   can we increase proposal throughput even more by using futures to provide a proxy to an eventual
+    response (being the lookup for a map)?
+    -   how much would that really increase throughput

--- a/text/drafts/misc.md
+++ b/text/drafts/misc.md
@@ -1,20 +1,30 @@
 # Misc Optimizations
+
 > cache for unfinished ideas
 
 ## Random
 
-* a loop over a vector is significantly slower than over the vector as slice; it's noticeably faster to iterate over a slice rather than a `vec!`
-* `.iter.map(|x| x.0.into()).collect`
-* **using `BtreeMap<T, ()>` to test for deduplication** for cache optimality (trading search efficiency in some cases...)
-    * using a different scope for this pattern
-* `format!` macro to `write!` macro to make it so that you don't have to create new objects in the heap
+-   a loop over a vector is significantly slower than over the vector as slice; it's noticeably
+    faster to iterate over a slice rather than a `vec!`
+-   `.iter.map(|x| x.0.into()).collect`
+-   **using `BtreeMap<T, ()>` to test for deduplication** for cache optimality (trading search
+    efficiency in some cases...)
+    -   using a different scope for this pattern
+-   `format!` macro to `write!` macro to make it so that you don't have to create new objects in the
+    heap
 
-* maps use `Blake2` hash
-* storage values use `twox` hash
-* `Blake2` is ~6x slower than `twox`
-* if you have keys in your map, that can be manipulated from the outside; an attacker could try to create hash collisions.
-* for the map, you can set the hasher you want to use => look up the correct hash for your type in the metadata.
+-   maps use `Blake2` hash
+-   storage values use `twox` hash
+-   `Blake2` is ~6x slower than `twox`
+-   if you have keys in your map, that can be manipulated from the outside; an attacker could try to
+    create hash collisions.
+-   for the map, you can set the hasher you want to use => look up the correct hash for your type in
+    the metadata.
 
 ### Small Vector Optimization
 
-By default, the value-set for each key in the map uses the `smallvec` crate to keep a maximum of one element stored inline with the map, as opposed to separately heap-allocated with a plain `Vec`. Operations such as `Fit` and `Replace` will automatically switch back to the inline storage if possible. This is ideal for maps that mostly use one element per key, as it can improvate memory locality with less indirection.
+By default, the value-set for each key in the map uses the `smallvec` crate to keep a maximum of one
+element stored inline with the map, as opposed to separately heap-allocated with a plain `Vec`.
+Operations such as `Fit` and `Replace` will automatically switch back to the inline storage if
+possible. This is ideal for maps that mostly use one element per key, as it can improvate memory
+locality with less indirection.

--- a/text/drafts/optimizations.md
+++ b/text/drafts/optimizations.md
@@ -1,62 +1,96 @@
 # Optimization Tricks
 
-Runtime overhead in Substrate corresponds to the efficiency of the underlying Rust code. Therefore, it is essential to use clean, efficient Rust patterns for performance releases. This section introduces common approaches for optimizing Rust code in general and links to resources that may guide further investigation.
+Runtime overhead in Substrate corresponds to the efficiency of the underlying Rust code. Therefore,
+it is essential to use clean, efficient Rust patterns for performance releases. This section
+introduces common approaches for optimizing Rust code in general and links to resources that may
+guide further investigation.
 
-* [Premature Optimization](#premature)
-* [Efficiency => Security](#sec)
-* [Zero-Cost Abstractions](#zero)
-* [Entering `unsafe` Waters 🏴‍☠️](#unsafe)
-* [Fearless Concurrency && Asynchrony](#more)
+-   [Premature Optimization](#premature)
+-   [Efficiency => Security](#sec)
+-   [Zero-Cost Abstractions](#zero)
+-   [Entering `unsafe` Waters 🏴‍☠️](#unsafe)
+-   [Fearless Concurrency && Asynchrony](#more)
 
 **This section was inspired by and pulls heavily from**
-* [Achieving Warp Speed with Rust](http://troubles.md/posts/rust-optimization/) by Jack Fransham, [`troubles.md`](http://troubles.md/)
-* [High Performance Rust](https://www.packtpub.com/application-development/rust-high-performance) by Iban Eguia Moraza
+
+-   [Achieving Warp Speed with Rust](http://troubles.md/posts/rust-optimization/) by Jack Fransham,
+    [`troubles.md`](http://troubles.md/)
+-   [High Performance Rust](https://www.packtpub.com/application-development/rust-high-performance)
+    by Iban Eguia Moraza
 
 ## Premature Optimization <a name = "premature"></a>
 
-*Programmers waste enormous amounts of time thinking about, or worrying about, the speed of noncritical parts of their programs, and these attempts at efficiency actually have a strong negative impact when debugging and maintenance are considered. We should forget about small efficiencies, say about 97% of the time: premature optimization is the root of all evil.* - Page 268 of [Structured Programming with `goto` Statements](http://wiki.c2.com/?StructuredProgrammingWithGoToStatements) by Donald Knuth
+_Programmers waste enormous amounts of time thinking about, or worrying about, the speed of
+noncritical parts of their programs, and these attempts at efficiency actually have a strong
+negative impact when debugging and maintenance are considered. We should forget about small
+efficiencies, say about 97% of the time: premature optimization is the root of all evil._ - Page 268
+of
+[Structured Programming with `goto` Statements](http://wiki.c2.com/?StructuredProgrammingWithGoToStatements)
+by Donald Knuth
 
-Before worrying about performance optimizations, focus on *optimizing* for readability, simplicity, and maintainability. The first step when building anything is achieving basic functionality. Only after establishing a minimal viable sample is it appropriate to consider performance-based enhancements. With that said, severe inefficiency does open attack vectors for Substrate runtimes (*see [the next section](#sec)*). Moreover, the tradeoff between optimization and simplicity is not always so clear... 
+Before worrying about performance optimizations, focus on _optimizing_ for readability, simplicity,
+and maintainability. The first step when building anything is achieving basic functionality. Only
+after establishing a minimal viable sample is it appropriate to consider performance-based
+enhancements. With that said, severe inefficiency does open attack vectors for Substrate runtimes
+(_see [the next section](#sec)_). Moreover, the tradeoff between optimization and simplicity is not
+always so clear...
 
-*A common misconception is that optimized code is necessarily more complicated, and that therefore optimization always represents a trade-off. However, in practice, better factored code often runs faster and uses less memory as well. In this regard, optimization is closely related to refactoring, since in both cases we are paying into the code so that we may draw back out again later if we need to.* - [src](http://wiki.c2.com/?PrematureOptimization)
+_A common misconception is that optimized code is necessarily more complicated, and that therefore
+optimization always represents a trade-off. However, in practice, better factored code often runs
+faster and uses less memory as well. In this regard, optimization is closely related to refactoring,
+since in both cases we are paying into the code so that we may draw back out again later if we need
+to._ - [src](http://wiki.c2.com/?PrematureOptimization)
 
 **Rust API Guidelines**
-* [Official Rust API Guidelines](https://rust-lang-nursery.github.io/api-guidelines/about.html)
-* [Rust Unofficial Design Patterns](https://github.com/rust-unofficial/patterns)
-* [Elegant Library API Guidelines](https://deterministic.space/elegant-apis-in-rust.html) by Pascal Hertleif
+
+-   [Official Rust API Guidelines](https://rust-lang-nursery.github.io/api-guidelines/about.html)
+-   [Rust Unofficial Design Patterns](https://github.com/rust-unofficial/patterns)
+-   [Elegant Library API Guidelines](https://deterministic.space/elegant-apis-in-rust.html) by
+    Pascal Hertleif
 
 Also, use [clippy](https://github.com/rust-lang/rust-clippy)!
 
 ## Efficiency => Security in Substrate <a name = "sec"></a>
 
-We call an algorithm *efficient* if its running time is polynomial in the size of the input, and *highly efficient* if its running time is linear in the size of the input. It is important for all on-chain algorithms to be highly efficient, because they must scale linearly as the size of the Polkadot network grows. In contrast, off-chain algorithms are only required to be efficient. - [Web3 Research](http://research.web3.foundation/en/latest/polkadot/NPoS/1.intro/)
+We call an algorithm _efficient_ if its running time is polynomial in the size of the input, and
+_highly efficient_ if its running time is linear in the size of the input. It is important for all
+on-chain algorithms to be highly efficient, because they must scale linearly as the size of the
+Polkadot network grows. In contrast, off-chain algorithms are only required to be efficient. -
+[Web3 Research](http://research.web3.foundation/en/latest/polkadot/NPoS/1.intro/)
 
-*See [Substrate Best Practices](https://substrate.dev/docs/en/tutorials/tcr/) for more details on how efficiency influences the runtime's economic security.*
+_See [Substrate Best Practices](https://substrate.dev/docs/en/tutorials/tcr/) for more details on
+how efficiency influences the runtime's economic security._
 
 **Related Reading**
-* [Onwards; Underpriced EVM Operations](https://www.parity.io/onwards/), September 2016
-* [Under-Priced DOS Attacks on Ethereum](https://www4.comp.polyu.edu.hk/~csxluo/DoSEVM.pdf)
+
+-   [Onwards; Underpriced EVM Operations](https://www.parity.io/onwards/), September 2016
+-   [Under-Priced DOS Attacks on Ethereum](https://www4.comp.polyu.edu.hk/~csxluo/DoSEVM.pdf)
 
 ## Rust Zero-Cost Abstractions <a name = "zero"></a>
 
 Substrate developers should take advantage of Rust's zero cost abstractions.
 
-*Articles*
-* [Abstraction without overhead: traits in Rust](https://blog.rust-lang.org/2015/05/11/traits.html)
-* [Effectively Using Iterators in Rust](https://hermanradtke.com/2015/06/22/effectively-using-iterators-in-rust.html)
-* [Type States](https://rust-embedded.github.io/book/static-guarantees/zero-cost-abstractions.html)
+_Articles_
 
-*Tweets*
-* [iterate over a slice rather than a `vec!`](https://twitter.com/heinz_gies/status/1121490424739303425)
+-   [Abstraction without overhead: traits in Rust](https://blog.rust-lang.org/2015/05/11/traits.html)
+-   [Effectively Using Iterators in Rust](https://hermanradtke.com/2015/06/22/effectively-using-iterators-in-rust.html)
+-   [Type States](https://rust-embedded.github.io/book/static-guarantees/zero-cost-abstractions.html)
 
-*Video*
-* [An introduction to structs, traits, and zero-cost abstractions](https://www.youtube.com/watch?v=Sn3JklPAVLk)
+_Tweets_
 
-## Entering `unsafe` Waters 🏴‍☠️  <a name = "unsafe"></a>
+-   [iterate over a slice rather than a `vec!`](https://twitter.com/heinz_gies/status/1121490424739303425)
 
-*Please read [The Rustonomicon](https://doc.rust-lang.org/nomicon/) before experimenting with the dark magic that is `unsafe`*
+_Video_
 
-To access an element in a specific position, use the `get()` method. This method performs a double bound check.
+-   [An introduction to structs, traits, and zero-cost abstractions](https://www.youtube.com/watch?v=Sn3JklPAVLk)
+
+## Entering `unsafe` Waters 🏴‍☠️ <a name = "unsafe"></a>
+
+_Please read [The Rustonomicon](https://doc.rust-lang.org/nomicon/) before experimenting with the
+dark magic that is `unsafe`_
+
+To access an element in a specific position, use the `get()` method. This method performs a double
+bound check.
 
 ```rust, ignore
 for arr in array_of_arrays {
@@ -67,10 +101,13 @@ for arr in array_of_arrays {
 ```
 
 The `.get()` call performs two checks:
+
 1. checks that the index will return `Some(elem)` or `None`
 2. checks that the returned element is of type `Some` or `None`
 
-If bound checking has already been performed independently of the call, we can invoke `.getunchecked()` to access the element. Although this is `unsafe` to use, it is equivalent to C/C++ indexing, thereby improving performance when we already know the element's location.
+If bound checking has already been performed independently of the call, we can invoke
+`.getunchecked()` to access the element. Although this is `unsafe` to use, it is equivalent to C/C++
+indexing, thereby improving performance when we already know the element's location.
 
 ```rust, ignore
 for arr in array_of_arrays {
@@ -78,41 +115,61 @@ for arr in array_of_arrays {
 }
 ```
 
-**NOTE**: if we don't verify the input to `.getunchecked()`, the caller may access whatever is stored in the location even if it is a memory address outside the slice
+**NOTE**: if we don't verify the input to `.getunchecked()`, the caller may access whatever is
+stored in the location even if it is a memory address outside the slice
 
 ## Fearless Concurrency && Asynchrony <a name = "more"></a>
 
-As a systems programming language, Rust provides significant flexibility with respect to low-level optimizations. Specifically, Rust provides fine-grain control over how you perform computation, delegate said computation to the OS's threads, and schedule state transitions within a given thread. There isn't space in this book to go into significant detail, but I'll try to provide resources/reading that have helped me get up to speed. For a high-level overview, Stjepan Glavina provides the following descriptions in [Lock-free Rust: Crossbeam in 2019](https://stjepang.github.io/2019/01/29/lock-free-rust-crossbeam-in-2019.html):
+As a systems programming language, Rust provides significant flexibility with respect to low-level
+optimizations. Specifically, Rust provides fine-grain control over how you perform computation,
+delegate said computation to the OS's threads, and schedule state transitions within a given thread.
+There isn't space in this book to go into significant detail, but I'll try to provide
+resources/reading that have helped me get up to speed. For a high-level overview, Stjepan Glavina
+provides the following descriptions in
+[Lock-free Rust: Crossbeam in 2019](https://stjepang.github.io/2019/01/29/lock-free-rust-crossbeam-in-2019.html):
 
-* **[Rayon](https://github.com/rayon-rs/rayon)** splits your data into distinct pieces, gives each piece to a thread to do some kind of computation on it, and finally aggregates results. Its goal is to distribute CPU-intensive tasks onto a thread pool.
-* **[Tokio](https://github.com/tokio-rs/tokio)** runs tasks which sometimes need to be paused in order to wait for asynchronous events. Handling tons of such tasks is no problem. Its goal is to distribute IO-intensive tasks onto a thread pool.
-* **[Crossbeam](https://github.com/crossbeam-rs/crossbeam)** is all about low-level concurrency: atomics, concurrent data structures, synchronization primitives. Same idea as the `std::sync` module, but bigger. Its goal is to provide tools on top of which libraries like Rayon and Tokio can be built.
+-   **[Rayon](https://github.com/rayon-rs/rayon)** splits your data into distinct pieces, gives each
+    piece to a thread to do some kind of computation on it, and finally aggregates results. Its goal
+    is to distribute CPU-intensive tasks onto a thread pool.
+-   **[Tokio](https://github.com/tokio-rs/tokio)** runs tasks which sometimes need to be paused in
+    order to wait for asynchronous events. Handling tons of such tasks is no problem. Its goal is to
+    distribute IO-intensive tasks onto a thread pool.
+-   **[Crossbeam](https://github.com/crossbeam-rs/crossbeam)** is all about low-level concurrency:
+    atomics, concurrent data structures, synchronization primitives. Same idea as the `std::sync`
+    module, but bigger. Its goal is to provide tools on top of which libraries like Rayon and Tokio
+    can be built.
 
 To dive deeper down these 🐰 holes
-* [Asynchrony](#async)
-* [Concurrency](#concurrency)
+
+-   [Asynchrony](#async)
+-   [Concurrency](#concurrency)
 
 ### Asynchrony <a name = "async"></a>
+
 [Are we `async` yet?](https://areweasyncyet.rs/)
 
 **Conceptual**
-* [RustLatam 2019 - Without Boats: Zero-Cost Async IO](https://www.youtube.com/watch?v=skos4B5x7qE)
-* [Introduction to Async/Await Programming (withoutboats/wakers-i):](https://boats.gitlab.io/blog/post/wakers-i/)
-* [Futures (by Aaron Turon)](http://aturon.github.io/2016/08/11/futures/)
+
+-   [RustLatam 2019 - Without Boats: Zero-Cost Async IO](https://www.youtube.com/watch?v=skos4B5x7qE)
+-   [Introduction to Async/Await Programming (withoutboats/wakers-i):](https://boats.gitlab.io/blog/post/wakers-i/)
+-   [Futures (by Aaron Turon)](http://aturon.github.io/2016/08/11/futures/)
 
 **Projects**
-* [Rust Asynchronous Ecosystem Working Group](https://github.com/rustasync)
-* [romio](https://github.com/withoutboats/romio)
-* [Tokio Docs](https://tokio.rs/docs/overview/)
+
+-   [Rust Asynchronous Ecosystem Working Group](https://github.com/rustasync)
+-   [romio](https://github.com/withoutboats/romio)
+-   [Tokio Docs](https://tokio.rs/docs/overview/)
 
 ### Concurrency <a name = "concurrency"></a>
 
 **Conceptual**
-* [Rust Concurrency Explained](https://www.youtube.com/watch?v=Dbytx0ivH7Q)
-* [Lock-free Rust: Crossbeam in 2019](https://stjepang.github.io/2019/01/29/lock-free-rust-crossbeam-in-2019.html)
-* [Crossbeam Research Meta-link](https://github.com/crossbeam-rs/rfcs/wiki)
+
+-   [Rust Concurrency Explained](https://www.youtube.com/watch?v=Dbytx0ivH7Q)
+-   [Lock-free Rust: Crossbeam in 2019](https://stjepang.github.io/2019/01/29/lock-free-rust-crossbeam-in-2019.html)
+-   [Crossbeam Research Meta-link](https://github.com/crossbeam-rs/rfcs/wiki)
 
 **Projects**
-* [sled](https://github.com/spacejam/sled)
-* [servo](https://github.com/servo/servo)
-* [TiKV](https://github.com/tikv/tikv)
+
+-   [sled](https://github.com/spacejam/sled)
+-   [servo](https://github.com/servo/servo)
+-   [TiKV](https://github.com/tikv/tikv)

--- a/text/drafts/rules.md
+++ b/text/drafts/rules.md
@@ -1,17 +1,28 @@
 # Pallet Development Rules
 
-* add pallet development criteria here
+-   add pallet development criteria here
 
 ## Logic Proofs <a name = "qed"></a>
 
-Because Substrate grants bare-metal control to developers, certain code patterns can expose panics at runtime. As mentioned in (2) of [Pallet Development Criteria](#criteria), panics can cause irreversible storage changes, possibly even bricking the blockchain and rendering it useless. 
+Because Substrate grants bare-metal control to developers, certain code patterns can expose panics
+at runtime. As mentioned in (2) of [Pallet Development Criteria](#criteria), panics can cause
+irreversible storage changes, possibly even bricking the blockchain and rendering it useless.
 
-It is the responsibility of Substrate developers to ensure that the code doesn't panics after storage changes. In many cases, safety might be independently verified by the developer while writing the code. To facilitate auditability and better testing, Substrate developers should include a proof in an `.expect()` call that shows why the code's logic is safe and will not panic. Convention dictates formatting the call like so
+It is the responsibility of Substrate developers to ensure that the code doesn't panics after
+storage changes. In many cases, safety might be independently verified by the developer while
+writing the code. To facilitate auditability and better testing, Substrate developers should include
+a proof in an `.expect()` call that shows why the code's logic is safe and will not panic.
+Convention dictates formatting the call like so
 
 ```rust, ignore
 <Object<T>>::method_call().expect("<proof of safety>; qed");
 ```
 
-You can find more examples of this pattern in the [Substrate codebase](https://github.com/paritytech/substrate/search?q=expect). Indeed, including logic proofs is very important for writing readable, well-maintained code. It comes as no surprise that this pattern is also discussed in the [Substrate collectables tutorial](https://shawntabrizi.com/substrate-collectables-workshop/#/3/buying-a-kitty?id=remember-quotverify-first-write-lastquot).
+You can find more examples of this pattern in the
+[Substrate codebase](https://github.com/paritytech/substrate/search?q=expect). Indeed, including
+logic proofs is very important for writing readable, well-maintained code. It comes as no surprise
+that this pattern is also discussed in the
+[Substrate collectables tutorial](https://shawntabrizi.com/substrate-collectables-workshop/#/3/buying-a-kitty?id=remember-quotverify-first-write-lastquot).
 
-> *QED stands for Quod Erat Demonstrandum which loosely translated means "that which was to be demonstrated"*
+> _QED stands for Quod Erat Demonstrandum which loosely translated means "that which was to be
+> demonstrated"_

--- a/text/drafts/string.md
+++ b/text/drafts/string.md
@@ -1,8 +1,13 @@
 ## String Storage (as Bytemap) <a name = "string" ></a>
 
-Runtime storage is for storing the state of the business logic for which the runtime operates. If arbitrary storage must be stored in the runtime, it is better to create a bytearray(`Vec<u8>`). With that said, Substrate doesn't directly support `String`. To achieve the same functionality, it is better to store a hash to a service like IPFS to then use the hash to fetch data for the UI (*recipe coming soon!*).
+Runtime storage is for storing the state of the business logic for which the runtime operates. If
+arbitrary storage must be stored in the runtime, it is better to create a bytearray(`Vec<u8>`). With
+that said, Substrate doesn't directly support `String`. To achieve the same functionality, it is
+better to store a hash to a service like IPFS to then use the hash to fetch data for the UI (_recipe
+coming soon!_).
 
-Here's a workaround to store a string in the runtime using JavaScript to convert the string to hex and back. You probably shouldn't do this...
+Here's a workaround to store a string in the runtime using JavaScript to convert the string to hex
+and back. You probably shouldn't do this...
 
 ```rust, ignore
 use frame_support::{StorageValue, dispatch::Result};
@@ -26,23 +31,25 @@ decl_storage! {
 }
 ```
 
-Store the string as a bytearray, which is inputted into the Polkadot UI as a hex string. These helper functions in JavaScript enable conversation from a string to hex and back, all in the browser console.
+Store the string as a bytearray, which is inputted into the Polkadot UI as a hex string. These
+helper functions in JavaScript enable conversation from a string to hex and back, all in the browser
+console.
 
 ```javascript
 function toHex(s) {
-    var s = unescape(encodeURIComponent(s))
-    var h = '0x'
-    for (var i = 0; i < s.length; i++) {
-        h += s.charCodeAt(i).toString(16)
-    }
-    return h
+	var s = unescape(encodeURIComponent(s));
+	var h = "0x";
+	for (var i = 0; i < s.length; i++) {
+		h += s.charCodeAt(i).toString(16);
+	}
+	return h;
 }
 
 function fromHex(h) {
-    var s = ''
-    for (var i = 0; i < h.length; i+=2) {
-        s += String.fromCharCode(parseInt(h.substr(i, 2), 16))
-    }
-    return decodeURIComponent(escape(s))
+	var s = "";
+	for (var i = 0; i < h.length; i += 2) {
+		s += String.fromCharCode(parseInt(h.substr(i, 2), 16));
+	}
+	return decodeURIComponent(escape(s));
 }
 ```

--- a/text/drafts/tight-and-loose-coupling.md
+++ b/text/drafts/tight-and-loose-coupling.md
@@ -1,6 +1,9 @@
 # Substrate Types and Traits
 
-Pallets may access their own associated types as well as the associated types of other pallets in the runtime. This is seen in most pallets when they access `frame_system`'s associated `AccountId` type. All pallets are tightly coupled to `frame_system` through this syntax, and thus have access to its types. You may optionally couple to additional pallets in this way.
+Pallets may access their own associated types as well as the associated types of other pallets in
+the runtime. This is seen in most pallets when they access `frame_system`'s associated `AccountId`
+type. All pallets are tightly coupled to `frame_system` through this syntax, and thus have access to
+its types. You may optionally couple to additional pallets in this way.
 
 > Another option, loosely coupling to other pallets, is discussed further later.
 
@@ -8,13 +11,21 @@ Pallets may access their own associated types as well as the associated types of
 pub trait Trait: system::Trait {}
 ```
 
-This provides access to `Hash`, `AccountId`, and `BlockNumber` anywhere that specifies the generic `<T: Trait>` using `T::<Type>`. It also provides access to other useful types, declared in [`frame_system`'s configuration trait](https://crates.parity.io/frame_system/trait.Trait.html).
+This provides access to `Hash`, `AccountId`, and `BlockNumber` anywhere that specifies the generic
+`<T: Trait>` using `T::<Type>`. It also provides access to other useful types, declared in
+[`frame_system`'s configuration trait](https://crates.parity.io/frame_system/trait.Trait.html).
 
-> basically add a note here on why traits are important for runtime development `=>` we are in the business of building libraries to support the configuration and modular and extensible digital infrastructure...
+> basically add a note here on why traits are important for runtime development `=>` we are in the
+> business of building libraries to support the configuration and modular and extensible digital
+> infrastructure...
 
-- [Currency Types](./currency.md)
-- [Transaction Fees](./fees.md)
+-   [Currency Types](./currency.md)
+-   [Transaction Fees](./fees.md)
 
 ## support::traits
 
-Unlike in smart contract development, the way to inherit shared behavior is not to directly import other pallets. Instead, it is common to either implement the same logic in the new context or utilize a trait from [`frame_support`](https://crates.parity.io/frame_support/index.html) to guide the new implementation. By abstracting common behavior from pallets into `frame_support`, Substrate makes it easy to extract and enforce best practices in the runtime.
+Unlike in smart contract development, the way to inherit shared behavior is not to directly import
+other pallets. Instead, it is common to either implement the same logic in the new context or
+utilize a trait from [`frame_support`](https://crates.parity.io/frame_support/index.html) to guide
+the new implementation. By abstracting common behavior from pallets into `frame_support`, Substrate
+makes it easy to extract and enforce best practices in the runtime.

--- a/text/drafts/ui.md
+++ b/text/drafts/ui.md
@@ -1,8 +1,10 @@
 ## Using the Polkadot UI to Interact
 
-To simplify interactions with the custom Substrate runtime, use the [Polkadot JS UI for Substrate](https://polkadot.js.org/apps/next/).
+To simplify interactions with the custom Substrate runtime, use the
+[Polkadot JS UI for Substrate](https://polkadot.js.org/apps/next/).
 
-By default, this UI is configured to interact with the public Substrate test-network BBQ Birch. To have it connect to your local node, simply go to:
+By default, this UI is configured to interact with the public Substrate test-network BBQ Birch. To
+have it connect to your local node, simply go to:
 
 ```
 Settings > remote node/endpoint to connect to > Local Node (127.0.0.1:9944)
@@ -10,7 +12,8 @@ Settings > remote node/endpoint to connect to > Local Node (127.0.0.1:9944)
 
 ![A picture of the Polkadot UI Settings Tab](https://i.imgur.com/1FpB5aM.png)
 
-If the UI connected successfully, you should be able to go to the **Explorer** tab and see the block production process running.
+If the UI connected successfully, you should be able to go to the **Explorer** tab and see the block
+production process running.
 
 ![A picture of the block production process running in Explorer tab](https://i.imgur.com/TXmM0cB.png)
 
@@ -26,20 +29,23 @@ If you want to check the value of a storage variable that you created, you can g
 Chain State > runtimeExampleStorage > (variable name)
 ```
 
-From there you should be able to query the state of the variable. It may return `<unknown>` if the value has not been set yet.
+From there you should be able to query the state of the variable. It may return `<unknown>` if the
+value has not been set yet.
 
 ![A picture of viewing a storage variable in the Polkadot UI](https://i.imgur.com/JLoWxc3.png)
 
-
 ### Viewing Events
 
-Some runtime examples below generate `Events` when functions are run. You can temporarily view these events in the **Explorer** tab under **recent events** if any get generated.
+Some runtime examples below generate `Events` when functions are run. You can temporarily view these
+events in the **Explorer** tab under **recent events** if any get generated.
 
 ![A picture of an event getting generated in the Explorer tab](https://i.imgur.com/2jUtBUk.png)
 
 ### WASM Runtime Upgrade
 
-Rather than restarting your chain for each update, you can also do an in-place runtime upgrade using the Polkadot UI. If you do this, you will not get runtime messages appearing in your terminal, but you should be able to interact with the chain via the UI just fine. To perform the upgrade, go to:
+Rather than restarting your chain for each update, you can also do an in-place runtime upgrade using
+the Polkadot UI. If you do this, you will not get runtime messages appearing in your terminal, but
+you should be able to interact with the chain via the UI just fine. To perform the upgrade, go to:
 
 ```
 Extrinsics > Upgrade Key > upgrade(new)
@@ -52,6 +58,5 @@ substrate-example/runtime/wasm/target/wasm32-unknown-unknown/release/node_runtim
 ```
 
 ![A picture of upgrading the Substrate runtime](https://i.imgur.com/rujS3p6.png)
-
 
 Once the upgrade is finalized, you should be able to refresh the UI and see your updates.

--- a/text/drafts/visibility.md
+++ b/text/drafts/visibility.md
@@ -1,13 +1,14 @@
 # Special Field Objects
 
-
 ## Public vs Private
 
-* and do we maintain access to all of its methods in the runtime if it's declared outside the `decl_module` block
-* also for functions?
+-   and do we maintain access to all of its methods in the runtime if it's declared outside the
+    `decl_module` block
+-   also for functions?
 
 ## [COMPACT]
 
-When do you use compact and when do you not? What are the benefits to runtime storage and what are the implications?
+When do you use compact and when do you not? What are the benefits to runtime storage and what are
+the implications?
 
 ## PhantomData

--- a/text/introduction.md
+++ b/text/introduction.md
@@ -2,41 +2,64 @@
 
 _A Hands-On Cookbook for Aspiring Blockchain Chefs_
 
-Substrate Recipes is a cookbook of working examples that demonstrate best practices when building blockchains with **[Substrate](https://github.com/paritytech/substrate)**. Each recipe contains a complete working code example as well as a detailed writeup describing the code. This book is [open source](https://github.com/substrate-developer-hub/recipes). Check out the [contributing guidelines](https://github.com/substrate-developer-hub/recipes/blob/master/CONTRIBUTING.md) for an overview of the structure and directions for getting involved.
+Substrate Recipes is a cookbook of working examples that demonstrate best practices when building
+blockchains with **[Substrate](https://github.com/paritytech/substrate)**. Each recipe contains a
+complete working code example as well as a detailed writeup describing the code. This book is
+[open source](https://github.com/substrate-developer-hub/recipes). Check out the
+[contributing guidelines](https://github.com/substrate-developer-hub/recipes/blob/master/CONTRIBUTING.md)
+for an overview of the structure and directions for getting involved.
 
 ## How to Use This Book
 
-The easiest place to read this book is at [https://substrate.dev/recipes](https://substrate.dev/recipes).
+The easiest place to read this book is at
+[https://substrate.dev/recipes](https://substrate.dev/recipes).
 
 The first two chapters are meant to be read in order.
 
-In Chapter 1, [Preparing your Kitchen](./1-prepare-kitchen/index.md), you will set up your toolchain, compile a blockchain node, and learn to interact with the blockchain.
+In Chapter 1, [Preparing your Kitchen](./1-prepare-kitchen/index.md), you will set up your
+toolchain, compile a blockchain node, and learn to interact with the blockchain.
 
-In Chapter 2, [Appetizers](./2-appetizers/index.md), you will cook your first few recipes, learning the fundamentals of Substrate development.
+In Chapter 2, [Appetizers](./2-appetizers/index.md), you will cook your first few recipes, learning
+the fundamentals of Substrate development.
 
-The rest of the book, the "Entrees", can be read in any order, and you should skip to whichever recipes interest you.
+The rest of the book, the "Entrees", can be read in any order, and you should skip to whichever
+recipes interest you.
 
-Remember, you can't learn to cook by reading alone. As you work through the book, put on your apron, get out some pots and pans, and practice compiling, testing, and hacking on the recipes. Play with the code in the kitchen, extract patterns, and apply them to a problem that you want to solve!
+Remember, you can't learn to cook by reading alone. As you work through the book, put on your apron,
+get out some pots and pans, and practice compiling, testing, and hacking on the recipes. Play with
+the code in the kitchen, extract patterns, and apply them to a problem that you want to solve!
 
 ## Getting Help
 
-When learning any new skill, you will inevitably get stuck at some point. When you do get stuck you can seek help in several ways:
+When learning any new skill, you will inevitably get stuck at some point. When you do get stuck you
+can seek help in several ways:
 
-* Ask a question on [Stack Overflow](https://stackoverflow.com/questions/tagged/substrate)
-* Ask a question in the [Substrate Technical Riot channel](https://riot.im/app/#/room/#substrate-technical:matrix.org)
-* Open a [new issue](https://github.com/substrate-developer-hub/recipes/issues/new) against this repository
+-   Ask a question on [Stack Overflow](https://stackoverflow.com/questions/tagged/substrate)
+-   Ask a question in the
+    [Substrate Technical Riot channel](https://riot.im/app/#/room/#substrate-technical:matrix.org)
+-   Open a [new issue](https://github.com/substrate-developer-hub/recipes/issues/new) against this
+    repository
 
 ## What is Substrate?
 
-[Substrate](https://github.com/paritytech/substrate) is a framework for building blockchains. For a high level overview, read the following blog posts:
-* [What is Substrate?](https://www.parity.io/what-is-substrate/)
-* [Substrate in a nutshell](https://www.parity.io/substrate-in-a-nutshell/)
-* [A brief summary of everything Substrate and Polkadot](https://www.parity.io/a-brief-summary-of-everything-substrate-polkadot/)
+[Substrate](https://github.com/paritytech/substrate) is a framework for building blockchains. For a
+high level overview, read the following blog posts:
+
+-   [What is Substrate?](https://www.parity.io/what-is-substrate/)
+-   [Substrate in a nutshell](https://www.parity.io/substrate-in-a-nutshell/)
+-   [A brief summary of everything Substrate and Polkadot](https://www.parity.io/a-brief-summary-of-everything-substrate-polkadot/)
 
 To learn more about Substrate, see the [official documentation](https://substrate.dev).
 
 ## Learning Rust
 
-Becoming productive with Substrate requires some familiarity with Rust. Fortunately, the Rust community is known for comprehensive documentation and tutorials. The most common resource for initially learning Rust is [The Rust Book](https://doc.rust-lang.org/book/index.html). To see examples of popular crate usage patterns, [Rust by Example](https://doc.rust-lang.org/rust-by-example/index.html) is also convenient.
+Becoming productive with Substrate requires some familiarity with Rust. Fortunately, the Rust
+community is known for comprehensive documentation and tutorials. The most common resource for
+initially learning Rust is [The Rust Book](https://doc.rust-lang.org/book/index.html). To see
+examples of popular crate usage patterns,
+[Rust by Example](https://doc.rust-lang.org/rust-by-example/index.html) is also convenient.
 
-While knowing some Rust is certainly necessary, it is not wise to delay learning Substrate until you are a Rust guru. Rather than learning Rust _before_ you learn Substrate, consider learning Rust _as_ you learn Substrate. If you're beyond the fundamentals of Rust, there are lots [more Rust resources](./more-resources.md) at the end of the book.
+While knowing some Rust is certainly necessary, it is not wise to delay learning Substrate until you
+are a Rust guru. Rather than learning Rust _before_ you learn Substrate, consider learning Rust _as_
+you learn Substrate. If you're beyond the fundamentals of Rust, there are lots
+[more Rust resources](./more-resources.md) at the end of the book.

--- a/text/more-resources.md
+++ b/text/more-resources.md
@@ -1,60 +1,84 @@
 # More Resources
 
 ## Substrate
+
 Learn more about Substrate from these resources:
 
-* [Substrate Developer Hub Home](https://substrate.dev) - Landing page of the official Substrate documentation.
-* [Conceptual Docs](https://substrate.dev/docs) - Explanation of Substrate's architecture at a high level of abstraction.
-* [Reference Docs](https://substrate.dev/rustdocs) - Documentaiton on specific Substrate APIs with little abstraction.
-* [Substrate Tutorials](https://substrate.dev/tutorials) - Step by step guides to accomplish specific tasks with Substrate.
+-   [Substrate Developer Hub Home](https://substrate.dev) - Landing page of the official Substrate
+    documentation.
+-   [Conceptual Docs](https://substrate.dev/docs) - Explanation of Substrate's architecture at a
+    high level of abstraction.
+-   [Reference Docs](https://substrate.dev/rustdocs) - Documentaiton on specific Substrate APIs with
+    little abstraction.
+-   [Substrate Tutorials](https://substrate.dev/tutorials) - Step by step guides to accomplish
+    specific tasks with Substrate.
 
 <!-- Reminder: There is a _lot_ more potential content for this section in drafts/dessert.md -->
 
 ## Rust
-Once you've got the fundamentals of Substrate, it can only help to know more rust. Here is a collection of helpful docs
-and blog posts to take you down the rabbit hole.
+
+Once you've got the fundamentals of Substrate, it can only help to know more rust. Here is a
+collection of helpful docs and blog posts to take you down the rabbit hole.
 
 ### API Design
 
 To become more familiar with commmon design patterns in Rust, the following links might be helpful:
-* [Official Rust API Guidelines](https://rust-lang.github.io/api-guidelines/about.html)
-* [Rust Unofficial Design Patterns](https://github.com/rust-unofficial/patterns)
-* [Elegant Library API Guidelines](https://deterministic.space/elegant-apis-in-rust.html)
+
+-   [Official Rust API Guidelines](https://rust-lang.github.io/api-guidelines/about.html)
+-   [Rust Unofficial Design Patterns](https://github.com/rust-unofficial/patterns)
+-   [Elegant Library API Guidelines](https://deterministic.space/elegant-apis-in-rust.html)
 
 ### Optimizations
 
-To optimize runtime performance, Substrate developers should make use of iterators, traits, and Rust's other "*zero cost* abstractions":
-* [Abstraction without overhead: traits in Rust](https://blog.rust-lang.org/2015/05/11/traits.html), [related conference talk](https://www.youtube.com/watch?v=Sn3JklPAVLk)
-* [Effectively Using Iterators in Rust](https://hermanradtke.com/2015/06/22/effectively-using-iterators-in-rust.html)
-* [Achieving Warp Speed with Rust](http://troubles.md/posts/rust-optimization/)
+To optimize runtime performance, Substrate developers should make use of iterators, traits, and
+Rust's other "_zero cost_ abstractions":
+
+-   [Abstraction without overhead: traits in Rust](https://blog.rust-lang.org/2015/05/11/traits.html),
+    [related conference talk](https://www.youtube.com/watch?v=Sn3JklPAVLk)
+-   [Effectively Using Iterators in Rust](https://hermanradtke.com/2015/06/22/effectively-using-iterators-in-rust.html)
+-   [Achieving Warp Speed with Rust](http://troubles.md/posts/rust-optimization/)
 
 ### Concurrency
-* **[Lock-free Rust: Crossbeam in 2019](https://stjepang.github.io/2019/01/29/lock-free-rust-crossbeam-in-2019.html)** a high-level overview of concurrency in Rust.
-* **[Rayon](https://github.com/rayon-rs/rayon)** splits your data into distinct pieces, gives each piece to a thread to do some kind of computation on it, and finally aggregates results. Its goal is to distribute CPU-intensive tasks onto a thread pool.
-* **[Tokio](https://github.com/tokio-rs/tokio)** runs tasks which sometimes need to be paused in order to wait for asynchronous events. Handling tons of such tasks is no problem. Its goal is to distribute IO-intensive tasks onto a thread pool.
-* **[Crossbeam](https://github.com/crossbeam-rs/crossbeam)** is all about low-level concurrency: atomics, concurrent data structures, synchronization primitives. Same idea as the `std::sync` module, but bigger. Its goal is to provide tools on top of which libraries like Rayon and Tokio can be built.
+
+-   **[Lock-free Rust: Crossbeam in 2019](https://stjepang.github.io/2019/01/29/lock-free-rust-crossbeam-in-2019.html)**
+    a high-level overview of concurrency in Rust.
+-   **[Rayon](https://github.com/rayon-rs/rayon)** splits your data into distinct pieces, gives each
+    piece to a thread to do some kind of computation on it, and finally aggregates results. Its goal
+    is to distribute CPU-intensive tasks onto a thread pool.
+-   **[Tokio](https://github.com/tokio-rs/tokio)** runs tasks which sometimes need to be paused in
+    order to wait for asynchronous events. Handling tons of such tasks is no problem. Its goal is to
+    distribute IO-intensive tasks onto a thread pool.
+-   **[Crossbeam](https://github.com/crossbeam-rs/crossbeam)** is all about low-level concurrency:
+    atomics, concurrent data structures, synchronization primitives. Same idea as the `std::sync`
+    module, but bigger. Its goal is to provide tools on top of which libraries like Rayon and Tokio
+    can be built.
 
 ### Asynchrony
+
 [Are we `async` yet?](https://areweasyncyet.rs/)
 
 **Conceptual**
-* [Introduction to Async/Await Programming (withoutboats/wakers-i)](https://boats.gitlab.io/blog/post/wakers-i/)
-* [Futures (by Aaron Turon)](https://aturon.github.io/tech/2016/08/11/futures/)
-* [RustLatam 2019 - Without Boats: Zero-Cost Async IO](https://www.youtube.com/watch?v=skos4B5x7qE)
+
+-   [Introduction to Async/Await Programming (withoutboats/wakers-i)](https://boats.gitlab.io/blog/post/wakers-i/)
+-   [Futures (by Aaron Turon)](https://aturon.github.io/tech/2016/08/11/futures/)
+-   [RustLatam 2019 - Without Boats: Zero-Cost Async IO](https://www.youtube.com/watch?v=skos4B5x7qE)
 
 **Projects**
-* [Rust Asynchronous Ecosystem Working Group](https://github.com/rustasync)
-* [romio](https://github.com/withoutboats/romio)
-* [Tokio Docs](https://tokio.rs/docs/overview/)
+
+-   [Rust Asynchronous Ecosystem Working Group](https://github.com/rustasync)
+-   [romio](https://github.com/withoutboats/romio)
+-   [Tokio Docs](https://tokio.rs/docs/overview/)
 
 ### Concurrency
 
 **Conceptual**
-* [Lock-free Rust: Crossbeam in 2019](https://stjepang.github.io/2019/01/29/lock-free-rust-crossbeam-in-2019.html)
-* [Crossbeam Research Meta-link](https://github.com/crossbeam-rs/rfcs/wiki)
-* [Rust Concurrency Explained](https://www.youtube.com/watch?v=Dbytx0ivH7Q)
+
+-   [Lock-free Rust: Crossbeam in 2019](https://stjepang.github.io/2019/01/29/lock-free-rust-crossbeam-in-2019.html)
+-   [Crossbeam Research Meta-link](https://github.com/crossbeam-rs/rfcs/wiki)
+-   [Rust Concurrency Explained](https://www.youtube.com/watch?v=Dbytx0ivH7Q)
 
 **Projects**
-* [sled](https://github.com/spacejam/sled)
-* [servo](https://github.com/servo/servo)
-* [TiKV](https://github.com/tikv/tikv)
+
+-   [sled](https://github.com/spacejam/sled)
+-   [servo](https://github.com/servo/servo)
+-   [TiKV](https://github.com/tikv/tikv)


### PR DESCRIPTION
This PR adds a config file for [prettier](https://github.com/prettier/prettier) in `.prettierrc.json`. This config is cribbed from the knowledgebase.

It also runs prettier on all the markdown files in the recipes. This was not easy. I expected `prettier --write **/*.md` to do the job, but it seems the glob parsing is buggy. In order to get the effects demonstrated in this PR I had to run all of these commands:
```bash
prettier --write **/*.md
prettier --write **/**/*.md
prettier --write **/**/**/*.md
prettier --write **/**/**/**/*.md
```