### PR TITLE
Update dependencies to 45b9f0a (rc2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7400,6 +7400,7 @@ dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
  "serde",
+ "smallvec 1.4.0",
  "sp-api",
  "sp-block-builder",
  "sp-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
 
 [[package]]
 name = "adding-machine"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -24,9 +24,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456d75cbb82da1ad150c8a9d97285ffcd21c9931dcb11e995903e7d75141b38b"
+checksum = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
 dependencies = [
  "gimli",
 ]
@@ -81,9 +81,9 @@ version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6757ed5faa82ccfbfa1837cd7a7a2e1bdb634236f21fa74d6c5c5736152838a1"
 dependencies = [
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
@@ -112,7 +112,7 @@ checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 
 [[package]]
 name = "api-runtime"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -139,18 +139,6 @@ dependencies = [
  "substrate-wasm-builder-runner",
  "sum-storage",
  "sum-storage-runtime-api",
-]
-
-[[package]]
-name = "app_dirs"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e73a24bad9bd6a94d6395382a6c69fe071708ae4409f763c5475e14ee896313d"
-dependencies = [
- "ole32-sys",
- "shell32-sys",
- "winapi 0.2.8",
- "xdg",
 ]
 
 [[package]]
@@ -205,7 +193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d0864d84b8e07b145449be9a8537db86bf9de5ce03b913214694643b4743502"
 dependencies = [
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
@@ -215,19 +203,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7deb0a829ca7bcfaf5da70b073a8d128619259a7be8216a355e23f00763059e5"
 
 [[package]]
-name = "async-std"
-version = "1.5.0"
+name = "async-macros"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "538ecb01eb64eecd772087e5b6f7540cbc917f047727339a472dafed2185b267"
+checksum = "e421d59b24c1feea2496e409b3e0a8de23e5fc130a2ddc0b012e551f3b272bba"
 dependencies = [
- "async-task",
- "broadcaster",
- "crossbeam-channel",
+ "futures-core-preview",
+ "pin-utils",
+]
+
+[[package]]
+name = "async-std"
+version = "0.99.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44501a9f7961bb539b67be0c428b3694e26557046a52759ca7eaf790030a64cc"
+dependencies = [
+ "async-macros",
+ "async-task 1.3.1",
+ "crossbeam-channel 0.3.9",
  "crossbeam-deque",
- "crossbeam-utils",
+ "crossbeam-utils 0.6.6",
  "futures-core",
  "futures-io",
- "futures-timer 2.0.2",
+ "futures-timer 1.0.3",
  "kv-log-macro",
  "log",
  "memchr",
@@ -241,6 +239,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-std"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45cee2749d880d7066e328a7e161c7470ced883b2fd000ca4643e9f1dd5083a"
+dependencies = [
+ "async-task 3.0.0",
+ "crossbeam-utils 0.7.2",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-timer 3.0.2",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "smol",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "async-task"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +271,12 @@ dependencies = [
  "libc",
  "winapi 0.3.8",
 ]
+
+[[package]]
+name = "async-task"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17772156ef2829aadc587461c7753af20b7e8db1529bc66855add962a3b35d3"
 
 [[package]]
 name = "async-tls"
@@ -287,7 +315,7 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "babe-grandpa-node"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "babe-grandpa-runtime",
  "ctrlc",
@@ -324,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "babe-grandpa-runtime"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -381,7 +409,7 @@ checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
 name = "basic-pow"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "futures 0.3.5",
  "log",
@@ -414,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "basic-token"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -426,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb26d6a69a335b8cb0e7c7e9775cd5666611dc50a37177c3f2cedcfc040e8c8"
+checksum = "c72a978d268b1d70b0e963217e60fdabd9523a941457a6c42a7315d15c7e89e5"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -440,7 +468,7 @@ dependencies = [
  "lazycell",
  "log",
  "peeking_take_while",
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
  "regex",
  "rustc-hash",
@@ -536,20 +564,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "broadcaster"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c972e21e0d055a36cf73e4daae870941fe7a8abcd5ac3396aab9e4c126bd87"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-sink",
- "futures-util",
- "parking_lot 0.10.2",
- "slab",
-]
-
-[[package]]
 name = "bs58"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -613,9 +627,9 @@ checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 
 [[package]]
 name = "cc"
-version = "1.0.53"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "404b1fe4f65288577753b17e3b36a04596ee784493ec249bf81c7f2d2acd751c"
+checksum = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
 dependencies = [
  "jobserver",
 ]
@@ -646,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "charity"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -661,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "check-membership"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -728,7 +742,7 @@ dependencies = [
 
 [[package]]
 name = "compounding-interest"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -763,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "constant-config"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -805,12 +819,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel 0.4.2",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils 0.7.2",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ec7fcd21571dc78f96cc96243cab8d8f035247c3efd16c687be154c3fa9efa"
+dependencies = [
+ "crossbeam-utils 0.6.6",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "maybe-uninit",
 ]
 
@@ -821,7 +858,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 dependencies = [
  "crossbeam-epoch",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "maybe-uninit",
 ]
 
@@ -833,7 +870,7 @@ checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
  "autocfg 1.0.0",
  "cfg-if",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "lazy_static",
  "maybe-uninit",
  "memoffset",
@@ -847,7 +884,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
 dependencies = [
  "cfg-if",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
+dependencies = [
+ "cfg-if",
+ "lazy_static",
 ]
 
 [[package]]
@@ -898,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "currency-imbalances"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -923,13 +970,13 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c0346158a19b3627234e15596f5e465c360fcdb97d817bcb255e0510f5a788"
+checksum = "72aa14c04dfae8dd7d8a2b1cb7ca2152618cd01336dbfe704b8dcbf8d41dbd69"
 
 [[package]]
 name = "default-instance"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -959,9 +1006,9 @@ version = "0.99.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2127768764f1556535c01b5326ef94bd60ff08dcfbdc544d53e69ed155610f5d"
 dependencies = [
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
@@ -971,6 +1018,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "directories"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "551a778172a450d7fc12e629ca3b0428d00f6afa9a43da1b630d54604e97371c"
+dependencies = [
+ "cfg-if",
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_users",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -991,7 +1060,7 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "double-map"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1061,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "execution-schedule"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1098,9 +1167,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
  "synstructure",
 ]
 
@@ -1148,7 +1217,7 @@ dependencies = [
 
 [[package]]
 name = "fixed-point"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1188,16 +1257,16 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "fork-tree"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "parity-scale-codec",
 ]
 
 [[package]]
 name = "frame-benchmarking"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1213,8 +1282,8 @@ dependencies = [
 
 [[package]]
 name = "frame-executive"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1228,8 +1297,8 @@ dependencies = [
 
 [[package]]
 name = "frame-metadata"
-version = "11.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "11.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -1239,8 +1308,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "bitmask",
  "frame-metadata",
@@ -1251,6 +1320,7 @@ dependencies = [
  "parity-scale-codec",
  "paste",
  "serde",
+ "smallvec 1.4.0",
  "sp-arithmetic",
  "sp-core",
  "sp-inherents",
@@ -1263,41 +1333,41 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "frame-support-procedural-tools",
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools-derive"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
 name = "frame-system"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "frame-support",
  "impl-trait-for-tuples",
@@ -1447,9 +1517,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
@@ -1469,6 +1539,16 @@ dependencies = [
 
 [[package]]
 name = "futures-timer"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7946248e9429ff093345d3e8fdf4eb0f9b2d79091611c9c14f744971a6f8be45"
+dependencies = [
+ "futures-core-preview",
+ "pin-utils",
+]
+
+[[package]]
+name = "futures-timer"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1de7508b218029b0f01662ed8f61b1c964b3ae99d6f25462d0f55a595109df6"
@@ -1478,6 +1558,10 @@ name = "futures-timer"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+dependencies = [
+ "gloo-timers",
+ "send_wrapper 0.4.0",
+]
 
 [[package]]
 name = "futures-util"
@@ -1541,7 +1625,7 @@ dependencies = [
 
 [[package]]
 name = "generic-event"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1607,6 +1691,19 @@ dependencies = [
  "fnv",
  "log",
  "regex",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1682,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "hello-substrate"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1808,7 +1905,7 @@ dependencies = [
 
 [[package]]
 name = "hybrid-consensus"
-version = "2.0.0-alpha.8"
+version = "2.0.0-dev"
 dependencies = [
  "ctrlc",
  "derive_more 0.15.0",
@@ -1972,9 +2069,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef5550a42e3740a0e71f909d4c861056a284060af885ae7aa6242820f920d9d"
 dependencies = [
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
@@ -2101,9 +2198,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8609af8f63b626e8e211f52441fcdb6ec54f1a446606b10d5c89ae9bf8a20058"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
@@ -2181,7 +2278,7 @@ dependencies = [
 
 [[package]]
 name = "kitchen-node"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "ctrlc",
  "derive_more 0.15.0",
@@ -2216,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "kv-log-macro"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2d3beed37e5483887d81eb39de6de03a8346531410e1306ca48a9a89bd3a51"
+checksum = "4ff57d6d215f7ca7eb35a9a64d656ba4d9d2bef114d741dc08048e75e2f5d418"
 dependencies = [
  "log",
 ]
@@ -2264,7 +2361,7 @@ dependencies = [
 
 [[package]]
 name = "last-caller"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2288,9 +2385,9 @@ checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "libc"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3baa92041a6fec78c687fa0cc2b3fae8884f743d672cf551bed1d6dac6988d0f"
+checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 
 [[package]]
 name = "libflate"
@@ -2328,9 +2425,9 @@ checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "libp2p"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ec214d189b57e4412f079ac5a1442578d06b12ca7282ba4696104cc92ab96c1"
+checksum = "057eba5432d3e740e313c6e13c9153d0cb76b4f71bfc2e5242ae5bdb7d41af67"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.5",
@@ -2359,9 +2456,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80a6000296bdbff540b6c00ef82108ef23aa68d195b9333823ea491562c338d7"
+checksum = "4f5e30dcd8cb13a02ad534e214da234eca1595a76b5788b645dfa5c734d2124b"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -2393,12 +2490,12 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core-derive"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67f0d915bee5d457a6d113377101e1f06e86a4286778aa4c6939553e9a4d7033"
+checksum = "f09548626b737ed64080fde595e06ce1117795b8b9fc4d2629fa36561c583171"
 dependencies = [
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
@@ -2414,9 +2511,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identify"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a455af71c59473444eba05e83dbaa20262bdbd9b4154f22389510fbac16f201"
+checksum = "6438ed8ca240c7635c9caa3be6c5258bc0058553ae97ba81737f04e5d33804f5"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
@@ -2457,11 +2554,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5bc788d92111802cb0c92d2e032fa6f46333aaeb5650c2f37b5d3eba78cabe6"
+checksum = "51b00163d13f705aae67c427bea0575f8aaf63da6524f9bd4a5a093b8bda0b38"
 dependencies = [
- "async-std",
+ "async-std 0.99.12",
  "data-encoding",
  "dns-parser",
  "either",
@@ -2479,9 +2576,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4095bce2100f840883f1f75dbd010c966ee4ad323ae9f82026396da5cf6cce68"
+checksum = "34ce63313ad4bce2d76e54c292a1293ea47a0ebbe16708f1513fa62184992f53"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -2516,9 +2613,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82930c36490008b1ef2f26c237a2c205c38ef6edc263738d0528b842740ab09f"
+checksum = "c189cf1dfe4b3f01e2c0fe5e97a6f5df8aeb6f3569e26981015eb7c08015ce5f"
 dependencies = [
  "futures 0.3.5",
  "libp2p-core",
@@ -2546,11 +2643,11 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4462bd96b97cac3f3a83b1b343ad3c3460cebbc8d929c040b1520c30e3611e08"
+checksum = "309f95fce9bec755eff5406f8b822fd3969990830c2b54f752e1fc181d5ace3e"
 dependencies = [
- "async-std",
+ "async-std 0.99.12",
  "futures 0.3.5",
  "futures-timer 3.0.2",
  "get_if_addrs",
@@ -2685,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "lockable-currency"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2706,16 +2803,16 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0609345ddee5badacf857d4f547e0e5a2e987db77085c24cd887f73573a04237"
+checksum = "9e488db3a9e108382265a30764f43cfc87517322e5d04ae0603b32a33461dca3"
 dependencies = [
  "hashbrown",
 ]
 
 [[package]]
 name = "manual-seal"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "futures 0.3.5",
  "jsonrpc-core",
@@ -2824,7 +2921,7 @@ dependencies = [
 
 [[package]]
 name = "minimal-grandpa-runtime"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -2917,9 +3014,9 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae32179a9904ccc6e063de8beee7f5dd55fae85ecb851ca923d55722bc28cf5d"
+checksum = "f75db05d738947aa5389863aadafbcf2e509d7ba099dc2ddcdf4fc66bf7a9e03"
 dependencies = [
  "blake2b_simd",
  "blake2s_simd",
@@ -2938,9 +3035,9 @@ checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
 
 [[package]]
 name = "multistream-select"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74cdcf7cfb3402881e15a1f95116cb033d69b33c83d481e1234777f5ef0c3d2c"
+checksum = "991c33683908c588b8f2cf66c221d8f390818c1bdcd13fce55208408e027a796"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.5",
@@ -3125,7 +3222,7 @@ checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
 
 [[package]]
 name = "ocw-runtime"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -3155,7 +3252,7 @@ dependencies = [
 
 [[package]]
 name = "offchain-demo"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "alt_serde",
  "frame-support",
@@ -3167,16 +3264,6 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std",
-]
-
-[[package]]
-name = "ole32-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2c49021782e5233cd243168edfa8037574afed4eba4bbaf538b3d8d1789d8c"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
 ]
 
 [[package]]
@@ -3211,8 +3298,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-babe"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3233,23 +3320,22 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "serde",
- "sp-io",
  "sp-runtime",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-finality-tracker"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3264,8 +3350,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-generic-asset"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3277,8 +3363,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-grandpa"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3297,8 +3383,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-indices"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3313,8 +3399,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-randomness-collective-flip"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3326,8 +3412,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-session"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3335,7 +3421,6 @@ dependencies = [
  "pallet-timestamp",
  "parity-scale-codec",
  "serde",
- "sp-io",
  "sp-runtime",
  "sp-session",
  "sp-staking",
@@ -3345,8 +3430,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-sudo"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3359,8 +3444,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-timestamp"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3376,21 +3461,22 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "frame-support",
  "frame-system",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
+ "smallvec 1.4.0",
  "sp-runtime",
  "sp-std",
 ]
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3485,9 +3571,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a0ec292e92e8ec7c58e576adacc1e3f399c597c8f263c42f18420abe58e7245"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
@@ -3517,8 +3603,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f557c32c6d268a07c921471619c0295f5efad3a0e76d4f97a05c091a51d110b2"
 dependencies = [
- "proc-macro2 1.0.13",
- "syn 1.0.22",
+ "proc-macro2 1.0.17",
+ "syn 1.0.26",
  "synstructure",
 ]
 
@@ -3580,9 +3666,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a229b1c58c692edcaa5b9b0948084f130f55d2dcc15b02fcc5340b2b4521476"
+checksum = "3431e8f72b90f8a7af91dec890d9814000cb371258e0ec7370d93e085361f531"
 dependencies = [
  "paste-impl",
  "proc-macro-hack",
@@ -3590,14 +3676,14 @@ dependencies = [
 
 [[package]]
 name = "paste-impl"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0bf239e447e67ff6d16a8bb5e4d4bd2343acf5066061c0e8e06ac5ba8ca68c"
+checksum = "25af5fc872ba284d8d84608bf8a0fa9b5376c96c23f503b007dfd9e34dde5606"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
@@ -3636,9 +3722,9 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "petgraph"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c127eea4a29ec6c85d153c59dc1213f33ec74cead30fe4730aecc88cc1fd92"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -3659,9 +3745,9 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e58db2081ba5b4c93bd6be09c40fd36cb9193a8336c384f3b40012e531aa7e40"
 dependencies = [
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
@@ -3675,6 +3761,18 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0deb65f46e873ba8aa7c6a8dbe3f23cb1bf59c339a81a1d56361dde4d66ac8"
+dependencies = [
+ "crossbeam-utils 0.7.2",
+ "futures-io",
+ "futures-sink",
+ "futures-util",
+]
 
 [[package]]
 name = "pkg-config"
@@ -3722,9 +3820,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
  "version_check",
 ]
 
@@ -3734,18 +3832,18 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
  "syn-mid",
  "version_check",
 ]
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d659fe7c6d27f25e9d80a1a094c223f5246f6a6596453e09d7229bf42750b63"
+checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
 
 [[package]]
 name = "proc-macro-nested"
@@ -3764,9 +3862,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.13"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f5ffe53a6b28e37c9c1ce74893477864d64f74778a93a4beb43c8fa167f639"
+checksum = "1502d12e458c49a4c9cbff560d0fe0060c252bc29799ed94ca2ed4bb665a0101"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -3836,9 +3934,9 @@ checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
  "itertools",
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
@@ -3895,7 +3993,7 @@ version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
 dependencies = [
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
 ]
 
 [[package]]
@@ -4099,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "randomness"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4138,7 +4236,7 @@ checksum = "08a89b46efaf957e52b18062fb2f4660f8b8a4dde1807ca002690868ef2c85a9"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-queue",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "lazy_static",
  "num_cpus",
 ]
@@ -4159,6 +4257,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
+name = "redox_users"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "rust-argon2",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4173,9 +4282,9 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602eb59cda66fcb9aec25841fb76bc01d2b34282dcdd705028da297db6f3eec8"
 dependencies = [
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
@@ -4207,7 +4316,7 @@ dependencies = [
 
 [[package]]
 name = "reservable-currency"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4235,7 +4344,7 @@ dependencies = [
 
 [[package]]
 name = "ringbuffer-queue"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -4274,7 +4383,7 @@ dependencies = [
 
 [[package]]
 name = "rpc-node"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "api-runtime",
  "ctrlc",
@@ -4308,6 +4417,18 @@ dependencies = [
  "tokio 0.1.22",
  "trie-root 0.15.2",
  "vergen",
+]
+
+[[package]]
+name = "rust-argon2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
+dependencies = [
+ "base64",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils 0.7.2",
 ]
 
 [[package]]
@@ -4390,8 +4511,8 @@ dependencies = [
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -4414,8 +4535,8 @@ dependencies = [
 
 [[package]]
 name = "sc-block-builder"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "parity-scale-codec",
  "sc-client-api",
@@ -4430,8 +4551,8 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "impl-trait-for-tuples",
  "sc-chain-spec-derive",
@@ -4446,26 +4567,25 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec-derive"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
 name = "sc-cli"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "ansi_term 0.12.1",
- "app_dirs",
  "atty",
  "chrono",
- "clap",
  "derive_more 0.99.7",
+ "directories",
  "env_logger",
  "fdlimit",
  "futures 0.3.5",
@@ -4499,8 +4619,8 @@ dependencies = [
 
 [[package]]
 name = "sc-client-api"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "derive_more 0.99.7",
  "fnv",
@@ -4535,8 +4655,8 @@ dependencies = [
 
 [[package]]
 name = "sc-client-db"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "blake2-rfc",
  "hash-db",
@@ -4564,8 +4684,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "sc-client-api",
  "sp-blockchain",
@@ -4575,8 +4695,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-babe"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "derive_more 0.99.7",
  "fork-tree",
@@ -4617,8 +4737,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-epochs"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -4630,8 +4750,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-manual-seal"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "assert_matches",
  "derive_more 0.99.7",
@@ -4655,8 +4775,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-pow"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "derive_more 0.99.7",
  "futures 0.3.5",
@@ -4677,8 +4797,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -4699,8 +4819,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-uncles"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "log",
  "sc-client-api",
@@ -4713,8 +4833,8 @@ dependencies = [
 
 [[package]]
 name = "sc-executor"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "derive_more 0.99.7",
  "lazy_static",
@@ -4740,8 +4860,8 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-common"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "derive_more 0.99.7",
  "log",
@@ -4757,8 +4877,8 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-wasmi"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -4772,8 +4892,8 @@ dependencies = [
 
 [[package]]
 name = "sc-finality-grandpa"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "assert_matches",
  "derive_more 0.99.7",
@@ -4809,8 +4929,8 @@ dependencies = [
 
 [[package]]
 name = "sc-informant"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "ansi_term 0.12.1",
  "futures 0.3.5",
@@ -4826,8 +4946,8 @@ dependencies = [
 
 [[package]]
 name = "sc-keystore"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "derive_more 0.99.7",
  "hex",
@@ -4841,8 +4961,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "bitflags",
  "bs58",
@@ -4893,8 +5013,8 @@ dependencies = [
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "futures 0.3.5",
  "futures-timer 3.0.2",
@@ -4908,8 +5028,8 @@ dependencies = [
 
 [[package]]
 name = "sc-offchain"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -4935,8 +5055,8 @@ dependencies = [
 
 [[package]]
 name = "sc-peerset"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "futures 0.3.5",
  "libp2p",
@@ -4948,8 +5068,8 @@ dependencies = [
 
 [[package]]
 name = "sc-proposer-metrics"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -4957,8 +5077,8 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -4989,8 +5109,8 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "derive_more 0.99.7",
  "futures 0.3.5",
@@ -5013,8 +5133,8 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-server"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "jsonrpc-core",
  "jsonrpc-http-server",
@@ -5028,8 +5148,8 @@ dependencies = [
 
 [[package]]
 name = "sc-service"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "derive_more 0.99.7",
  "exit-future",
@@ -5086,8 +5206,8 @@ dependencies = [
 
 [[package]]
 name = "sc-state-db"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -5100,8 +5220,8 @@ dependencies = [
 
 [[package]]
 name = "sc-telemetry"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.5",
@@ -5122,8 +5242,8 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "erased-serde",
  "log",
@@ -5137,8 +5257,8 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-graph"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "derive_more 0.99.7",
  "futures 0.3.5",
@@ -5157,8 +5277,8 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "derive_more 0.99.7",
  "futures 0.3.5",
@@ -5208,6 +5328,12 @@ dependencies = [
  "subtle 2.2.2",
  "zeroize",
 ]
+
+[[package]]
+name = "scoped-tls-hkt"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e9d7eaddb227e8fbaaa71136ae0e1e913ca159b86c7da82f3e8f0044ad3a63"
 
 [[package]]
 name = "scopeguard"
@@ -5270,6 +5396,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0eddf2e8f50ced781f288c19f18621fa72a3779e3cb58dbf23b07469b0abeb4"
 
 [[package]]
+name = "send_wrapper"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+
+[[package]]
 name = "serde"
 version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5284,9 +5416,9 @@ version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818fbf6bfa9a42d3bfcaca148547aa00c7b915bec71d1757aa2d44ca68771984"
 dependencies = [
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
@@ -5330,9 +5462,9 @@ checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sha2"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
+checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
 dependencies = [
  "block-buffer",
  "digest",
@@ -5355,7 +5487,7 @@ dependencies = [
 
 [[package]]
 name = "sha3pow"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "parity-scale-codec",
  "rand 0.7.3",
@@ -5365,16 +5497,6 @@ dependencies = [
  "sp-consensus-pow",
  "sp-core",
  "sp-runtime",
-]
-
-[[package]]
-name = "shell32-sys"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee04b46101f57121c9da2b151988283b6beb79b34f5bb29a58ee48cb695122c"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
 ]
 
 [[package]]
@@ -5395,7 +5517,7 @@ dependencies = [
 
 [[package]]
 name = "simple-crowdfund"
-version = "2.0.0-alpha.8"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5410,7 +5532,7 @@ dependencies = [
 
 [[package]]
 name = "simple-event"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5422,7 +5544,7 @@ dependencies = [
 
 [[package]]
 name = "simple-map"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5434,7 +5556,7 @@ dependencies = [
 
 [[package]]
 name = "single-value"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5489,9 +5611,9 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a945ec7f7ce853e89ffa36be1e27dce9a43e82ff9093bf3461c30d5da74ed11b"
 dependencies = [
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
@@ -5508,6 +5630,25 @@ name = "smallvec"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
+
+[[package]]
+name = "smol"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686c634ad1873fffef6aed20f180eede424fbf3bb31802394c90fd7335a661b7"
+dependencies = [
+ "async-task 3.0.0",
+ "crossbeam",
+ "futures-io",
+ "futures-util",
+ "nix",
+ "once_cell",
+ "piper",
+ "scoped-tls-hkt",
+ "slab",
+ "socket2",
+ "wepoll-binding",
+]
 
 [[package]]
 name = "snow"
@@ -5561,8 +5702,8 @@ dependencies = [
 
 [[package]]
 name = "sp-allocator"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "derive_more 0.99.7",
  "log",
@@ -5573,8 +5714,8 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "hash-db",
  "parity-scale-codec",
@@ -5588,20 +5729,20 @@ dependencies = [
 
 [[package]]
 name = "sp-api-proc-macro"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "blake2-rfc",
  "proc-macro-crate",
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
 name = "sp-application-crypto"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "parity-scale-codec",
  "serde",
@@ -5612,13 +5753,12 @@ dependencies = [
 
 [[package]]
 name = "sp-arithmetic"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "integer-sqrt",
  "num-traits 0.2.11",
  "parity-scale-codec",
- "primitive-types",
  "serde",
  "sp-debug-derive",
  "sp-std",
@@ -5626,8 +5766,8 @@ dependencies = [
 
 [[package]]
 name = "sp-authorship"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -5637,8 +5777,8 @@ dependencies = [
 
 [[package]]
 name = "sp-block-builder"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -5649,8 +5789,8 @@ dependencies = [
 
 [[package]]
 name = "sp-blockchain"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "derive_more 0.99.7",
  "log",
@@ -5665,8 +5805,8 @@ dependencies = [
 
 [[package]]
 name = "sp-chain-spec"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "serde",
  "serde_json 1.0.53",
@@ -5674,8 +5814,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "derive_more 0.99.7",
  "futures 0.3.5",
@@ -5697,8 +5837,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-babe"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "merlin",
  "parity-scale-codec",
@@ -5714,8 +5854,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-pow"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -5726,8 +5866,8 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-vrf"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "parity-scale-codec",
  "schnorrkel",
@@ -5738,8 +5878,8 @@ dependencies = [
 
 [[package]]
 name = "sp-core"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "base58",
  "blake2-rfc",
@@ -5780,8 +5920,8 @@ dependencies = [
 
 [[package]]
 name = "sp-database"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "kvdb",
  "parking_lot 0.10.2",
@@ -5789,18 +5929,18 @@ dependencies = [
 
 [[package]]
 name = "sp-debug-derive"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
 name = "sp-externalities"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -5810,8 +5950,8 @@ dependencies = [
 
 [[package]]
 name = "sp-finality-grandpa"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -5826,8 +5966,8 @@ dependencies = [
 
 [[package]]
 name = "sp-finality-tracker"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "parity-scale-codec",
  "sp-inherents",
@@ -5836,8 +5976,8 @@ dependencies = [
 
 [[package]]
 name = "sp-inherents"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "derive_more 0.99.7",
  "parity-scale-codec",
@@ -5848,8 +5988,8 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "futures 0.3.5",
  "hash-db",
@@ -5868,8 +6008,8 @@ dependencies = [
 
 [[package]]
 name = "sp-keyring"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "lazy_static",
  "sp-core",
@@ -5879,8 +6019,8 @@ dependencies = [
 
 [[package]]
 name = "sp-offchain"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -5889,8 +6029,8 @@ dependencies = [
 
 [[package]]
 name = "sp-panic-handler"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "backtrace",
  "log",
@@ -5898,8 +6038,8 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "serde",
  "sp-core",
@@ -5907,8 +6047,8 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "hash256-std-hasher",
  "impl-trait-for-tuples",
@@ -5928,8 +6068,8 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -5943,20 +6083,20 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface-proc-macro"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "Inflector",
  "proc-macro-crate",
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
 name = "sp-serializer"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "serde",
  "serde_json 1.0.53",
@@ -5964,8 +6104,8 @@ dependencies = [
 
 [[package]]
 name = "sp-session"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -5977,8 +6117,8 @@ dependencies = [
 
 [[package]]
 name = "sp-staking"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "parity-scale-codec",
  "sp-runtime",
@@ -5987,8 +6127,8 @@ dependencies = [
 
 [[package]]
 name = "sp-state-machine"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "hash-db",
  "log",
@@ -6006,13 +6146,13 @@ dependencies = [
 
 [[package]]
 name = "sp-std"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 
 [[package]]
 name = "sp-storage"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "impl-serde 0.2.3",
  "ref-cast",
@@ -6023,8 +6163,8 @@ dependencies = [
 
 [[package]]
 name = "sp-timestamp"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6037,16 +6177,16 @@ dependencies = [
 
 [[package]]
 name = "sp-tracing"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "sp-transaction-pool"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "derive_more 0.99.7",
  "futures 0.3.5",
@@ -6060,8 +6200,8 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "hash-db",
  "memory-db",
@@ -6074,8 +6214,8 @@ dependencies = [
 
 [[package]]
 name = "sp-utils"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "futures 0.3.5",
  "futures-core",
@@ -6085,8 +6225,8 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "impl-serde 0.2.3",
  "parity-scale-codec",
@@ -6097,8 +6237,8 @@ dependencies = [
 
 [[package]]
 name = "sp-wasm-interface"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -6135,7 +6275,7 @@ dependencies = [
 
 [[package]]
 name = "storage-cache"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6163,7 +6303,7 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "struct-storage"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6193,9 +6333,9 @@ checksum = "d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
@@ -6214,9 +6354,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0054a7df764039a6cd8592b9de84be4bec368ff081d203a7d5371cbfa8e65c81"
 dependencies = [
  "heck",
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
@@ -6233,8 +6373,8 @@ dependencies = [
 
 [[package]]
 name = "substrate-build-script-utils"
-version = "2.0.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "2.0.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
  "platforms",
 ]
@@ -6250,10 +6390,10 @@ dependencies = [
 
 [[package]]
 name = "substrate-prometheus-endpoint"
-version = "0.8.0-dev"
-source = "git+https://github.com/paritytech/substrate?rev=12e08fd25455053e3cedc8b19beb7e77330a5713#12e08fd25455053e3cedc8b19beb7e77330a5713"
+version = "0.8.0-rc2"
+source = "git+https://github.com/paritytech/substrate?rev=45b9f0a9cbf901abaa9f1fca5fe8baeed029133d#45b9f0a9cbf901abaa9f1fca5fe8baeed029133d"
 dependencies = [
- "async-std",
+ "async-std 1.6.0",
  "derive_more 0.99.7",
  "futures-util",
  "hyper 0.13.5",
@@ -6282,7 +6422,7 @@ checksum = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
 
 [[package]]
 name = "sum-storage"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6319,7 +6459,7 @@ dependencies = [
 
 [[package]]
 name = "super-runtime"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "adding-machine",
  "basic-token",
@@ -6391,11 +6531,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.22"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1425de3c33b0941002740a420b1a906a350b88d08b82b2c8a01035a3f9447bac"
+checksum = "2010dd20d6200209c24f17022e34c73b8e79fb42180f8c9ca970a8dbc44acc8c"
 dependencies = [
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
  "unicode-xid 0.2.0",
 ]
@@ -6406,9 +6546,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
@@ -6426,9 +6566,9 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
  "unicode-xid 0.2.0",
 ]
 
@@ -6487,22 +6627,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5976891d6950b4f68477850b5b9e5aa64d955961466f9e174363f573e54e8ca7"
+checksum = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab81dbd1cd69cd2ce22ecfbdd3bdb73334ba25350649408cc6c085f46d89573d"
+checksum = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
 dependencies = [
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
@@ -6642,7 +6782,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures 0.1.29",
 ]
 
@@ -6685,7 +6825,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures 0.1.29",
  "lazy_static",
  "log",
@@ -6700,9 +6840,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4adb8b3e5f86b707f1b54e7c15b6de52617a823608ccda98a15d3a24222f265a"
+checksum = "15cb62a0d2770787abc96e99c1cd98fcf17f94959f3af63ca85bdfb203f051b4"
 dependencies = [
  "futures-core",
  "rustls",
@@ -6753,7 +6893,7 @@ checksum = "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-queue",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures 0.1.29",
  "lazy_static",
  "log",
@@ -6768,7 +6908,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
  "futures 0.1.29",
  "slab",
  "tokio-executor 0.1.10",
@@ -6853,9 +6993,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99bbad0de3fd923c9c3232ead88510b783e5a4d16a6154adffa3d53308de984c"
 dependencies = [
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
 ]
 
 [[package]]
@@ -7036,7 +7176,7 @@ checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 
 [[package]]
 name = "vec-set"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7065,9 +7205,9 @@ dependencies = [
 
 [[package]]
 name = "version_check"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "void"
@@ -7121,9 +7261,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
  "wasm-bindgen-shared",
 ]
 
@@ -7155,9 +7295,9 @@ version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eb197bd3a47553334907ffd2f16507b4f4f01bbec3ac921a7719e0decdfe72a"
 dependencies = [
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7178,7 +7318,7 @@ dependencies = [
  "js-sys",
  "parking_lot 0.9.0",
  "pin-utils",
- "send_wrapper",
+ "send_wrapper 0.2.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -7247,7 +7387,7 @@ dependencies = [
 
 [[package]]
 name = "weight-fee-runtime"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-executive",
  "frame-support",
@@ -7277,13 +7417,32 @@ dependencies = [
 
 [[package]]
 name = "weights"
-version = "2.0.0-alpha.7"
+version = "2.0.0-dev"
 dependencies = [
  "frame-support",
  "frame-system",
  "parity-scale-codec",
  "sp-core",
  "sp-runtime",
+]
+
+[[package]]
+name = "wepoll-binding"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374fff4ff9701ff8b6ad0d14bacd3156c44063632d8c136186ff5967d48999a7"
+dependencies = [
+ "bitflags",
+ "wepoll-sys",
+]
+
+[[package]]
+name = "wepoll-sys"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9082a777aed991f6769e2b654aa0cb29f1c3d615daf009829b07b66c7aff6a24"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -7378,12 +7537,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "xdg"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d089681aa106a86fade1b0128fb5daf07d5867a509ab036d99988dec80429a57"
-
-[[package]]
 name = "yamux"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7412,8 +7565,8 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
- "proc-macro2 1.0.13",
+ "proc-macro2 1.0.17",
  "quote 1.0.6",
- "syn 1.0.22",
+ "syn 1.0.26",
  "synstructure",
 ]

--- a/consensus/sha3pow/Cargo.toml
+++ b/consensus/sha3pow/Cargo.toml
@@ -18,8 +18,8 @@ compatibility_version = "2.0.0-dev"
 parity-scale-codec = '1.3.0'
 sha3 = "0.8"
 rand = { version = "0.7", features = ["small_rng"] }
-sc-consensus-pow = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-consensus-pow = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
+sc-consensus-pow = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-consensus-pow = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }

--- a/nodes/babe-grandpa-node/Cargo.toml
+++ b/nodes/babe-grandpa-node/Cargo.toml
@@ -32,24 +32,24 @@ tokio = "0.1.22"
 exit-future = "0.2.0"
 parking_lot = "0.9.0"
 trie-root = "0.15.2"
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-cli = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-client-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-executor = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-service = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-inherents = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-network = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-consensus-babe = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-consensus-babe = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-finality-grandpa = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-finality-grandpa = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-basic-authorship = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-cli = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-client-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-executor = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-service = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-inherents = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-network = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-consensus-babe = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-consensus-babe = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-finality-grandpa = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-finality-grandpa = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-basic-authorship = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
 
 # This node only works with runtimes that can provide babe and grandpa authorities.
 # No other runtimes that come with the recipes provide these APIs, but the substrate demonstration
@@ -66,7 +66,7 @@ runtime = { package = "babe-grandpa-runtime", path = "../../runtimes/babe-grandp
 
 [build-dependencies]
 vergen = "3.0.4"
-substrate-build-script-utils = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
+substrate-build-script-utils = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
 
 [features]
 ocw = []

--- a/nodes/basic-pow/Cargo.toml
+++ b/nodes/basic-pow/Cargo.toml
@@ -27,23 +27,23 @@ structopt = '0.3.8'
 parity-scale-codec = '1.3.0'
 sha3 = "0.8"
 rand = { version = "0.7", features = ["small_rng"] }
-sc-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-consensus-pow = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-consensus-pow = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-client-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-blockchain = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-timestamp = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-basic-authorship = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-cli = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-executor = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-network = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-service = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-inherents = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
+sc-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-consensus-pow = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-consensus-pow = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-client-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-blockchain = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-timestamp = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-basic-authorship = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-cli = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-executor = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-network = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-service = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-inherents = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
 sha3pow = { path = '../../consensus/sha3pow' }
 
 # This node is compatible with any of the runtimes below
@@ -60,4 +60,4 @@ runtime = { package = "super-runtime", path = "../../runtimes/super-runtime" }
 
 [build-dependencies]
 vergen = '3.0.4'
-substrate-build-script-utils = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
+substrate-build-script-utils = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }

--- a/nodes/hybrid-consensus/Cargo.toml
+++ b/nodes/hybrid-consensus/Cargo.toml
@@ -33,25 +33,25 @@ tokio = "0.1.22"
 exit-future = "0.2.0"
 parking_lot = "0.9.0"
 trie-root = "0.15.2"
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-cli = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-client-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-executor = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-service = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-inherents = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-timestamp = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-network = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-finality-grandpa = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-finality-grandpa = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-basic-authorship = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-consensus-pow = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-consensus-pow = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-cli = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-client-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-executor = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-service = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-inherents = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-timestamp = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-network = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-finality-grandpa = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-finality-grandpa = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-basic-authorship = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-consensus-pow = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-consensus-pow = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
 sha3pow = { path = '../../consensus/sha3pow' }
 
 runtime = { package = "minimal-grandpa-runtime", path = "../../runtimes/minimal-grandpa-runtime"}
@@ -59,4 +59,4 @@ runtime = { package = "minimal-grandpa-runtime", path = "../../runtimes/minimal-
 
 [build-dependencies]
 vergen = "3.0.4"
-substrate-build-script-utils = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
+substrate-build-script-utils = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }

--- a/nodes/kitchen-node/Cargo.toml
+++ b/nodes/kitchen-node/Cargo.toml
@@ -31,22 +31,22 @@ tokio = "0.1.22"
 exit-future = "0.2.0"
 parking_lot = "0.9.0"
 trie-root = "0.15.2"
-sc-basic-authorship = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-cli = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-client-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-consensus-manual-seal = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-executor = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-network = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-service = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-inherents = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-timestamp = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
+sc-basic-authorship = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-cli = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-client-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-consensus-manual-seal = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-executor = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-network = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-service = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-inherents = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-timestamp = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
 
 # This node is compatible with any of the runtimes below
 # ---
@@ -67,7 +67,7 @@ runtime = { package = "super-runtime", path = "../../runtimes/super-runtime" }
 
 [build-dependencies]
 vergen = "3.0.4"
-substrate-build-script-utils = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
+substrate-build-script-utils = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
 
 [features]
 ocw = []

--- a/nodes/manual-seal/Cargo.toml
+++ b/nodes/manual-seal/Cargo.toml
@@ -30,23 +30,23 @@ sha3 = "0.8"
 rand = { version = "0.7", features = ["small_rng"] }
 jsonrpc-core = "14.0.5"
 
-sc-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-consensus-manual-seal = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-rpc = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-client-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-blockchain =  { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-timestamp = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-basic-authorship = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-cli = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-executor = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-network = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-service = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-inherents = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
+sc-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-consensus-manual-seal = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-rpc = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-client-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-blockchain =  { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-timestamp = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-basic-authorship = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-cli = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-executor = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-network = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-service = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-inherents = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
 
 # This node is compatible with any of the runtimes below
 # ---
@@ -64,4 +64,4 @@ runtime = { package = "super-runtime", path = "../../runtimes/super-runtime" }
 
 [build-dependencies]
 vergen = '3.0.4'
-substrate-build-script-utils = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
+substrate-build-script-utils = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }

--- a/nodes/rpc-node/Cargo.toml
+++ b/nodes/rpc-node/Cargo.toml
@@ -34,24 +34,24 @@ jsonrpc-core-client = "14.0.3"
 jsonrpc-derive = "14.0.3"
 ctrlc = { features = ['termination'], version = '3.1.3' }
 futures01 = { package = 'futures', version = '0.1.29'}
-sc-rpc = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-client-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
+sc-rpc = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-client-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
 sum-storage-rpc = { path = "../../pallets/sum-storage/rpc" }
-sc-basic-authorship = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-cli = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-consensus-manual-seal = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-executor = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-network = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-service = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-inherents = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-timestamp = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
+sc-basic-authorship = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-cli = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-consensus-manual-seal = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-executor = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-network = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-service = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-inherents = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-timestamp = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
 
 # RPC Node only works with Runtime's that provide the sum-storage-runtime-api
 # That means it only works with the api-runtime
@@ -59,4 +59,4 @@ runtime = { package = "api-runtime", path = "../../runtimes/api-runtime" }
 
 [build-dependencies]
 vergen = '3.0.4'
-substrate-build-script-utils = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
+substrate-build-script-utils = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }

--- a/pallets/adding-machine/Cargo.toml
+++ b/pallets/adding-machine/Cargo.toml
@@ -26,10 +26,10 @@ std = [
 
 [dependencies]
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [dev-dependencies]
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/pallets/adding-machine/src/tests.rs
+++ b/pallets/adding-machine/src/tests.rs
@@ -38,6 +38,7 @@ impl system::Trait for TestRuntime {
 	type DbWeight = ();
 	type BlockExecutionWeight = ();
 	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();

--- a/pallets/basic-token/Cargo.toml
+++ b/pallets/basic-token/Cargo.toml
@@ -28,10 +28,10 @@ std = [
 
 [dependencies]
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [dev-dependencies]
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/pallets/basic-token/src/tests.rs
+++ b/pallets/basic-token/src/tests.rs
@@ -38,6 +38,7 @@ impl system::Trait for TestRuntime {
 	type DbWeight = ();
 	type BlockExecutionWeight = ();
 	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();

--- a/pallets/charity/Cargo.toml
+++ b/pallets/charity/Cargo.toml
@@ -29,12 +29,12 @@ std = [
 [dependencies]
 serde = "1.0.102"
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-balances = { package = 'pallet-balances', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+balances = { package = 'pallet-balances', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [dev-dependencies]
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/pallets/charity/src/tests.rs
+++ b/pallets/charity/src/tests.rs
@@ -43,6 +43,8 @@ impl system::Trait for TestRuntime {
 	type DbWeight = ();
 	type BlockExecutionWeight = ();
 	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();

--- a/pallets/charity/src/tests.rs
+++ b/pallets/charity/src/tests.rs
@@ -44,7 +44,6 @@ impl system::Trait for TestRuntime {
 	type BlockExecutionWeight = ();
 	type ExtrinsicBaseWeight = ();
 	type MaximumExtrinsicWeight = MaximumBlockWeight;
-	type MaximumExtrinsicWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();

--- a/pallets/check-membership/Cargo.toml
+++ b/pallets/check-membership/Cargo.toml
@@ -27,8 +27,8 @@ std = [
 
 [dependencies]
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/pallets/compounding-interest/Cargo.toml
+++ b/pallets/compounding-interest/Cargo.toml
@@ -31,12 +31,12 @@ std = [
 [dependencies]
 substrate-fixed = { git = 'https://github.com/encointer/substrate-fixed.git', tag = "v0.5.4+sub_v0.1" }
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-arithmetic = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-arithmetic = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [dev-dependencies]
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/pallets/compounding-interest/src/tests.rs
+++ b/pallets/compounding-interest/src/tests.rs
@@ -41,6 +41,7 @@ impl system::Trait for TestRuntime {
 	type DbWeight = ();
 	type BlockExecutionWeight = ();
 	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();

--- a/pallets/constant-config/Cargo.toml
+++ b/pallets/constant-config/Cargo.toml
@@ -26,10 +26,10 @@ std = [
 
 [dependencies]
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [dev-dependencies]
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/pallets/constant-config/src/tests.rs
+++ b/pallets/constant-config/src/tests.rs
@@ -41,6 +41,7 @@ impl system::Trait for TestRuntime {
 	type DbWeight = ();
 	type BlockExecutionWeight = ();
 	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();

--- a/pallets/currency-imbalances/Cargo.toml
+++ b/pallets/currency-imbalances/Cargo.toml
@@ -27,10 +27,10 @@ std = [
 
 [dependencies]
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [dev-dependencies]
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/pallets/default-instance/Cargo.toml
+++ b/pallets/default-instance/Cargo.toml
@@ -26,10 +26,10 @@ std = [
 
 [dependencies]
 parity-scale-codec = { default-features = false, features = ['derive'], version = '1.3.0' }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [dev-dependencies]
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/pallets/double-map/Cargo.toml
+++ b/pallets/double-map/Cargo.toml
@@ -27,11 +27,11 @@ std = [
 
 [dependencies]
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [dev-dependencies]
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/pallets/double-map/src/tests.rs
+++ b/pallets/double-map/src/tests.rs
@@ -38,6 +38,7 @@ impl system::Trait for TestRuntime {
 	type DbWeight = ();
 	type BlockExecutionWeight = ();
 	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();

--- a/pallets/execution-schedule/Cargo.toml
+++ b/pallets/execution-schedule/Cargo.toml
@@ -27,12 +27,12 @@ std = [
 
 [dependencies]
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [dev-dependencies]
 rand = "0.7.2"
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/pallets/execution-schedule/src/tests.rs
+++ b/pallets/execution-schedule/src/tests.rs
@@ -135,6 +135,7 @@ impl system::Trait for TestRuntime {
 	type DbWeight = ();
 	type BlockExecutionWeight = ();
 	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();

--- a/pallets/fixed-point/Cargo.toml
+++ b/pallets/fixed-point/Cargo.toml
@@ -30,12 +30,12 @@ std = [
 [dependencies]
 substrate-fixed = { git = 'https://github.com/encointer/substrate-fixed.git', tag = "v0.5.4+sub_v0.1" }
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-arithmetic = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-arithmetic = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [dev-dependencies]
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/pallets/fixed-point/src/tests.rs
+++ b/pallets/fixed-point/src/tests.rs
@@ -41,6 +41,7 @@ impl system::Trait for TestRuntime {
 	type DbWeight = ();
 	type BlockExecutionWeight = ();
 	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();

--- a/pallets/generic-event/Cargo.toml
+++ b/pallets/generic-event/Cargo.toml
@@ -26,10 +26,10 @@ std = [
 
 [dependencies]
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [dev-dependencies]
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/pallets/generic-event/src/tests.rs
+++ b/pallets/generic-event/src/tests.rs
@@ -38,6 +38,7 @@ impl system::Trait for TestRuntime {
 	type DbWeight = ();
 	type BlockExecutionWeight = ();
 	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();

--- a/pallets/hello-substrate/Cargo.toml
+++ b/pallets/hello-substrate/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["shawntabrizi"]
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"
-descriotion = "A pallet that demonstrates printing output the a node's console"
+description = "A pallet that demonstrates printing output the a node's console"
 
 [package.metadata.substrate]
 categories = [

--- a/pallets/hello-substrate/Cargo.toml
+++ b/pallets/hello-substrate/Cargo.toml
@@ -26,10 +26,10 @@ std = [
 
 [dependencies]
 parity-scale-codec = { version = '1.3.0', features = ['derive'], default-features = false}
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [dev-dependencies]
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/pallets/hello-substrate/src/tests.rs
+++ b/pallets/hello-substrate/src/tests.rs
@@ -40,6 +40,7 @@ impl system::Trait for TestRuntime {
 	type DbWeight = ();
 	type BlockExecutionWeight = ();
 	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();

--- a/pallets/last-caller/Cargo.toml
+++ b/pallets/last-caller/Cargo.toml
@@ -28,10 +28,10 @@ std = [
 
 [dependencies]
 parity-scale-codec = { default-features = false, features = ['derive'], version = '1.3.0' }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [dev-dependencies]
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/pallets/lockable-currency/Cargo.toml
+++ b/pallets/lockable-currency/Cargo.toml
@@ -27,10 +27,10 @@ std = [
 
 [dependencies]
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-balances = { package = 'pallet-balances', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+balances = { package = 'pallet-balances', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [dev-dependencies]
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/pallets/offchain-demo/Cargo.toml
+++ b/pallets/offchain-demo/Cargo.toml
@@ -26,12 +26,12 @@ alt_serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", default-features = false, git = "https://github.com/Xanewok/json", branch = "no-std", features = ["alloc"] }
 
 # Substrate dependencies
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [features]
 default = ['std']

--- a/pallets/offchain-demo/src/tests.rs
+++ b/pallets/offchain-demo/src/tests.rs
@@ -59,6 +59,7 @@ impl system::Trait for TestRuntime {
 	type DbWeight = ();
 	type BlockExecutionWeight = ();
 	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();

--- a/pallets/randomness/Cargo.toml
+++ b/pallets/randomness/Cargo.toml
@@ -21,17 +21,17 @@ compatibility_version = "2.0.0-dev"
 parity-scale-codec = { default-features = false, features = ['derive'], version = '1.3.0' }
 
 # Substrate pallet/frame dependencies
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [dev-dependencies]
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-pallet-randomness-collective-flip = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-pallet-babe = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-pallet-timestamp = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+pallet-randomness-collective-flip = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+pallet-babe = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+pallet-timestamp = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [features]
 default = ['std']

--- a/pallets/randomness/src/tests.rs
+++ b/pallets/randomness/src/tests.rs
@@ -39,6 +39,7 @@ impl system::Trait for TestRuntime {
 	type DbWeight = ();
 	type BlockExecutionWeight = ();
 	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();

--- a/pallets/reservable-currency/Cargo.toml
+++ b/pallets/reservable-currency/Cargo.toml
@@ -28,11 +28,11 @@ std = [
 
 [dependencies]
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-balances = { package = 'pallet-balances', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+balances = { package = 'pallet-balances', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [dev-dependencies]
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/pallets/reservable-currency/src/tests.rs
+++ b/pallets/reservable-currency/src/tests.rs
@@ -43,6 +43,7 @@ impl system::Trait for TestRuntime {
 	type DbWeight = ();
 	type BlockExecutionWeight = ();
 	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();

--- a/pallets/ringbuffer-queue/Cargo.toml
+++ b/pallets/ringbuffer-queue/Cargo.toml
@@ -27,11 +27,11 @@ std = [
 
 [dependencies]
 codec = { package = 'parity-scale-codec', default-features = false, features = ['derive'], version = '1.3.0' }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [dev-dependencies]
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/pallets/ringbuffer-queue/src/ringbuffer.rs
+++ b/pallets/ringbuffer-queue/src/ringbuffer.rs
@@ -240,6 +240,7 @@ mod tests {
 		type DbWeight = ();
 		type BlockExecutionWeight = ();
 		type ExtrinsicBaseWeight = ();
+		type MaximumExtrinsicWeight = MaximumBlockWeight;
 		type MaximumBlockLength = MaximumBlockLength;
 		type AvailableBlockRatio = AvailableBlockRatio;
 		type Version = ();

--- a/pallets/ringbuffer-queue/src/tests.rs
+++ b/pallets/ringbuffer-queue/src/tests.rs
@@ -39,6 +39,7 @@ impl system::Trait for TestRuntime {
 	type DbWeight = ();
 	type BlockExecutionWeight = ();
 	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();

--- a/pallets/simple-crowdfund/Cargo.toml
+++ b/pallets/simple-crowdfund/Cargo.toml
@@ -31,14 +31,14 @@ std = [
 
 [dependencies]
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-storage = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-balances = { package = 'pallet-balances', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-storage = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+balances = { package = 'pallet-balances', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [dev-dependencies]
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/pallets/simple-crowdfund/src/tests.rs
+++ b/pallets/simple-crowdfund/src/tests.rs
@@ -44,6 +44,7 @@ impl system::Trait for Test {
 	type DbWeight = ();
 	type BlockExecutionWeight = ();
 	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();

--- a/pallets/simple-event/Cargo.toml
+++ b/pallets/simple-event/Cargo.toml
@@ -26,10 +26,10 @@ std = [
 
 [dependencies]
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { package = "frame-support", version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-system = { package = "frame-system", version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { package = "frame-support", version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+system = { package = "frame-system", version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [dev-dependencies]
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/pallets/simple-event/src/tests.rs
+++ b/pallets/simple-event/src/tests.rs
@@ -40,6 +40,7 @@ impl system::Trait for TestRuntime {
 	type DbWeight = ();
 	type BlockExecutionWeight = ();
 	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();

--- a/pallets/simple-map/Cargo.toml
+++ b/pallets/simple-map/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["4meta5"]
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"
-desciption = "A pallet that demonstrates Substrate's storage maps"
+description = "A pallet that demonstrates Substrate's storage maps"
 
 [package.metadata.substrate]
 categories = [

--- a/pallets/simple-map/Cargo.toml
+++ b/pallets/simple-map/Cargo.toml
@@ -25,10 +25,10 @@ std = [
 
 [dependencies]
 parity-scale-codec = { default-features = false, features = ['derive'], version = '1.3.0' }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [dev-dependencies]
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/pallets/simple-map/src/tests.rs
+++ b/pallets/simple-map/src/tests.rs
@@ -39,6 +39,7 @@ impl system::Trait for TestRuntime {
 	type DbWeight = ();
 	type BlockExecutionWeight = ();
 	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();

--- a/pallets/single-value/Cargo.toml
+++ b/pallets/single-value/Cargo.toml
@@ -26,10 +26,10 @@ std = [
 
 [dependencies]
 parity-scale-codec = { default-features = false, features = ['derive'], version = '1.3.0' }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system  = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system  = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [dev-dependencies]
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/pallets/single-value/src/tests.rs
+++ b/pallets/single-value/src/tests.rs
@@ -41,6 +41,7 @@ impl system::Trait for TestRuntime {
 	type DbWeight = ();
 	type BlockExecutionWeight = ();
 	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();

--- a/pallets/storage-cache/Cargo.toml
+++ b/pallets/storage-cache/Cargo.toml
@@ -20,14 +20,14 @@ compatibility_version = "2.0.0-dev"
 parity-scale-codec = { default-features = false, features = ['derive'], version = '1.3.0' }
 
 # Substrate pallet/frame dependencies
-frame-support = { package = 'frame-support', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { package = 'frame-system', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { package = 'frame-support', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { package = 'frame-system', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [dev-dependencies]
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [features]
 default = ['std']

--- a/pallets/storage-cache/src/tests.rs
+++ b/pallets/storage-cache/src/tests.rs
@@ -38,6 +38,7 @@ impl system::Trait for TestRuntime {
 	type DbWeight = ();
 	type BlockExecutionWeight = ();
 	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();

--- a/pallets/struct-storage/Cargo.toml
+++ b/pallets/struct-storage/Cargo.toml
@@ -27,11 +27,11 @@ std = [
 
 [dependencies]
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-balances = { package = 'pallet-balances', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+balances = { package = 'pallet-balances', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [dev-dependencies]
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/pallets/struct-storage/src/tests.rs
+++ b/pallets/struct-storage/src/tests.rs
@@ -52,6 +52,7 @@ impl system::Trait for TestRuntime {
 	type DbWeight = ();
 	type BlockExecutionWeight = ();
 	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();

--- a/pallets/sum-storage/Cargo.toml
+++ b/pallets/sum-storage/Cargo.toml
@@ -18,15 +18,15 @@ compatibility_version = "2.0.0-dev"
 
 [dependencies]
 codec = { package = "parity-scale-codec", version = "1.3.0", default-features = false, features = ["derive"] }
-sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
+sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
 
 
 [dev-dependencies]
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
 
 [features]
 default = ["std"]

--- a/pallets/sum-storage/rpc/Cargo.toml
+++ b/pallets/sum-storage/rpc/Cargo.toml
@@ -12,10 +12,10 @@ jsonrpc-core-client = "14.0.3"
 jsonrpc-derive = "14.0.3"
 serde = { version = "1.0.101", features = ["derive"], optional = true }
 
-sp-rpc = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-sp-blockchain = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-sp-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-rpc = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+sp-blockchain = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+sp-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 sum-storage-runtime-api = { version = "2.0.0", path = "../runtime-api", default-features = false }
 

--- a/pallets/sum-storage/runtime-api/Cargo.toml
+++ b/pallets/sum-storage/runtime-api/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "GPL-3.0-or-later"
 
 [dependencies]
-sp-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
+sp-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
 
 [dev-dependencies]
 serde_json = "1.0.41"

--- a/pallets/sum-storage/src/tests.rs
+++ b/pallets/sum-storage/src/tests.rs
@@ -39,6 +39,7 @@ impl system::Trait for Test {
 	type DbWeight = ();
 	type BlockExecutionWeight = ();
 	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();

--- a/pallets/vec-set/Cargo.toml
+++ b/pallets/vec-set/Cargo.toml
@@ -26,11 +26,11 @@ std = [
 
 [dependencies]
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [dev-dependencies]
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/pallets/vec-set/src/tests.rs
+++ b/pallets/vec-set/src/tests.rs
@@ -38,6 +38,7 @@ impl system::Trait for TestRuntime {
 	type DbWeight = ();
 	type BlockExecutionWeight = ();
 	type ExtrinsicBaseWeight = ();
+	type MaximumExtrinsicWeight = MaximumBlockWeight;
 	type MaximumBlockLength = MaximumBlockLength;
 	type AvailableBlockRatio = AvailableBlockRatio;
 	type Version = ();

--- a/pallets/weights/Cargo.toml
+++ b/pallets/weights/Cargo.toml
@@ -27,10 +27,10 @@ std = [
 
 [dependencies]
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 
 [dev-dependencies]
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/runtimes/api-runtime/Cargo.toml
+++ b/runtimes/api-runtime/Cargo.toml
@@ -17,30 +17,30 @@ categories = [
 compatibility_version = "2.0.0-dev"
 
 [dependencies]
-balances = { package = "pallet-balances", version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-indices = { package = "pallet-indices", version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-sudo = { package = "pallet-sudo", version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-timestamp = { package = "pallet-timestamp", version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-transaction-payment = { package = "pallet-transaction-payment", version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-randomness-collective-flip = { package = "pallet-randomness-collective-flip", version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
+balances = { package = "pallet-balances", version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+indices = { package = "pallet-indices", version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+sudo = { package = "pallet-sudo", version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+timestamp = { package = "pallet-timestamp", version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+transaction-payment = { package = "pallet-transaction-payment", version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+randomness-collective-flip = { package = "pallet-randomness-collective-flip", version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
 
 parity-scale-codec = { version = "1.3.0", default-features = false, features = ["derive"] }
-frame-executive = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
+frame-executive = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
 
 serde = { version = "1.0.101", optional = true, features = ["derive"] }
-sp-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-sp-block-builder = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-sp-inherents = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-sp-offchain = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-sp-session = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-sp-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-sp-version = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
+sp-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+sp-block-builder = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+sp-inherents = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+sp-offchain = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+sp-session = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+sp-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+sp-version = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
 sum-storage = { default-features = false, path = "../../pallets/sum-storage" }
 sum-storage-runtime-api = { default-features = false, path = "../../pallets/sum-storage/runtime-api" }
 

--- a/runtimes/api-runtime/src/lib.rs
+++ b/runtimes/api-runtime/src/lib.rs
@@ -16,7 +16,7 @@ use frame_system as system;
 use sp_api::impl_runtime_apis;
 use sp_core::{OpaqueMetadata, H256};
 use sp_runtime::traits::{
-	BlakeTwo256, Block as BlockT, ConvertInto, IdentifyAccount, IdentityLookup, Verify,
+	BlakeTwo256, Block as BlockT, IdentifyAccount, IdentityLookup, Saturating, Verify,
 };
 use sp_runtime::{
 	create_runtime_str, generic,
@@ -35,6 +35,7 @@ pub use frame_support::{
 	traits::Randomness,
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
+		IdentityFee,
 		Weight,
 	},
 	StorageValue,
@@ -107,6 +108,9 @@ parameter_types! {
 	pub const BlockHashCount: BlockNumber = 250;
 	pub const MaximumBlockWeight: Weight = 2 * WEIGHT_PER_SECOND;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
+	/// Assume 10% of weight for average on_initialize calls.
+	pub const MaximumExtrinsicWeight: Weight = AvailableBlockRatio::get()
+		.saturating_sub(Perbill::from_percent(10)) * MaximumBlockWeight::get();
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;
 }
@@ -144,6 +148,10 @@ impl system::Trait for Runtime {
 	/// The base weight of any extrinsic processed by the runtime, independent of the
 	/// logic of that extrinsic. (Signature verification, nonce increment, fee, etc...)
 	type ExtrinsicBaseWeight = ExtrinsicBaseWeight;
+	/// The maximum weight that a single extrinsic of `Normal` dispatch class can have,
+	/// idependent of the logic of that extrinsic. (Roughly max block weight - average on
+	/// initialize cost).
+	type MaximumExtrinsicWeight = MaximumExtrinsicWeight;
 	/// Maximum size of all encoded transactions (in bytes) that are allowed in one block.
 	type MaximumBlockLength = MaximumBlockLength;
 	/// Portion of the block weight that is available to all normal transactions.
@@ -202,7 +210,7 @@ impl transaction_payment::Trait for Runtime {
 	type Currency = balances::Module<Runtime>;
 	type OnTransactionPayment = ();
 	type TransactionByteFee = TransactionByteFee;
-	type WeightToFee = ConvertInto;
+	type WeightToFee = IdentityFee<Balance>;
 	type FeeMultiplierUpdate = ();
 }
 

--- a/runtimes/babe-grandpa-runtime/Cargo.toml
+++ b/runtimes/babe-grandpa-runtime/Cargo.toml
@@ -22,34 +22,34 @@ compatibility_version = "2.0.0-dev"
 parity-scale-codec = { version = "1.3.0", default-features = false, features = ["derive"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 # Substrate Pallets
-babe = { package = 'pallet-babe', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false}
-balances = { package = 'pallet-balances', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-grandpa = { package = 'pallet-grandpa', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-randomness-collective-flip = { package = 'pallet-randomness-collective-flip', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sudo = { package = 'pallet-sudo', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-timestamp = { package = 'pallet-timestamp', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-transaction-payment = { package = 'pallet-transaction-payment', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+babe = { package = 'pallet-babe', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false}
+balances = { package = 'pallet-balances', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+grandpa = { package = 'pallet-grandpa', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+randomness-collective-flip = { package = 'pallet-randomness-collective-flip', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sudo = { package = 'pallet-sudo', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+timestamp = { package = 'pallet-timestamp', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+transaction-payment = { package = 'pallet-transaction-payment', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 # Recipe Pallets
 #TODO Maybe include Gautam's Validator Set allet here
 
 # Other Substrate dependencies
-frame-executive = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-block-builder = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-consensus-babe = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-finality-grandpa = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-inherents = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-offchain = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-session = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-version = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-executive = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-block-builder = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-consensus-babe = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-finality-grandpa = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-inherents = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-offchain = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-session = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-version = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 
 [build-dependencies]

--- a/runtimes/babe-grandpa-runtime/src/lib.rs
+++ b/runtimes/babe-grandpa-runtime/src/lib.rs
@@ -19,7 +19,7 @@ use grandpa::{AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList};
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata, H256};
 use sp_runtime::traits::{
-	BlakeTwo256, Block as BlockT, ConvertInto, IdentifyAccount, IdentityLookup, NumberFor, Verify,
+	BlakeTwo256, Block as BlockT, IdentifyAccount, IdentityLookup, NumberFor, Saturating, Verify,
 };
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
@@ -39,6 +39,7 @@ pub use frame_support::{
 	traits::{KeyOwnerProofSystem, Randomness},
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
+		IdentityFee,
 		Weight,
 	},
 	StorageValue,
@@ -136,6 +137,9 @@ parameter_types! {
 	pub const BlockHashCount: BlockNumber = 250;
 	pub const MaximumBlockWeight: Weight = 2 * WEIGHT_PER_SECOND;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
+	/// Assume 10% of weight for average on_initialize calls.
+	pub const MaximumExtrinsicWeight: Weight = AvailableBlockRatio::get()
+		.saturating_sub(Perbill::from_percent(10)) * MaximumBlockWeight::get();
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;
 }
@@ -173,6 +177,10 @@ impl system::Trait for Runtime {
 	/// The base weight of any extrinsic processed by the runtime, independent of the
 	/// logic of that extrinsic. (Signature verification, nonce increment, fee, etc...)
 	type ExtrinsicBaseWeight = ExtrinsicBaseWeight;
+	/// The maximum weight that a single extrinsic of `Normal` dispatch class can have,
+	/// idependent of the logic of that extrinsic. (Roughly max block weight - average on
+	/// initialize cost).
+	type MaximumExtrinsicWeight = MaximumExtrinsicWeight;
 	/// Maximum size of all encoded transactions (in bytes) that are allowed in one block.
 	type MaximumBlockLength = MaximumBlockLength;
 	/// Portion of the block weight that is available to all normal transactions.
@@ -250,7 +258,7 @@ impl transaction_payment::Trait for Runtime {
 	type Currency = balances::Module<Runtime>;
 	type OnTransactionPayment = ();
 	type TransactionByteFee = TransactionByteFee;
-	type WeightToFee = ConvertInto;
+	type WeightToFee = IdentityFee<Balance>;
 	type FeeMultiplierUpdate = ();
 }
 

--- a/runtimes/minimal-grandpa-runtime/Cargo.toml
+++ b/runtimes/minimal-grandpa-runtime/Cargo.toml
@@ -20,28 +20,28 @@ compatibility_version = "2.0.0-dev"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
 
-frame-executive = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-block-builder = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-finality-grandpa = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-inherents = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-offchain = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-session = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-version = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-executive = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-block-builder = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-finality-grandpa = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-inherents = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-offchain = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-session = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-version = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
-balances = { package = 'pallet-balances', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-transaction-payment = { package = 'pallet-transaction-payment', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-grandpa = { package = 'pallet-grandpa', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-randomness-collective-flip = { package = 'pallet-randomness-collective-flip', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-timestamp = { package = 'pallet-timestamp', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sudo = { package = 'pallet-sudo', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+balances = { package = 'pallet-balances', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+transaction-payment = { package = 'pallet-transaction-payment', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+grandpa = { package = 'pallet-grandpa', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+randomness-collective-flip = { package = 'pallet-randomness-collective-flip', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+timestamp = { package = 'pallet-timestamp', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sudo = { package = 'pallet-sudo', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [build-dependencies]
 wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.4" }

--- a/runtimes/minimal-grandpa-runtime/src/lib.rs
+++ b/runtimes/minimal-grandpa-runtime/src/lib.rs
@@ -18,6 +18,7 @@ use frame_support::{
 	traits::KeyOwnerProofSystem,
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
+		IdentityFee,
 		Weight,
 	},
 };
@@ -26,7 +27,7 @@ use grandpa::{AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList};
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata, H256};
 use sp_runtime::traits::{
-	BlakeTwo256, Block as BlockT, IdentifyAccount, IdentityLookup, NumberFor, Verify,
+	BlakeTwo256, Block as BlockT, IdentifyAccount, IdentityLookup, NumberFor, Saturating, Verify,
 };
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
@@ -37,11 +38,6 @@ use sp_std::prelude::*;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
-
-// These structs are used in one of the commented-by-default implementations of
-// transaction_payment::Trait. Don't warn when they are unused.
-#[allow(unused_imports)]
-use sp_runtime::traits::ConvertInto;
 
 // A few exports that help ease life for downstream crates.
 pub use balances::Call as BalancesCall;
@@ -104,8 +100,8 @@ pub mod opaque {
 
 /// This runtime version.
 pub const VERSION: RuntimeVersion = RuntimeVersion {
-	spec_name: create_runtime_str!("weight-fee-runtime"),
-	impl_name: create_runtime_str!("weight-fee-runtime"),
+	spec_name: create_runtime_str!("minimal-grandpa-runtime"),
+	impl_name: create_runtime_str!("minimal-grandpa-runtime"),
 	authoring_version: 1,
 	spec_version: 1,
 	impl_version: 1,
@@ -126,6 +122,9 @@ parameter_types! {
 	pub const BlockHashCount: BlockNumber = 250;
 	pub const MaximumBlockWeight: Weight = 2 * WEIGHT_PER_SECOND;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
+	/// Assume 10% of weight for average on_initialize calls.
+	pub const MaximumExtrinsicWeight: Weight = AvailableBlockRatio::get()
+		.saturating_sub(Perbill::from_percent(10)) * MaximumBlockWeight::get();
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;
 }
@@ -163,6 +162,10 @@ impl system::Trait for Runtime {
 	/// The base weight of any extrinsic processed by the runtime, independent of the
 	/// logic of that extrinsic. (Signature verification, nonce increment, fee, etc...)
 	type ExtrinsicBaseWeight = ExtrinsicBaseWeight;
+	/// The maximum weight that a single extrinsic of `Normal` dispatch class can have,
+	/// idependent of the logic of that extrinsic. (Roughly max block weight - average on
+	/// initialize cost).
+	type MaximumExtrinsicWeight = MaximumExtrinsicWeight;
 	/// Maximum size of all encoded transactions (in bytes) that are allowed in one block.
 	type MaximumBlockLength = MaximumBlockLength;
 	/// Portion of the block weight that is available to all normal transactions.
@@ -234,7 +237,7 @@ impl transaction_payment::Trait for Runtime {
 	type Currency = Balances;
 	type OnTransactionPayment = ();
 	type TransactionByteFee = TransactionByteFee;
-	type WeightToFee = ConvertInto;
+	type WeightToFee = IdentityFee<Balance>;
 	type FeeMultiplierUpdate = ();
 }
 

--- a/runtimes/ocw-runtime/Cargo.toml
+++ b/runtimes/ocw-runtime/Cargo.toml
@@ -21,26 +21,26 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
 
 # Substrate pallets & dependencies
-frame-executive = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-pallet-balances = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-pallet-indices = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-pallet-randomness-collective-flip = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-pallet-sudo = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-pallet-timestamp = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-pallet-transaction-payment = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-block-builder = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-inherents = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-offchain = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-session = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-version = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-executive = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+pallet-balances = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+pallet-indices = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+pallet-randomness-collective-flip = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+pallet-sudo = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+pallet-timestamp = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+pallet-transaction-payment = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-block-builder = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-inherents = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-offchain = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-session = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-version = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 # Recipe Pallets
 offchain-demo = { path = "../../pallets/offchain-demo", default-features = false }

--- a/runtimes/ocw-runtime/src/lib.rs
+++ b/runtimes/ocw-runtime/src/lib.rs
@@ -1,5 +1,5 @@
 //! This Runtime demonstrates how to config signed and unsigned transaction handler to be used
-//   by off-chain worker in its including pallets.
+//!   by off-chain worker in its including pallets.
 
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
@@ -16,8 +16,8 @@ pub mod genesis;
 use sp_api::impl_runtime_apis;
 use sp_core::{Encode, OpaqueMetadata, H256};
 use sp_runtime::traits::{
-	BlakeTwo256, Block as BlockT, ConvertInto, IdentifyAccount, IdentityLookup,
-	SaturatedConversion, Verify,
+	BlakeTwo256, Block as BlockT, IdentifyAccount, IdentityLookup,
+	SaturatedConversion, Saturating, Verify,
 };
 use sp_runtime::{
 	create_runtime_str, generic,
@@ -36,6 +36,7 @@ pub use frame_support::{
 	traits::Randomness,
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
+		IdentityFee,
 		Weight,
 	},
 	StorageValue,
@@ -115,6 +116,9 @@ parameter_types! {
 	pub const BlockHashCount: BlockNumber = 250;
 	pub const MaximumBlockWeight: Weight = 2 * WEIGHT_PER_SECOND;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
+	/// Assume 10% of weight for average on_initialize calls.
+	pub const MaximumExtrinsicWeight: Weight = AvailableBlockRatio::get()
+		.saturating_sub(Perbill::from_percent(10)) * MaximumBlockWeight::get();
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;
 }
@@ -152,6 +156,10 @@ impl frame_system::Trait for Runtime {
 	/// The base weight of any extrinsic processed by the runtime, independent of the
 	/// logic of that extrinsic. (Signature verification, nonce increment, fee, etc...)
 	type ExtrinsicBaseWeight = ExtrinsicBaseWeight;
+	/// The maximum weight that a single extrinsic of `Normal` dispatch class can have,
+	/// idependent of the logic of that extrinsic. (Roughly max block weight - average on
+	/// initialize cost).
+	type MaximumExtrinsicWeight = MaximumExtrinsicWeight;
 	/// Maximum size of all encoded transactions (in bytes) that are allowed in one block.
 	type MaximumBlockLength = MaximumBlockLength;
 	/// Portion of the block weight that is available to all normal transactions.
@@ -205,7 +213,7 @@ impl pallet_transaction_payment::Trait for Runtime {
 	type Currency = pallet_balances::Module<Runtime>;
 	type OnTransactionPayment = ();
 	type TransactionByteFee = TransactionByteFee;
-	type WeightToFee = ConvertInto;
+	type WeightToFee = IdentityFee<Balance>;
 	type FeeMultiplierUpdate = ();
 }
 

--- a/runtimes/super-runtime/Cargo.toml
+++ b/runtimes/super-runtime/Cargo.toml
@@ -20,11 +20,11 @@ parity-scale-codec = { version = "1.3.0", default-features = false, features = [
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 # Substrate Pallets
-balances = { package = 'pallet-balances', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-randomness-collective-flip = { package = 'pallet-randomness-collective-flip', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sudo = { package = 'pallet-sudo', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-transaction-payment = { package = 'pallet-transaction-payment', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-timestamp = { package = 'pallet-timestamp', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+balances = { package = 'pallet-balances', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+randomness-collective-flip = { package = 'pallet-randomness-collective-flip', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sudo = { package = 'pallet-sudo', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+transaction-payment = { package = 'pallet-transaction-payment', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+timestamp = { package = 'pallet-timestamp', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 # Recipe Pallets
 adding-machine = { path = "../../pallets/adding-machine", default-features = false }
@@ -51,20 +51,20 @@ struct-storage = { path = "../../pallets/struct-storage", default-features = fal
 vec-set = { path = "../../pallets/vec-set", default-features = false }
 
 # Other Substrate dependencies
-frame-executive = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-block-builder = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-inherents = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-offchain = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-session = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-version = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-executive = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-block-builder = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-inherents = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-offchain = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-session = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-version = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 
 [build-dependencies]

--- a/runtimes/super-runtime/src/lib.rs
+++ b/runtimes/super-runtime/src/lib.rs
@@ -18,10 +18,11 @@ use frame_system as system;
 use sp_api::impl_runtime_apis;
 use sp_core::{OpaqueMetadata, H256};
 use sp_runtime::traits::{
-	BlakeTwo256, Block as BlockT, ConvertInto, IdentifyAccount, IdentityLookup, Verify,
+	BlakeTwo256, Block as BlockT, IdentifyAccount, IdentityLookup, Verify,
 };
 use sp_runtime::{
 	create_runtime_str, generic,
+	traits::Saturating,
 	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult, MultiSignature,
 };
@@ -38,6 +39,7 @@ pub use frame_support::{
 	traits::Randomness,
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
+		IdentityFee,
 		Weight,
 	},
 	StorageValue,
@@ -116,6 +118,9 @@ parameter_types! {
 	pub const BlockHashCount: BlockNumber = 250;
 	pub const MaximumBlockWeight: Weight = 2 * WEIGHT_PER_SECOND;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
+	/// Assume 10% of weight for average on_initialize calls.
+	pub const MaximumExtrinsicWeight: Weight = AvailableBlockRatio::get()
+		.saturating_sub(Perbill::from_percent(10)) * MaximumBlockWeight::get();
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;
 }
@@ -153,6 +158,10 @@ impl system::Trait for Runtime {
 	/// The base weight of any extrinsic processed by the runtime, independent of the
 	/// logic of that extrinsic. (Signature verification, nonce increment, fee, etc...)
 	type ExtrinsicBaseWeight = ExtrinsicBaseWeight;
+	/// The maximum weight that a single extrinsic of `Normal` dispatch class can have,
+	/// idependent of the logic of that extrinsic. (Roughly max block weight - average on
+	/// initialize cost).
+	type MaximumExtrinsicWeight = MaximumExtrinsicWeight;
 	/// Maximum size of all encoded transactions (in bytes) that are allowed in one block.
 	type MaximumBlockLength = MaximumBlockLength;
 	/// Portion of the block weight that is available to all normal transactions.
@@ -206,7 +215,7 @@ impl transaction_payment::Trait for Runtime {
 	type Currency = balances::Module<Runtime>;
 	type OnTransactionPayment = ();
 	type TransactionByteFee = TransactionByteFee;
-	type WeightToFee = ConvertInto;
+	type WeightToFee = IdentityFee<Balance>;
 	type FeeMultiplierUpdate = ();
 }
 

--- a/runtimes/weight-fee-runtime/Cargo.toml
+++ b/runtimes/weight-fee-runtime/Cargo.toml
@@ -22,6 +22,7 @@ compatibility_version = "2.0.0-dev"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 weights = { path = "../../pallets/weights", default-features = false }
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
+smallvec = "1.4"
 
 frame-executive = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }

--- a/runtimes/weight-fee-runtime/Cargo.toml
+++ b/runtimes/weight-fee-runtime/Cargo.toml
@@ -23,27 +23,27 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 weights = { path = "../../pallets/weights", default-features = false }
 parity-scale-codec = { version = "1.3.0", features = ["derive"], default-features = false }
 
-frame-executive = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-block-builder = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-inherents = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-offchain = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-session = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sp-version = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+frame-executive = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-support = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+frame-system = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-api = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-block-builder = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-core = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-inherents = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-io = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-offchain = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-runtime = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-session = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-std = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-transaction-pool = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sp-version = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
-balances = { package = 'pallet-balances', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-generic-asset = { package = 'pallet-generic-asset', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-transaction-payment = { package = 'pallet-transaction-payment', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-randomness-collective-flip = { package = 'pallet-randomness-collective-flip', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-timestamp = { package = 'pallet-timestamp', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
-sudo = { package = 'pallet-sudo', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713', default-features = false }
+balances = { package = 'pallet-balances', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+generic-asset = { package = 'pallet-generic-asset', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+transaction-payment = { package = 'pallet-transaction-payment', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+randomness-collective-flip = { package = 'pallet-randomness-collective-flip', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+timestamp = { package = 'pallet-timestamp', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
+sudo = { package = 'pallet-sudo', version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d', default-features = false }
 
 [build-dependencies]
 wasm-builder-runner = { package = "substrate-wasm-builder-runner", version = "1.0.4" }

--- a/runtimes/weight-fee-runtime/src/lib.rs
+++ b/runtimes/weight-fee-runtime/src/lib.rs
@@ -301,12 +301,6 @@ parameter_types! {
 	// conversion techniques is harmless.
 	pub const FeeWeightRatio: u128 = 1_000;
 
-	// Used with QuadraticWeightToFee conversion. Leaving these constants in tact when using other
-	// conversion techniques is harmless.
-	pub const WeightFeeConstant: u128 = 1_000;
-	pub const WeightFeeLinear: u128 = 100;
-	pub const WeightFeeQuadratic : u128 = 10;
-
 	// Establish the byte-fee. It is used in all configurations.
 	pub const TransactionByteFee: u128 = 1;
 }
@@ -326,7 +320,7 @@ impl transaction_payment::Trait for Runtime {
 	// serialized transaction in bytes
 	type TransactionByteFee = TransactionByteFee;
 
-	// Function to convert dispatch weight to a chargeable fee.
+	// Convert dispatch weight to a chargeable fee.
 	// Enable exactly one of the following options.
 	//type WeightToFee = IdentityFee<Balance>;
 	type WeightToFee = LinearWeightToFee<FeeWeightRatio>;

--- a/runtimes/weight-fee-runtime/src/lib.rs
+++ b/runtimes/weight-fee-runtime/src/lib.rs
@@ -20,13 +20,17 @@ use frame_support::{
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
 		Weight,
+		WeightToFeePolynomial,
+		WeightToFeeCoefficient,
+		WeightToFeeCoefficients,
 	},
 };
 use frame_system as system;
+use smallvec::smallvec;
 use sp_api::impl_runtime_apis;
 use sp_core::{OpaqueMetadata, H256};
 use sp_runtime::traits::{
-	BlakeTwo256, Block as BlockT, Convert, IdentifyAccount, IdentityLookup, Verify,
+	BlakeTwo256, Block as BlockT, IdentifyAccount, IdentityLookup, Saturating, Verify,
 };
 use sp_runtime::{
 	create_runtime_str, generic,
@@ -43,7 +47,7 @@ use sp_version::RuntimeVersion;
 #[allow(unused_imports)]
 use generic_asset::{AssetCurrency, AssetIdProvider, SpendingAssetCurrency};
 #[allow(unused_imports)]
-use sp_runtime::traits::ConvertInto;
+use frame_support::weights::IdentityFee;
 
 // A few exports that help ease life for downstream crates.
 pub use balances::Call as BalancesCall;
@@ -120,6 +124,9 @@ parameter_types! {
 	pub const BlockHashCount: BlockNumber = 250;
 	pub const MaximumBlockWeight: Weight = 2 * WEIGHT_PER_SECOND;
 	pub const AvailableBlockRatio: Perbill = Perbill::from_percent(75);
+	/// Assume 10% of weight for average on_initialize calls.
+	pub const MaximumExtrinsicWeight: Weight = AvailableBlockRatio::get()
+		.saturating_sub(Perbill::from_percent(10)) * MaximumBlockWeight::get();
 	pub const MaximumBlockLength: u32 = 5 * 1024 * 1024;
 	pub const Version: RuntimeVersion = VERSION;
 }
@@ -157,6 +164,10 @@ impl system::Trait for Runtime {
 	/// The base weight of any extrinsic processed by the runtime, independent of the
 	/// logic of that extrinsic. (Signature verification, nonce increment, fee, etc...)
 	type ExtrinsicBaseWeight = ExtrinsicBaseWeight;
+	/// The maximum weight that a single extrinsic of `Normal` dispatch class can have,
+	/// idependent of the logic of that extrinsic. (Roughly max block weight - average on
+	/// initialize cost).
+	type MaximumExtrinsicWeight = MaximumExtrinsicWeight;
 	/// Maximum size of all encoded transactions (in bytes) that are allowed in one block.
 	type MaximumBlockLength = MaximumBlockLength;
 	/// Portion of the block weight that is available to all normal transactions.
@@ -218,45 +229,58 @@ impl weights::Trait for Runtime {}
 
 // --------------------- Multiple Options for WeightToFee -----------------------
 
-/// Convert from weight to balance via a simple coefficient multiplication. The associated type C
-/// encapsulates a constant in units of balance per weight.
+/// Convert from weight to fee via a simple coefficient multiplication. The associated type C
+/// encapsulates an integer constant in units of balance per weight.
 pub struct LinearWeightToFee<C>(sp_std::marker::PhantomData<C>);
 
-impl<C> Convert<Weight, Balance> for LinearWeightToFee<C>
+impl<C> WeightToFeePolynomial for LinearWeightToFee<C>
 where
 	C: Get<Balance>,
 {
-	fn convert(w: Weight) -> Balance {
-		// substrate-node a weight of 10_000 (smallest non-zero weight) to be mapped to 10^7 units of
-		// fees, hence:
-		let coefficient = C::get();
-		Balance::from(w).saturating_mul(coefficient)
+	type Balance = Balance;
+
+	fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
+		let coefficient = WeightToFeeCoefficient {
+			coeff_integer: C::get(),
+			coeff_frac: Perbill::zero(),
+			negative: false,
+			degree: 1,
+		};
+
+		// Return a smallvec of coefficients. Order does not need to match degrees
+		// because each coefficient has an explicit degree annotation.
+		smallvec!(coefficient)
 	}
 }
 
-/// Convert from weight to balance via a quadratic curve. The type parameters encapsulate the
-/// coefficients.
-pub struct QuadraticWeightToFee<C0, C1, C2>(C0, C1, C2);
+/// Convert from weight to fee via a quadratic curve with hard-coded coefficients.
+/// The coefficients used are for demonstration purpose and do not represent "typical" values.
+/// fee = 3 w^2 - 2.4 w
+pub struct QuadraticWeightToFee;
 
-impl<C0, C1, C2> Convert<Weight, Balance> for QuadraticWeightToFee<C0, C1, C2>
-where
-	C0: Get<Balance>,
-	C1: Get<Balance>,
-	C2: Get<Balance>,
-{
-	fn convert(w: Weight) -> Balance {
-		let c0 = C0::get();
-		let c1 = C1::get();
-		let c2 = C2::get();
-		let w = Balance::from(w);
+impl WeightToFeePolynomial for QuadraticWeightToFee {
+	type Balance = Balance;
 
-		// All the safe math reduces to
-		// c0 + c1 * w + c2 * w * w
+	fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
+		let linear = WeightToFeeCoefficient {
+			coeff_integer: 2,
+			coeff_frac: Perbill::from_percent(40),
+			negative: true,
+			degree: 1,
+		};
+		let quadratic = WeightToFeeCoefficient {
+			coeff_integer: 3,
+			coeff_frac: Perbill::zero(),
+			negative: false,
+			degree: 2,
+		};
 
-		let c1w = c1.saturating_mul(w);
-		let c2w2 = c2.saturating_mul(w).saturating_mul(w);
-
-		c0.saturating_add(c1w).saturating_add(c2w2)
+		// Return a smallvec of coefficients. Order does not need to match degrees
+		// because each coefficient has an explicit degree annotation. In fact, any
+		// negative coefficients should be saved for last regardless of their degree
+		// because large negative coefficients will likely cause saturation (to zero)
+		// if they happen early on.
+		smallvec![quadratic, linear]
 	}
 }
 
@@ -291,9 +315,9 @@ impl transaction_payment::Trait for Runtime {
 	// The asset in which fees will be collected.
 	// Enable exactly one of the following options.
 	type Currency = Balances; // The balances pallet (The most common choice)
-						  //type Currency = FixedGenericAsset<Self>; // A generic asset whose ID is hard-coded above.
-						  //type Currency = SpendingAssetCurrency<Self>; // A generic asset whose ID is stored in the
-						  // generic_asset pallet's runtime storage
+	// type Currency = FixedGenericAsset<Self>; // A generic asset whose ID is hard-coded above.
+	//type Currency = SpendingAssetCurrency<Self>; // A generic asset whose ID is stored in the
+	                                               // generic_asset pallet's runtime storage
 
 	// What to do when fees are paid. () means take no additional actions.
 	type OnTransactionPayment = ();
@@ -304,9 +328,9 @@ impl transaction_payment::Trait for Runtime {
 
 	// Function to convert dispatch weight to a chargeable fee.
 	// Enable exactly one of the following options.
-	//type WeightToFee = ConvertInto;
-	//type WeightToFee = LinearWeightToFee<FeeWeightRatio>;
-	type WeightToFee = QuadraticWeightToFee<WeightFeeConstant, WeightFeeLinear, WeightFeeQuadratic>;
+	//type WeightToFee = IdentityFee<Balance>;
+	type WeightToFee = LinearWeightToFee<FeeWeightRatio>;
+	// type WeightToFee = QuadraticWeightToFee<WeightFeeConstant, WeightFeeLinear, WeightFeeQuadratic>;
 
 	//TODO Explore how to change FeeMultiplierUpdate
 	type FeeMultiplierUpdate = ();

--- a/text/3-entrees/custom-rpc.md
+++ b/text/3-entrees/custom-rpc.md
@@ -60,7 +60,7 @@ With our RPC written, we're ready to install it on our node. We begin with a few
 jsonrpc-core = "14.0.3"
 jsonrpc-core-client = "14.0.3"
 jsonrpc-derive = "14.0.3"
-sc-rpc = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
+sc-rpc = { version = '2.0.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
 ```
 
 Next, in our `rpc-node`'s `service.rs` file, we extend the service with our RPC. We've chosen to

--- a/text/3-entrees/fees.md
+++ b/text/3-entrees/fees.md
@@ -4,25 +4,23 @@ _[runtimes/weight-fee-runtime](https://github.com/substrate-developer-hub/recipe
 
 Substrate provides the
 [`transaction_payment` pallet](https://crates.parity.io/pallet_transaction_payment/index.html) for
-calculating and collecting fees for executing transactions. Fees are broken down into several
+calculating and collecting fees for executing transactions. Fees are broken down into two
 components:
 
--   Base fee - A fixed fee applied to each transaction. A parameter in the `transaction_payment`
-    pallet.
--   Length fee - A fee proportional to the transaction's length in bytes. The proportionality
-    constant is a parameter in the `transaction_payment` pallet.
--   Weight fee - A fee calculated from the transaction's weight. Weights are intended to capture the
-    actual resources consumed by the transaction. Learn more in the
-    [recipe on weights](./weights.md). It doesn't need to be linear, although it often is. The same
-    conversion function is applied across all transactions from all pallets in the runtime.
+-   Byte fee - A fee proportional to the transaction's length in bytes. The proportionality constant
+    is a parameter in the `transaction_payment` pallet.
+-   Weight fee - A fee calculated from the transaction's weight. Weights quantify the time spent
+    executing the transaction. Learn more in the [recipe on weights](./weights.md). The conversion
+    doesn't need to be linear, although it often is. The same conversion function is applied across
+    all transactions from all pallets in the runtime.
 -   Fee Multiplier - A multiplier for the computed fee, that can change as the chain progresses.
     This topic is not (yet) covered further in the recipes.
 
 ```
-total_fee = base_fee + transaction_length * length_fee + weight_to_fee(total_weight)
+total_fee = transaction_length * length_fee + weight_to_fee(total_weight)
 ```
 
-## Setting the Constants
+## Setting the Parameters
 
 Each of the parameters described above is set in the `transaction_payment` pallet's configuration
 trait. For example, the `super-runtime` sets these parameters as follows.
@@ -32,49 +30,123 @@ src:
 
 ```rust,ignore
 parameter_types! {
-	pub const TransactionBaseFee: u128 = 0;
 	pub const TransactionByteFee: u128 = 1;
 }
 
 impl transaction_payment::Trait for Runtime {
 	type Currency = balances::Module<Runtime>;
 	type OnTransactionPayment = ();
-	type TransactionBaseFee = TransactionBaseFee;
 	type TransactionByteFee = TransactionByteFee;
-	type WeightToFee = ConvertInto;
+	type WeightToFee = IdentityFee<Balance>;
 	type FeeMultiplierUpdate = ();
 }
 ```
 
-## Converting Weight To Fees
+## 1 to 1 Conversion
 
-In many cases converting weight to fees in a one-to-one fashion, as shown above, will suffice and
-can be accomplished with
-[`ConvertInto`](https://crates.parity.io/sp_runtime/traits/struct.ConvertInto.html). This approach
-is also taken in the
-[node template](https://github.com/substrate-developer-hub/substrate-node-template/blob/43ee95347b6626580b1d9d554c3c8b77dc85bc01/runtime/src/lib.rs#L230).
+In many cases converting weight to fees one-to-one, as shown above, will suffice and can be
+accomplished with
+[`IdentityFee`](https://crates.parity.io/frame_support/weights/struct.IdentityFee.html). This
+approach is also taken in the
+[node template](https://github.com/paritytech/substrate/blob/2d39ec2c4aaec1cc0f91fcb91734de8f408dc1b2/bin/node-template/runtime/src/lib.rs#L246).
 It is also possible to provide a type that makes a more complex calculation. Any type that
-implements `Convert<Weight, Balance>` will suffice.
+implements
+[`WeightToFeePolynomial`](https://crates.parity.io/frame_support/weights/trait.WeightToFeePolynomial.html)
+will suffice.
 
-This example uses a quadratic conversion and supports custom coefficients.
+## Linear Conversion
 
-src:
-[`runtimes/weight-fee-runtime/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/weight-fee-runtime/src/lib.rs)
+Another common way to convert weight to fees is linearly. When converting linearly, the weight is
+multiplied by a constant coefficient to determine the fee to charge. This is demonstrated in the
+`weight-fee-runtime` with the `LinearWeightToFee` struct.
+
+We declare the struct with a associated type `C` which will provide the coefficient.
 
 ```rust, ignore
-pub struct QuadraticWeightToFee<C0, C1, C2>(C0, C1, C2);
+pub struct LinearWeightToFee<C>(sp_std::marker::PhantomData<C>);
+```
 
-impl<C0, C1, C2> Convert<Weight, Balance> for QuadraticWeightToFee<C0, C1, C2>
-	where C0: Get<Balance>, C1: Get<Balance>, C2: Get<Balance> {
+Then we implement `WeightToFeePolynomial` for it. When implementing this trait, your main job is to
+return set of
+[`WeightToFeeCoefficient`](https://crates.parity.io/frame_support/weights/struct.WeightToFeeCoefficient.html)s.
+These coefficients can have integer and fractional parts and be positive or negative. In our
+`LinearWeightToFee` there is a single integer coefficient supplied by the associated type.
 
-	fn convert(w: Weight) -> Balance {
-		let c0 = C0::get();
-		let c1 = C1::get();
-		let c2 = C2::get();
-		let w = Balance::from(w);
+```rust, ignore
+impl<C> WeightToFeePolynomial for LinearWeightToFee<C>
+where
+	C: Get<Balance>,
+{
+	type Balance = Balance;
 
-		// TODO use safe math
-		c0 + c1 * w + c2 * w * w
+	fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
+		let coefficient = WeightToFeeCoefficient {
+			coeff_integer: C::get(),
+			coeff_frac: Perbill::zero(),
+			negative: false,
+			degree: 1,
+		};
+
+		// Return a smallvec of coefficients. Order does not need to match degrees
+		// because each coefficient has an explicit degree annotation.
+		smallvec!(coefficient)
+	}
+}
+```
+
+This struct is reusable, and works with different coefficients. Using it looks like this.
+
+```rust, ignore
+parameter_types! {
+	// Used with LinearWeightToFee conversion. Leaving this constant in tact when using other
+	// conversion techniques is harmless.
+	pub const FeeWeightRatio: u128 = 1_000;
+
+	// --snip--
+}
+
+impl transaction_payment::Trait for Runtime {
+
+	// Convert dispatch weight to a chargeable fee.
+	type WeightToFee = LinearWeightToFee<FeeWeightRatio>;
+
+	// --snip--
+}
+```
+
+## Quadratic Conversion
+
+More complex polynomials can also be used. When using complex polynomials, it is unlikely that your
+logic will be reused among multiple chains, so it is generally no worth the overhead of making the
+coefficients configurable. The `QuadraticWeightToFee` demonstrate a 2nd degree polynomial with
+hard-coded non-integer signed coefficients.
+
+```rust, ignore
+pub struct QuadraticWeightToFee;
+
+impl WeightToFeePolynomial for QuadraticWeightToFee {
+	type Balance = Balance;
+
+	fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
+		let linear = WeightToFeeCoefficient {
+			coeff_integer: 2,
+			coeff_frac: Perbill::from_percent(40),
+			negative: true,
+			degree: 1,
+		};
+		let quadratic = WeightToFeeCoefficient {
+			coeff_integer: 3,
+			coeff_frac: Perbill::zero(),
+			negative: false,
+			degree: 2,
+		};
+
+		// Return a smallvec of coefficients. Order does not need to match degrees
+		// because each coefficient has an explicit degree annotation. In fact, any
+		// negative coefficients should be saved for last regardless of their degree
+		// because large negative coefficients will likely cause saturation (to zero)
+		// if they happen early on.
+		smallvec![quadratic, linear]
 	}
 }
 ```

--- a/text/3-entrees/fees.md
+++ b/text/3-entrees/fees.md
@@ -67,7 +67,7 @@ pub struct LinearWeightToFee<C>(sp_std::marker::PhantomData<C>);
 ```
 
 Then we implement `WeightToFeePolynomial` for it. When implementing this trait, your main job is to
-return set of
+return a set of
 [`WeightToFeeCoefficient`](https://crates.parity.io/frame_support/weights/struct.WeightToFeeCoefficient.html)s.
 These coefficients can have integer and fractional parts and be positive or negative. In our
 `LinearWeightToFee` there is a single integer coefficient supplied by the associated type.

--- a/text/3-entrees/fees.md
+++ b/text/3-entrees/fees.md
@@ -60,7 +60,7 @@ Another common way to convert weight to fees is linearly. When converting linear
 multiplied by a constant coefficient to determine the fee to charge. This is demonstrated in the
 `weight-fee-runtime` with the `LinearWeightToFee` struct.
 
-We declare the struct with a associated type `C` which will provide the coefficient.
+We declare the struct with an associated type `C`, which will provide the coefficient.
 
 ```rust, ignore
 pub struct LinearWeightToFee<C>(sp_std::marker::PhantomData<C>);

--- a/text/3-entrees/fees.md
+++ b/text/3-entrees/fees.md
@@ -118,7 +118,7 @@ impl transaction_payment::Trait for Runtime {
 
 More complex polynomials can also be used. When using complex polynomials, it is unlikely that your
 logic will be reused among multiple chains, so it is generally not worth the overhead of making the
-coefficients configurable. The `QuadraticWeightToFee` demonstrate a 2nd degree polynomial with
+coefficients configurable. The `QuadraticWeightToFee` demonstrates a 2nd-degree polynomial with
 hard-coded non-integer signed coefficients.
 
 ```rust, ignore

--- a/text/3-entrees/fees.md
+++ b/text/3-entrees/fees.md
@@ -117,7 +117,7 @@ impl transaction_payment::Trait for Runtime {
 ## Quadratic Conversion
 
 More complex polynomials can also be used. When using complex polynomials, it is unlikely that your
-logic will be reused among multiple chains, so it is generally no worth the overhead of making the
+logic will be reused among multiple chains, so it is generally not worth the overhead of making the
 coefficients configurable. The `QuadraticWeightToFee` demonstrate a 2nd degree polynomial with
 hard-coded non-integer signed coefficients.
 

--- a/text/3-entrees/fees.md
+++ b/text/3-entrees/fees.md
@@ -98,7 +98,7 @@ This struct is reusable, and works with different coefficients. Using it looks l
 
 ```rust, ignore
 parameter_types! {
-	// Used with LinearWeightToFee conversion. Leaving this constant in tact when using other
+	// Used with LinearWeightToFee conversion. Leaving this constant intact when using other
 	// conversion techniques is harmless.
 	pub const FeeWeightRatio: u128 = 1_000;
 

--- a/text/3-entrees/fees.md
+++ b/text/3-entrees/fees.md
@@ -22,8 +22,9 @@ total_fee = transaction_length * length_fee + weight_to_fee(total_weight)
 
 ## Setting the Parameters
 
-Each of the parameters described above is set in the `transaction_payment` pallet's configuration
-trait. For example, the `super-runtime` sets these parameters as follows.
+Each of the parameters described above is set in the
+[transaction payment pallet](https://crates.parity.io/pallet_transaction_payment/index.html)'s
+configuration trait. For example, the `super-runtime` sets these parameters as follows.
 
 src:
 [`runtimes/super-runtime/src/lib.rs`](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/super-runtime/src/lib.rs)

--- a/text/3-entrees/kitchen-node.md
+++ b/text/3-entrees/kitchen-node.md
@@ -90,9 +90,9 @@ without the UI.
 Installing the instant seal engine has three dependencies whereas the runtime had only one.
 
 ```toml
-sc-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sc-consensus-manual-seal = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
-sp-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '12e08fd25455053e3cedc8b19beb7e77330a5713' }
+sc-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sc-consensus-manual-seal = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
+sp-consensus = { version = '0.8.0-dev', git = 'https://github.com/paritytech/substrate', rev = '45b9f0a9cbf901abaa9f1fca5fe8baeed029133d' }
 ```
 
 ### The Proposer


### PR DESCRIPTION
This PR updates all the substrate dependencies to `45b9f0a` which is the commit tagged as `v2.0.0-rc2`. It also makes minor code changes to make the code compile on the updated API. This is in preparation for releasing recipes rc2.

The only significant code changes are in the weight-fee runtime because converting weight to fee now requires the [`WeightToFeePolynomial` trait](https://crates.parity.io/frame_support/weights/trait.WeightToFeePolynomial.html). These changes are also reflected in the writeup.