### PR TITLE
Reduce minimum block time to 1 ms

### DIFF
--- a/runtimes/api-runtime/src/lib.rs
+++ b/runtimes/api-runtime/src/lib.rs
@@ -174,7 +174,7 @@ impl system::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const MinimumPeriod: u64 = 1000;
+	pub const MinimumPeriod: u64 = 1;
 }
 
 impl timestamp::Trait for Runtime {

--- a/runtimes/minimal-grandpa-runtime/src/lib.rs
+++ b/runtimes/minimal-grandpa-runtime/src/lib.rs
@@ -201,7 +201,7 @@ impl grandpa::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const MinimumPeriod: u64 = 1_000;
+	pub const MinimumPeriod: u64 = 1;
 }
 
 impl timestamp::Trait for Runtime {

--- a/runtimes/ocw-runtime/src/lib.rs
+++ b/runtimes/ocw-runtime/src/lib.rs
@@ -182,7 +182,7 @@ impl frame_system::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const MinimumPeriod: u64 = 1000;
+	pub const MinimumPeriod: u64 = 1;
 }
 
 impl pallet_timestamp::Trait for Runtime {

--- a/runtimes/super-runtime/src/lib.rs
+++ b/runtimes/super-runtime/src/lib.rs
@@ -183,7 +183,7 @@ impl system::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const MinimumPeriod: u64 = 1000;
+	pub const MinimumPeriod: u64 = 1;
 }
 
 impl timestamp::Trait for Runtime {

--- a/runtimes/weight-fee-runtime/src/lib.rs
+++ b/runtimes/weight-fee-runtime/src/lib.rs
@@ -188,7 +188,7 @@ impl system::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const MinimumPeriod: u64 = 1000;
+	pub const MinimumPeriod: u64 = 1;
 }
 
 impl timestamp::Trait for Runtime {


### PR DESCRIPTION
The timestamp pallet allows specifying a minimum block time. Previously this time had been set to 1s. But the PoW-based nodes tend to author blocks faster than that once several nodes are mining. There was no fundamental reason to have that min block time, so I've lowered it to 1ms in all runtimes.