### PR TITLE
Rename vec-set's store to VecSet

### DIFF
--- a/pallets/vec-set/src/lib.rs
+++ b/pallets/vec-set/src/lib.rs
@@ -20,7 +20,7 @@ pub trait Trait: system::Trait {
 }
 
 decl_storage! {
-	trait Store for Module<T: Trait> as VecMap {
+	trait Store for Module<T: Trait> as VecSet {
 		// The set of all members. Stored as a single vec
 		Members get(fn members): Vec<T::AccountId>;
 	}

--- a/text/3-entrees/storage-api/vec-set.md
+++ b/text/3-entrees/storage-api/vec-set.md
@@ -29,7 +29,7 @@ needs, we are able to build a set from the `Vec`. We declare our single storage 
 
 ```rust, ignore
 decl_storage! {
-	trait Store for Module<T: Trait> as VecMap {
+	trait Store for Module<T: Trait> as VecSet {
 		// The set of all members. Stored as a single vec
 		Members get(fn members): Vec<T::AccountId>;
 	}


### PR DESCRIPTION
This PR fixes a minor naming inconsistency in the `vec-set` pallet.