### PR TITLE
Prune babe-grandpa-node from dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,6 @@ FROM paritytech/substrate-playground-template-base:sha-ac4bc53
 ADD . .
 
 RUN cargo build --release -p basic-pow
-RUN cargo build --release -p babe-grandpa-node
 RUN cargo build --release -p hybrid-consensus
 RUN cargo build --release -p kitchen-node
 RUN cargo build --release -p manual-seal


### PR DESCRIPTION
This PR removes the babe-grandpa-node compilation from the playground dockerfile. This details was missed when the babe grandpa node was first pruned.