### PR TITLE
Fix code links for nodes

### DIFF
--- a/text/basic-pow.md
+++ b/text/basic-pow.md
@@ -3,10 +3,10 @@
 `nodes/basic-pow`
 [
 	![Try on playground](https://img.shields.io/badge/Playground-Try%20it!-brightgreen?logo=Parity%20Substrate)
-](https://playground-staging.substrate.dev/?deploy=recipes&files=%2Fhome%2Fsubstrate%2Fworkspace%2Fnodes%2Fbasic-pow%2Fsrc%2Flib.rs)
+](https://playground-staging.substrate.dev/?deploy=recipes&files=%2Fhome%2Fsubstrate%2Fworkspace%2Fnodes%2Fbasic-pow%2Fsrc%2Fservice.rs)
 [
 	![View on GitHub](https://img.shields.io/badge/Github-View%20Code-brightgreen?logo=github)
-](https://github.com/substrate-developer-hub/recipes/tree/master/nodes/basic-pow/src/lib.rs)
+](https://github.com/substrate-developer-hub/recipes/tree/master/nodes/basic-pow/src/service.rs)
 
 The `basic-pow` node demonstrates how to wire up a custom consensus engine into the Substrate
 Service. It uses a minimal proof of work consensus engine to reach agreement over the blockchain. It

--- a/text/custom-rpc.md
+++ b/text/custom-rpc.md
@@ -3,10 +3,10 @@
 `nodes/custom-rpc`
 [
 	![Try on playground](https://img.shields.io/badge/Playground-Try%20it!-brightgreen?logo=Parity%20Substrate)
-](https://playground-staging.substrate.dev/?deploy=recipes&files=%2Fhome%2Fsubstrate%2Fworkspace%2Fnodes%2Frpc-node%2Fsrc%2Flib.rs)
+](https://playground-staging.substrate.dev/?deploy=recipes&files=%2Fhome%2Fsubstrate%2Fworkspace%2Fnodes%2Frpc-node%2Fsrc%2Fservice.rs)
 [
 	![View on GitHub](https://img.shields.io/badge/Github-View%20Code-brightgreen?logo=github)
-](https://github.com/substrate-developer-hub/recipes/tree/master/nodes/rpc-node/src/lib.rs)
+](https://github.com/substrate-developer-hub/recipes/tree/master/nodes/rpc-node/src/service.rs)
 
 `runtimes/api-runtime`
 [

--- a/text/hybrid-consensus.md
+++ b/text/hybrid-consensus.md
@@ -3,10 +3,10 @@
 `nodes/hybrid-consensus`
 [
 	![Try on playground](https://img.shields.io/badge/Playground-Try%20it!-brightgreen?logo=Parity%20Substrate)
-](https://playground-staging.substrate.dev/?deploy=recipes&files=%2Fhome%2Fsubstrate%2Fworkspace%2Fnodes%2Fhybrid-consensus%2Fsrc%2Flib.rs)
+](https://playground-staging.substrate.dev/?deploy=recipes&files=%2Fhome%2Fsubstrate%2Fworkspace%2Fnodes%2Fhybrid-consensus%2Fsrc%2Fservice.rs)
 [
 	![View on GitHub](https://img.shields.io/badge/Github-View%20Code-brightgreen?logo=github)
-](https://github.com/substrate-developer-hub/recipes/tree/master/nodes/hybrid-consensus/src/lib.rs)
+](https://github.com/substrate-developer-hub/recipes/tree/master/nodes/hybrid-consensus/src/service.rs)
 
 This recipe demonstrates a Substrate-based node that employs hybrid consensus. Specifically, it uses
 [Sha3 Proof of Work](./sha3-pow-consensus.md) to dictate block authoring, and the

--- a/text/kitchen-node.md
+++ b/text/kitchen-node.md
@@ -3,10 +3,10 @@
 `nodes/kitchen-node`
 [
 	![Try on playground](https://img.shields.io/badge/Playground-Try%20it!-brightgreen?logo=Parity%20Substrate)
-](https://playground-staging.substrate.dev/?deploy=recipes&files=%2Fhome%2Fsubstrate%2Fworkspace%2Fnodes%2Fkitchen-node%2Fsrc%2Flib.rs)
+](https://playground-staging.substrate.dev/?deploy=recipes&files=%2Fhome%2Fsubstrate%2Fworkspace%2Fnodes%2Fkitchen-node%2Fsrc%2Fservice.rs)
 [
 	![View on GitHub](https://img.shields.io/badge/Github-View%20Code-brightgreen?logo=github)
-](https://github.com/substrate-developer-hub/recipes/tree/master/nodes/kitchen-node/src/lib.rs)
+](https://github.com/substrate-developer-hub/recipes/tree/master/nodes/kitchen-node/src/service.rs)
 
 This recipe demonstrates a general purpose Substrate node that supports most of the recipes'
 runtimes, and uses


### PR DESCRIPTION
The "View Code" links on all four node writeups was broken. The links incorrectly pointed to `lib.rs` which is not present in the nodes. In the Rust sense, the analogous file would be `main.rs` but I think in terms of where the interesting code lies, `service.rs` is more analogous.

**Why didn't the link checker catch this?**

The link checker doesn't check links that point to github pages because of this [mlc config](https://github.com/substrate-developer-hub/recipes/blob/48f37d7f22795e9f6d7dbccd2ae7bb7c4bf26a1b/.github/workflows/mlc_config.json#L7). This is because when PRs are opened to add new recipes, the links to where those files will live is not yet live on the `master` branch. This decision is open for reconsideration.