### PR TITLE
Addition to Manual Seal that combines it with Instant seal

### DIFF
--- a/nodes/manual-seal/src/combined_service.rs
+++ b/nodes/manual-seal/src/combined_service.rs
@@ -8,6 +8,7 @@ use sc_network::config::DummyFinalityProofRequestBuilder;
 use sc_service::{error::Error as ServiceError, AbstractService, Configuration, ServiceBuilder};
 use sp_inherents::InherentDataProviders;
 use std::sync::Arc;
+// Note: We need to use the futures prelude for the `map` function.
 use futures::prelude::*;
 
 // Our native executor instance.

--- a/nodes/manual-seal/src/combined_service.rs
+++ b/nodes/manual-seal/src/combined_service.rs
@@ -1,0 +1,174 @@
+//! Service and ServiceFactory implementation. Specialized wrapper over substrate service.
+
+use sc_consensus::LongestChain;
+use sc_consensus_manual_seal::{self as manual_seal, rpc};
+use sc_executor::native_executor_instance;
+pub use sc_executor::NativeExecutor;
+use sc_network::config::DummyFinalityProofRequestBuilder;
+use sc_service::{error::Error as ServiceError, AbstractService, Configuration, ServiceBuilder};
+use sp_inherents::InherentDataProviders;
+use std::sync::Arc;
+use futures::prelude::*;
+
+// Our native executor instance.
+native_executor_instance!(
+	pub Executor,
+	runtime::api::dispatch,
+	runtime::native_version,
+);
+
+/// Starts a `ServiceBuilder` for a full service.
+///
+/// Use this macro if you don't actually need the full service, but just the builder in order to
+/// be able to perform chain operations.
+macro_rules! new_full_start {
+	($config:expr) => {{
+		let builder = sc_service::ServiceBuilder::new_full::<
+			runtime::opaque::Block,
+			runtime::RuntimeApi,
+			crate::combined_service::Executor,
+		>($config)?
+		.with_select_chain(|_config, backend| Ok(sc_consensus::LongestChain::new(backend.clone())))?
+		.with_transaction_pool(|config, client, _fetcher, prometheus_registry| {
+			let pool_api = sc_transaction_pool::FullChainApi::new(client.clone());
+			Ok(sc_transaction_pool::BasicPool::new(
+				config,
+				std::sync::Arc::new(pool_api),
+				prometheus_registry,
+			))
+		})?
+		.with_import_queue(
+			|_config, client, _select_chain, _transaction_pool, spawn_task_handle, registry| {
+				Ok(sc_consensus_manual_seal::import_queue(
+					Box::new(client),
+					spawn_task_handle,
+					registry,
+				))
+			},
+		)?;
+
+		builder
+		}};
+}
+
+type RpcExtension = jsonrpc_core::IoHandler<sc_rpc::Metadata>;
+
+/// Builds a new service for a full client.
+pub fn new_full(config: Configuration) -> Result<impl AbstractService, ServiceError> {
+	let is_authority = config.role.is_authority();
+
+	let inherent_data_providers = InherentDataProviders::new();
+	inherent_data_providers
+		.register_provider(sp_timestamp::InherentDataProvider)
+		.map_err(Into::into)
+		.map_err(sp_consensus::error::Error::InherentData)?;
+
+	let builder = new_full_start!(config);
+
+	// Channel for the rpc handler to communicate with the authorship task.
+	let (command_sink, commands_stream) = futures::channel::mpsc::channel(1000);
+
+	let service = builder
+		// manual-seal relies on receiving sealing requests aka EngineCommands over rpc.
+		.with_rpc_extensions(|_| -> Result<RpcExtension, _> {
+			let mut io = jsonrpc_core::IoHandler::default();
+			io.extend_with(
+				// We provide the rpc handler with the sending end of the channel to allow the rpc
+				// send EngineCommands to the background block authorship task.
+				rpc::ManualSealApi::to_delegate(rpc::ManualSeal::new(command_sink)),
+			);
+			Ok(io)
+		})?
+        .build()?;
+        
+    // 1) We create the pool here because we need it for both the `pool_stream`
+    // and later in the consensus builder.
+    let pool = service.transaction_pool().pool().clone();
+
+    // 2) We create a pool_stream for notifications of blocks that are imported into
+    // the transaction pool. This code was cribbed from the implementation of instant seal
+    // and is how instant seal works internally.
+    let pool_stream = pool
+        .validated_pool()
+        .import_notification_stream()
+        .map(|_| {
+            // Every new block create an `EngineCommand` that will seal a new block.
+            rpc::EngineCommand::SealNewBlock {
+                create_empty: false,
+                finalize: false,
+                parent_hash: None,
+                sender: None,
+            }
+        });
+
+    // 3) Use select to take events produced by both the `commands_stream` and the
+    // `pool_stream` together.
+    let combined_stream = futures::stream::select(commands_stream, pool_stream);
+
+
+	if is_authority {
+		// Proposer object for block authorship.
+		let proposer = sc_basic_authorship::ProposerFactory::new(
+			service.client(),
+			service.transaction_pool(),
+			service.prometheus_registry().as_ref(),
+		);
+
+		// Background authorship future.
+		let authorship_future = manual_seal::run_manual_seal(
+			Box::new(service.client()),
+			proposer,
+			service.client(), // 4) vvvvv
+			pool,             // <- Use the same pool that we used to get `pool_stream`.
+			combined_stream,  // <- Here we place the combined streams. 
+			service.select_chain().unwrap(),
+			inherent_data_providers,
+		);
+
+		// we spawn the future on a background thread managed by service.
+		service.spawn_essential_task("manual-seal", authorship_future);
+	};
+
+	Ok(service)
+}
+
+/// Builds a new service for a light client.
+pub fn new_light(config: Configuration) -> Result<impl AbstractService, ServiceError> {
+	ServiceBuilder::new_light::<runtime::opaque::Block, runtime::RuntimeApi, Executor>(config)?
+		.with_select_chain(|_config, backend| Ok(LongestChain::new(backend.clone())))?
+		.with_transaction_pool(|config, client, fetcher, prometheus_registry| {
+			let fetcher = fetcher
+				.ok_or_else(|| "Trying to start light transaction pool without active fetcher")?;
+			let pool_api = sc_transaction_pool::LightChainApi::new(client, fetcher);
+			let pool = sc_transaction_pool::BasicPool::with_revalidation_type(
+				config,
+				Arc::new(pool_api),
+				prometheus_registry,
+				sc_transaction_pool::RevalidationType::Light,
+			);
+			Ok(pool)
+		})?
+		.with_import_queue_and_fprb(
+			|_config,
+			 client,
+			 _backend,
+			 _fetcher,
+			 _select_chain,
+			 _tx_pool,
+			 spawn_task_handle,
+			 registry| {
+				let finality_proof_request_builder =
+					Box::new(DummyFinalityProofRequestBuilder::default()) as Box<_>;
+
+				let import_queue = sc_consensus_manual_seal::import_queue(
+					Box::new(client),
+					spawn_task_handle,
+					registry,
+				);
+
+				Ok((import_queue, finality_proof_request_builder))
+			},
+		)?
+		.with_finality_proof_provider(|_client, _backend| Ok(Arc::new(()) as _))?
+		.build()
+}

