### PR TITLE
Some playground love

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,10 @@
+FROM jeluard/substrate-playground-template-base@sha256:35683978140807d8e3c9eaa814e9034bd254e74224073984db2159302d44946b
+
+ADD . .
+
+RUN cargo build --release -p basic-pow
+RUN cargo build --release -p babe-grandpa-node
+RUN cargo build --release -p hybrid-consensus
+RUN cargo build --release -p kitchen-node
+RUN cargo build --release -p manual-seal
+RUN cargo build --release -p rpc-node

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,5 +13,6 @@
   "forwardPorts": [
     3000,
     9944
-  ]
+  ],
+  "image": "jeluard/substrate-playground-template-recipes:sha-043ecec"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "Substrate recipes",
+  "name": "Substrate Recipes",
   "dockerFile": "Dockerfile",
   "settings": {
     "terminal.integrated.shell.linux": "/bin/bash",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "Substrate recipes",
+  "dockerFile": "Dockerfile",
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash",
+    "lldb.executable": "/usr/bin/lldb"
+  },
+  "extensions": [
+    "rust-lang.rust",
+    "bungcip.better-toml",
+    "vadimcn.vscode-lldb"
+  ],
+  "forwardPorts": [
+    3000,
+    9944
+  ]
+}

--- a/.github/workflows/build-push-template.yml
+++ b/.github/workflows/build-push-template.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Commit .devcontainer.json update
       uses: EndBug/add-and-commit@v4
       with:
-        message: ":bookmark: update image"
+        message: "🔖 Update Docker Image for Substrate Playground"
         add: ".devcontainer/devcontainer.json"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-push-template.yml
+++ b/.github/workflows/build-push-template.yml
@@ -23,6 +23,7 @@ jobs:
         tag_with_ref: true
         tag_with_sha: true
 
+    # https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter
     - run: echo ::set-output name=image::jeluard/substrate-playground-template-recipes:sha-${GITHUB_SHA::7}
       id: env
 

--- a/.github/workflows/build-push-template.yml
+++ b/.github/workflows/build-push-template.yml
@@ -1,4 +1,4 @@
-name: Build and Push template
+name: Build and Push Playground Image
 
 on:
   push:

