### PR TITLE
Standardize authors string

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,5 +1,5 @@
 [book]
-authors = ["4meta5, Joshy Orndorff"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 language = "en"
 multilingual = false
 src = "text"

--- a/consensus/sha3pow/Cargo.toml
+++ b/consensus/sha3pow/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ['Joshy Orndorff, Wei Tang']
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 edition = '2018'
 name = 'sha3pow'
 repository = 'https://github.com/substrate-developer-hub/recipes'

--- a/nodes/babe-grandpa-node/Cargo.toml
+++ b/nodes/babe-grandpa-node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "babe-grandpa-node"
 version = "2.0.0-dev"
 edition = "2018"
-authors = ['Joshy Orndorff', '4meta5', 'Jimmy Chu']
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 description = 'A Substrate node where consensus authorities are determined by the runtime and passed to the consensus engine via a runtime API.'
 license = "GPL-3.0-or-later"

--- a/nodes/basic-pow/Cargo.toml
+++ b/nodes/basic-pow/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ['Joshy Orndorff']
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 edition = '2018'
 name = 'basic-pow'
 repository = 'https://github.com/substrate-developer-hub/recipes'

--- a/nodes/hybrid-consensus/Cargo.toml
+++ b/nodes/hybrid-consensus/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hybrid-consensus"
 version = "2.0.0-dev"
 edition = "2018"
-authors = ['Joshy Orndorff']
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 description = 'A Substrate node with PoW authoring and PoA finality'
 license = "GPL-3.0-or-later"

--- a/nodes/kitchen-node/Cargo.toml
+++ b/nodes/kitchen-node/Cargo.toml
@@ -2,7 +2,7 @@
 name = "kitchen-node"
 version = "2.0.0-dev"
 edition = "2018"
-authors = ['Joshy Orndorff', '4meta5', 'Jimmy Chu']
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 description = 'An instant-sealing Substrate node. Can be used with most recipe runtimes.'
 license = "GPL-3.0-or-later"

--- a/nodes/manual-seal/Cargo.toml
+++ b/nodes/manual-seal/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-authors = ['Seun LanLege', 'Joshy Orndorff']
+name = 'manual-seal'
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 build = 'build.rs'
 edition = '2018'
-name = 'manual-seal'
 repository = 'https://github.com/paritytech/substrate/'
-version = '2.0.0-dev'
-description = 'A Substrate-based node that uses the instant-seal and manual-seal consensus engines'
+version = "2.0.0-dev"
+description = "A Substrate-based node that uses the instant-seal and manual-seal consensus engines"
 license = "GPL-3.0-or-later"
 
 [package.metadata.substrate]

--- a/nodes/rpc-node/Cargo.toml
+++ b/nodes/rpc-node/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-authors = ['Anonymous']
+name = 'rpc-node'
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 build = 'build.rs'
 edition = '2018'
-name = 'rpc-node'
-version = '2.0.0-dev'
+version = "2.0.0-dev"
 repository = 'https://github.com/substrate-developer-hub/recipes'
-description = 'A Substrate node that demonstrates a custom RPC endpoint'
+description = "A Substrate node that demonstrates a custom RPC endpoint"
 license = "GPL-3.0-or-later"
 
 [package.metadata.substrate]

--- a/pallets/adding-machine/Cargo.toml
+++ b/pallets/adding-machine/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "adding-machine"
 version = "2.0.0-dev"
-authors = ["4meta5, Joshy Orndorff"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/pallets/basic-token/Cargo.toml
+++ b/pallets/basic-token/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "basic-token"
 version = "2.0.0-dev"
-authors = ["4meta5"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/pallets/charity/Cargo.toml
+++ b/pallets/charity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "charity"
 version = "2.0.0-dev"
-authors = ["4meta5"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/pallets/check-membership/Cargo.toml
+++ b/pallets/check-membership/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "check-membership"
 version = "2.0.0-dev"
-authors = ["4meta5"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/pallets/compounding-interest/Cargo.toml
+++ b/pallets/compounding-interest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "compounding-interest"
 version = "2.0.0-dev"
-authors = ["Joshy Orndorff"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/pallets/constant-config/Cargo.toml
+++ b/pallets/constant-config/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "constant-config"
 version = "2.0.0-dev"
-authors = ["4meta5"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/pallets/currency-imbalances/Cargo.toml
+++ b/pallets/currency-imbalances/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "currency-imbalances"
 version = "2.0.0-dev"
-authors = ["4meta5"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/pallets/default-instance/Cargo.toml
+++ b/pallets/default-instance/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "default-instance"
 version = "2.0.0-dev"
-authors = ["Joshy"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/pallets/double-map/Cargo.toml
+++ b/pallets/double-map/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "double-map"
 version = "2.0.0-dev"
-authors = ["4meta5"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/pallets/execution-schedule/Cargo.toml
+++ b/pallets/execution-schedule/Cargo.toml
@@ -2,7 +2,7 @@
 name = "execution-schedule"
 version = "2.0.0-dev"
 repository = 'https://github.com/substrate-developer-hub/recipes'
-authors = ["4meta5"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 edition = "2018"
 license = "GPL-3.0-or-later"
 description = "A pallet that demonstrates scheduling calls for future dispatch"

--- a/pallets/fixed-point/Cargo.toml
+++ b/pallets/fixed-point/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fixed-point"
 version = "2.0.0-dev"
-authors = ["Joshy Orndorff"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 edition = "2018"
 description = "A pallet that demonstrates using fixed-point arithmetic in Substrate"
 license = "GPL-3.0-or-later"

--- a/pallets/generic-event/Cargo.toml
+++ b/pallets/generic-event/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "generic-event"
 version = "2.0.0-dev"
-authors = ["4meta5"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/pallets/hello-substrate/Cargo.toml
+++ b/pallets/hello-substrate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hello-substrate"
 version = "2.0.0-dev"
-authors = ["shawntabrizi"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/pallets/last-caller/Cargo.toml
+++ b/pallets/last-caller/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "last-caller"
 version = "2.0.0-dev"
-authors = ["Joshy"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/pallets/lockable-currency/Cargo.toml
+++ b/pallets/lockable-currency/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lockable-currency"
 version = "2.0.0-dev"
-authors = ["4meta5"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/pallets/map-set/Cargo.toml
+++ b/pallets/map-set/Cargo.toml
@@ -2,7 +2,7 @@
 name = "map-set"
 version = "2.0.0-dev"
 repository = 'https://github.com/substrate-developer-hub/recipes'
-authors = ["4meta5"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 edition = "2018"
 license = "GPL-3.0-or-later"
 description = "A pallet that implements a storage Set on top of a storage map"

--- a/pallets/offchain-demo/Cargo.toml
+++ b/pallets/offchain-demo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "offchain-demo"
 version = "2.0.0-dev"
-authors = ["Parity Technologies <admin@parity.io>"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 edition = "2018"
 repository = "https://github.com/substrate-developer-hub/recipes/"
 license = "GPL-3.0-or-later"

--- a/pallets/randomness/Cargo.toml
+++ b/pallets/randomness/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "randomness"
 version = "2.0.0-dev"
-authors = ["4meta5"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/pallets/reservable-currency/Cargo.toml
+++ b/pallets/reservable-currency/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "reservable-currency"
 version = "2.0.0-dev"
-authors = ["4meta5"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/pallets/ringbuffer-queue/Cargo.toml
+++ b/pallets/ringbuffer-queue/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ringbuffer-queue"
 version = "2.0.0-dev"
-authors = ["apopiak"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/pallets/simple-crowdfund/Cargo.toml
+++ b/pallets/simple-crowdfund/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "simple-crowdfund"
 version = "2.0.0-dev"
-authors = ["4meta5"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/pallets/simple-event/Cargo.toml
+++ b/pallets/simple-event/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "simple-event"
 version = "2.0.0-dev"
-authors = ["4meta5"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/pallets/simple-map/Cargo.toml
+++ b/pallets/simple-map/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "simple-map"
 version = "2.0.0-dev"
-authors = ["4meta5"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/pallets/single-value/Cargo.toml
+++ b/pallets/single-value/Cargo.toml
@@ -2,7 +2,7 @@
 name = "single-value"
 version = "2.0.0-dev"
 repository = 'https://github.com/substrate-developer-hub/recipes'
-authors = ["4meta5"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 edition = "2018"
 license = "GPL-3.0-or-later"
 description = "A pallet that demonstrates storing values in Substrate storage"

--- a/pallets/storage-cache/Cargo.toml
+++ b/pallets/storage-cache/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "storage-cache"
 version = "2.0.0-dev"
-authors = ["4meta5"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/pallets/struct-storage/Cargo.toml
+++ b/pallets/struct-storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "struct-storage"
 version = "2.0.0-dev"
-authors = ["4meta5"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/pallets/sum-storage/Cargo.toml
+++ b/pallets/sum-storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sum-storage"
 version = "2.0.0-dev"
-authors = ["Joshy Orndorff"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 edition = "2018"
 description = "A pallet with two storage items whose sum is exposed via a custom runtime API"
 license = "GPL-3.0-or-later"

--- a/pallets/sum-storage/rpc/Cargo.toml
+++ b/pallets/sum-storage/rpc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sum-storage-rpc"
 version = "2.0.0"
-authors = ["JoshyOrndorff"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 edition = "2018"
 license = "GPL-3.0-or-later"
 

--- a/pallets/sum-storage/runtime-api/Cargo.toml
+++ b/pallets/sum-storage/runtime-api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sum-storage-runtime-api"
 version = "2.0.0"
-authors = ["Joshy Orndorff"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 edition = "2018"
 license = "GPL-3.0-or-later"
 

--- a/pallets/vec-set/Cargo.toml
+++ b/pallets/vec-set/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vec-set"
 version = "2.0.0-dev"
 repository = 'https://github.com/substrate-developer-hub/recipes'
-authors = ["4meta5"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 edition = "2018"
 license = "GPL-3.0-or-later"
 description = "A pallet that implements a storage Set on top of a Vec"

--- a/pallets/weights/Cargo.toml
+++ b/pallets/weights/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "weights"
 version = "2.0.0-dev"
-authors = ["Anonymous"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/runtimes/api-runtime/Cargo.toml
+++ b/runtimes/api-runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "api-runtime"
 version = "2.0.0-dev"
-authors = ["Joshy Orndorff"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/runtimes/babe-grandpa-runtime/Cargo.toml
+++ b/runtimes/babe-grandpa-runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "babe-grandpa-runtime"
 version = "2.0.0-dev"
-authors = ["Joshy Orndorff"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/runtimes/minimal-grandpa-runtime/Cargo.toml
+++ b/runtimes/minimal-grandpa-runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "minimal-grandpa-runtime"
 version = "2.0.0-dev"
-authors = ["Anonymous"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/runtimes/ocw-runtime/Cargo.toml
+++ b/runtimes/ocw-runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ocw-runtime"
 version = "2.0.0-dev"
-authors = ["Anonymous"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/runtimes/super-runtime/Cargo.toml
+++ b/runtimes/super-runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "super-runtime"
 version = "2.0.0-dev"
-authors = ["Joshy Orndorff"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/runtimes/weight-fee-runtime/Cargo.toml
+++ b/runtimes/weight-fee-runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "weight-fee-runtime"
 version = "2.0.0-dev"
-authors = ["Anonymous"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"

--- a/traits/account-set/Cargo.toml
+++ b/traits/account-set/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "account-set"
 version = "2.0.0-dev"
-authors = ["Joshy Orndorff"]
+authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
 repository = 'https://github.com/substrate-developer-hub/recipes'
 edition = "2018"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
This PR updates all `Cargo.toml` files and the `book.toml` file to list the authors as
`Substrate DevHub <https://github.com/substrate-developer-hub>`