--- a/nodes/manual-seal/src/command.rs
+++ b/nodes/manual-seal/src/command.rs
@@ -1,7 +1,7 @@
 use crate::chain_spec;
 use crate::cli::Cli;
-// use crate::service;
-use crate::combined_service as service;
+use crate::service;
+// use crate::combined_service as service;
 use sc_cli::SubstrateCli;
 
 impl SubstrateCli for Cli {

--- a/nodes/manual-seal/src/command.rs
+++ b/nodes/manual-seal/src/command.rs
@@ -1,6 +1,7 @@
 use crate::chain_spec;
 use crate::cli::Cli;
-use crate::service;
+// use crate::service;
+use crate::combined_service as service;
 use sc_cli::SubstrateCli;
 
 impl SubstrateCli for Cli {

--- a/nodes/manual-seal/src/main.rs
+++ b/nodes/manual-seal/src/main.rs
@@ -3,7 +3,8 @@
 
 mod chain_spec;
 #[macro_use]
-mod service;
+// mod service;
+mod combined_service;
 mod cli;
 mod command;
 

--- a/nodes/manual-seal/src/main.rs
+++ b/nodes/manual-seal/src/main.rs
@@ -3,8 +3,8 @@
 
 mod chain_spec;
 #[macro_use]
-// mod service;
-mod combined_service;
+mod service;
+// mod combined_service;
 mod cli;
 mod command;
 

--- a/text/3-entrees/manual-seal.md
+++ b/text/3-entrees/manual-seal.md
@@ -180,22 +180,25 @@ service.spawn_essential_task("manual-seal", authorship_future);
 
 ## Combining Instant Seal with Manual Seal
 
-It is possible to combine the manual seal of the node we built above with the functionality
-of the [Kitchen Node's](./kitchen-node.md) instant seal to get the best of both worlds. We can
-use the instant seal method to produce blocks and "go forward" in the block number in order
-to test and trigger different functionality in a live environment, while the normal behavior is
-to seal a block whenever a new block is imported. This configuration may be desirable in some
-testing environments and resembles the functionality of Ethereum's `ganache-cli`.
+It is possible to combine the manual seal of the node we built above with the functionality of the
+[Kitchen Node's](./kitchen-node.md) instant seal to get the best of both worlds. We can use the
+instant seal method to produce blocks and "go forward" in the block number in order to test and
+trigger different functionality in a live environment, while the normal behavior is to seal a block
+whenever a new block is imported. This configuration may be desirable in some testing environments
+and resembles the functionality of Ethereum's `ganache-cli`.
 
 ### Implementation
 
-In the same repository for the manual seal node is a file called `combined_service.rs` which contains modified code of the normal `service.rs` file we just looked at together. Modifications are numbered and begin at line 85.
+In the same repository for the manual seal node is a file called `combined_service.rs` which
+contains modified code of the normal `service.rs` file we just looked at together. Modifications are
+numbered and begin at line 85.
 
 ```rust, ignore
 let pool = service.transaction_pool().pool().clone();
 ```
 
-The first step is to create an instance of a transaction pool that will be shared between the `pool_stream` which receives events whenever a new transaction is imported and the service builder.
+The first step is to create an instance of a transaction pool that will be shared between the
+`pool_stream` which receives events whenever a new transaction is imported and the service builder.
 
 ```rust, ignore
 let pool_stream = pool
@@ -212,13 +215,17 @@ let pool_stream = pool
 	});
 ```
 
-Next we implement the instant seal just as it's implemented under the covers in the call to `run_instant_seal`. Namely, we make sure that any new notifications we will submit an RPC `EngineCommand` to seal a new block.
+Next we implement the instant seal just as it's implemented under the covers in the call to
+`run_instant_seal`. Namely, we make sure that any new notifications we will submit an RPC
+`EngineCommand` to seal a new block.
 
 ```rust, ignore
 let combined_stream = futures::stream::select(commands_stream, pool_stream);
 ```
 
-We combine the futures using the `select` utility which will receive events from either one of the streams we pass to it. In this case, we're passing all notifications received from the manual seal stream and the instant seal stream together.
+We combine the futures using the `select` utility which will receive events from either one of the
+streams we pass to it. In this case, we're passing all notifications received from the manual seal
+stream and the instant seal stream together.
 
 ```rust, ignore
 let authorship_future = manual_seal::run_manual_seal(
@@ -226,7 +233,7 @@ let authorship_future = manual_seal::run_manual_seal(
 	proposer,
 	service.client(), // 4) vvvvv
 	pool,             // <- Use the same pool that we used to get `pool_stream`.
-	combined_stream,  // <- Here we place the combined streams. 
+	combined_stream,  // <- Here we place the combined streams.
 	service.select_chain().unwrap(),
 	inherent_data_providers,
 );
@@ -234,4 +241,8 @@ let authorship_future = manual_seal::run_manual_seal(
 
 Finally we initialize the authorship_future with the combined streams.
 
-In order to run this variant of the node you will need to uncomment two lines and rebuild the node. In `command.rs` comment the line that reads `use crate::service;` and uncomment `use crate::combined_service as service;`. In `main.rs` comment `mod service;` and uncomment `mod combined_service'`. Now you can rebuild the node and test out that it will seal blocks using the manual method and the instant method together.
+In order to run this variant of the node you will need to uncomment two lines and rebuild the node.
+In `command.rs` comment the line that reads `use crate::service;` and uncomment
+`use crate::combined_service as service;`. In `main.rs` comment `mod service;` and uncomment
+`mod combined_service'`. Now you can rebuild the node and test out that it will seal blocks using
+the manual method and the instant method together.

--- a/text/3-entrees/manual-seal.md
+++ b/text/3-entrees/manual-seal.md
@@ -181,17 +181,17 @@ service.spawn_essential_task("manual-seal", authorship_future);
 ## Combining Instant Seal with Manual Seal
 
 It is possible to combine the manual seal of the node we built above with the functionality of the
-[Kitchen Node's](./kitchen-node.md) instant seal to get the best of both worlds. We can use the
-instant seal method to produce blocks and "go forward" in the block number in order to test and
-trigger different functionality in a live environment, while the normal behavior is to seal a block
-whenever a new block is imported. This configuration may be desirable in some testing environments
-and resembles the functionality of Ethereum's `ganache-cli`.
+[Kitchen Node's](./kitchen-node.md) instant seal to get the best of both worlds. This configuration
+may be desirable in development and testing environments. We can use the normal behavior of instant
+seal to create blocks any time a transaction is imported into the pool. On the other hand we can
+move forward in block number by instantly sealing empty blocks. The functionality may be familiar to
+developers of Ethereum smart contracts that have used `ganache-cli`.
 
 ### Implementation
 
-In the same repository for the manual seal node is a file called `combined_service.rs` which
-contains modified code of the normal `service.rs` file we just looked at together. Modifications are
-numbered and begin at line 85.
+In the same directory for the manual seal node is a file called `combined_service.rs`. This file
+contains modified code of the `service.rs` file we just looked at in the section above. Some modification have been made. These modifications are
+numbered and begin at line 85 in the source.
 
 ```rust, ignore
 let pool = service.transaction_pool().pool().clone();

--- a/text/3-entrees/manual-seal.md
+++ b/text/3-entrees/manual-seal.md
@@ -177,3 +177,12 @@ With the future created, we can now kick it off using the service's
 // we spawn the future on a background thread managed by service.
 service.spawn_essential_task("manual-seal", authorship_future);
 ```
+
+## Combining Instant Seal with Manual Seal
+
+The [Kitchen Node](./kitchen-node.md) uses instant seal which is a variant of manual seal
+that will seal a new block whenever a notification of a new block is received from the transaction pool. Now you may want to have a node that combines both properties so that you can use manual seal to seal new blocks via RPC when you want and otherwise seal blocks when new transactions are imported. This node is very similar to test chains used in other ecosystems, such as Ethereum's `ganache-cli`.
+
+### Using `select` to Merge Futures
+
+As we saw in the previous version of manual seal, 

--- a/text/3-entrees/manual-seal.md
+++ b/text/3-entrees/manual-seal.md
@@ -239,7 +239,7 @@ let authorship_future = manual_seal::run_manual_seal(
 );
 ```
 
-Finally we initialize the authorship_future with the combined streams.
+Finally we initialize the `authorship_future` with the combined streams.
 
 In order to run this variant of the node you will need to uncomment two lines and rebuild the node.
 In `command.rs` comment the line that reads `use crate::service;` and uncomment


### PR DESCRIPTION
The motivation behind this addition to the Manual Seal recipe is to have a node that has the normal behavior of using manual seal, but has the option to progress forward in block time using instant seal. This kind of node may be desirable in testing or development environments.

The method I took was to add an additional `combined_service.rs` file which needs to be manually uncommented in the source for the node to be enabled. Let me know if it would be a good idea to add a CLI flag instead to switch between the modes of manual seal, instant + manual seal, and instant seal (as mentioned in chat).