--- a/.github/workflows/build-push-template.yml
+++ b/.github/workflows/build-push-template.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Build and push the recipes Docker image
+    - name: Build and push Docker image for Substrate Playground
       uses: docker/build-push-action@v1 # https://github.com/docker/build-push-action
       with:
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/build-push-template.yml
+++ b/.github/workflows/build-push-template.yml
@@ -1,0 +1,48 @@
+name: Build and Push template
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  build-push-template:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build and push the recipes Docker image
+      uses: docker/build-push-action@v1 # https://github.com/docker/build-push-action
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        dockerfile: .devcontainer/Dockerfile
+        repository: jeluard/substrate-playground-template-recipes
+        tags: latest
+        add_git_labels: true
+        tag_with_ref: true
+        tag_with_sha: true
+
+    - run: echo ::set-output name=image::jeluard/substrate-playground-template-recipes:sha-${GITHUB_SHA::7}
+      id: env
+
+    - name: Update devcontainer.json
+      run: |-
+        t=$(mktemp)
+        cat .devcontainer/devcontainer.json | jq ".image = \"${{ steps.env.outputs.image }}\"" > ${t} && mv ${t} .devcontainer/devcontainer.json
+
+    - name: Commit .devcontainer.json update
+      uses: EndBug/add-and-commit@v4
+      with:
+        message: ":bookmark: update image"
+        add: ".devcontainer/devcontainer.json"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Trigger playground inclusion
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        token: ${{ secrets.REPO_ACCESS_TOKEN }}
+        repository: paritytech/substrate-playground
+        event-type: template-updated
+        client-payload: '{"id": "recipes", "image": "${{ steps.env.outputs.image }}"}'

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,187 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run Basic pow",
+            "type": "shell",
+            "command": "cargo",
+            "args": ["run", "--release", "-p", "basic-pow", "--", "--dev"],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "new"
+            },
+            "problemMatcher": [
+            {
+                "owner": "rust",
+                "fileLocation": ["relative", "${workspaceRoot}"],
+                "pattern": {
+                "regexp": "^(.*):(\\d+):(\\d+):\\s+(\\d+):(\\d+)\\s+(warning|error):\\s+(.*)$",
+                "file": 1,
+                "line": 2,
+                "column": 3,
+                "endLine": 4,
+                "endColumn": 5,
+                "severity": 6,
+                "message": 7
+                }
+            }
+            ]
+        },
+        {
+            "label": "Run Babe grandpa node",
+            "type": "shell",
+            "command": "cargo",
+            "args": ["run", "--release", "-p", "babe-grandpa-node", "--", "--dev"],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "new"
+            },
+            "problemMatcher": [
+            {
+                "owner": "rust",
+                "fileLocation": ["relative", "${workspaceRoot}"],
+                "pattern": {
+                "regexp": "^(.*):(\\d+):(\\d+):\\s+(\\d+):(\\d+)\\s+(warning|error):\\s+(.*)$",
+                "file": 1,
+                "line": 2,
+                "column": 3,
+                "endLine": 4,
+                "endColumn": 5,
+                "severity": 6,
+                "message": 7
+                }
+            }
+            ]
+        },
+        {
+            "label": "Run Hybrid consensus",
+            "type": "shell",
+            "command": "cargo",
+            "args": ["run", "--release", "-p", "hybrid-consensus", "--", "--dev"],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "new"
+            },
+            "problemMatcher": [
+            {
+                "owner": "rust",
+                "fileLocation": ["relative", "${workspaceRoot}"],
+                "pattern": {
+                "regexp": "^(.*):(\\d+):(\\d+):\\s+(\\d+):(\\d+)\\s+(warning|error):\\s+(.*)$",
+                "file": 1,
+                "line": 2,
+                "column": 3,
+                "endLine": 4,
+                "endColumn": 5,
+                "severity": 6,
+                "message": 7
+                }
+            }
+            ]
+        },
+        {
+            "label": "Run Kitchen node",
+            "type": "shell",
+            "command": "cargo",
+            "args": ["run", "--release", "-p", "kitchen-node", "--", "--dev"],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "new"
+            },
+            "problemMatcher": [
+            {
+                "owner": "rust",
+                "fileLocation": ["relative", "${workspaceRoot}"],
+                "pattern": {
+                "regexp": "^(.*):(\\d+):(\\d+):\\s+(\\d+):(\\d+)\\s+(warning|error):\\s+(.*)$",
+                "file": 1,
+                "line": 2,
+                "column": 3,
+                "endLine": 4,
+                "endColumn": 5,
+                "severity": 6,
+                "message": 7
+                }
+            }
+            ]
+        },
+        {
+            "label": "Run Manual seal",
+            "type": "shell",
+            "command": "cargo",
+            "args": ["run", "--release", "-p", "manual-seal", "--", "--dev"],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "new"
+            },
+            "problemMatcher": [
+            {
+                "owner": "rust",
+                "fileLocation": ["relative", "${workspaceRoot}"],
+                "pattern": {
+                "regexp": "^(.*):(\\d+):(\\d+):\\s+(\\d+):(\\d+)\\s+(warning|error):\\s+(.*)$",
+                "file": 1,
+                "line": 2,
+                "column": 3,
+                "endLine": 4,
+                "endColumn": 5,
+                "severity": 6,
+                "message": 7
+                }
+            }
+            ]
+        },
+        {
+            "label": "Run RPC node",
+            "type": "shell",
+            "command": "cargo",
+            "args": ["run", "--release", "-p", "rpc-node", "--", "--dev"],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "reveal": "always",
+                "panel": "new"
+            },
+            "problemMatcher": [
+            {
+                "owner": "rust",
+                "fileLocation": ["relative", "${workspaceRoot}"],
+                "pattern": {
+                "regexp": "^(.*):(\\d+):(\\d+):\\s+(\\d+):(\\d+)\\s+(warning|error):\\s+(.*)$",
+                "file": 1,
+                "line": 2,
+                "column": 3,
+                "endLine": 4,
+                "endColumn": 5,
+                "severity": 6,
+                "message": 7
+                }
+            }
+            ]
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fsubstrate-developer-hub%2Frecipes%2Fbadge%3Fref%3Dmaster&style=flat)
 ![Lines of Code](https://tokei.rs/b1/github/substrate-developer-hub/recipes)
+[![Try on playground](https://img.shields.io/badge/Playground-recipes-brightgreen?logo=Parity%20Substrate)](https://playground-staging.substrate.dev/?deploy=recipes)
 
 _A Hands-On Cookbook for Aspiring Blockchain Chefs_
 


### PR DESCRIPTION
This adds the necessary files so that this repository is accessible as a playground template: Note that most files are standard VSCode files.

The GH actions file triggers and changes to the `master` branch and will:
 
* build a standalone Docker image
* publish it to [dockerhub](https://hub.docker.com/)
* update the `devcontainer.json` (see [Remote containers](https://code.visualstudio.com/docs/remote/containers))
* trigger the remote build and template inclusion in [substrate-playground](https://github.com/paritytech/substrate-playground/)

The following secrets will have to be defined:

* `DOCKER_USERNAME` and `DOCKER_PASSWORD` to push the image to dockerhub (values will depend on the chosen docker image org)
* `REPO_ACCESS_TOKEN` a [token](https://github.com/peter-evans/repository-dispatch#token) with `public_repo` or `repo` scope
