### PR TITLE
Update CI Actions

### DIFF
--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -10,7 +10,7 @@ jobs:
   build-book:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Setup mdBook
       uses: peaceiris/actions-mdbook@v1

--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup mdBook
       uses: peaceiris/actions-mdbook@v1
       with:
-        mdbook-version: '0.3.5'
+        mdbook-version: '0.3.7'
         # mdbook-version: 'latest'
 
     - name: Install mdbook-linkcheck

--- a/.github/workflows/build-deploy-book.yml
+++ b/.github/workflows/build-deploy-book.yml
@@ -9,7 +9,7 @@ jobs:
   build-deploy-book:
     runs-on: ubuntu-18.04
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Setup mdBook
       uses: peaceiris/actions-mdbook@v1

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
       # Steps taken from https://github.com/actions/cache/blob/master/examples.md#rust---cargo
     - name: Cache cargo registry

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -20,22 +20,13 @@ jobs:
 
       # Steps taken from https://github.com/actions/cache/blob/master/examples.md#rust---cargo
     - name: Cache cargo registry
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
-        path: ~/.cargo/registry
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
         key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-    - name: Cache cargo index
-      uses: actions/cache@v1
-      with:
-        path: ~/.cargo/git
-        key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-
-    - name: Cache cargo build
-      uses: actions/cache@v1
-      with:
-        path: target
-        key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Install toolchain
       uses: actions-rs/toolchain@v1


### PR DESCRIPTION
This PR updates several tools used in the Recipes' CI to the latest versions.

actions/checkout: v1 -> v2
mdbook: 3.5 -> 3.7
actions/cache: v1 -> v2

The update to the cache actions also condenses what was previously three separate caches into a single cache as recommended by https://github.com/actions/cache/blob/master/examples.md#rust---cargo