### PR TITLE
update type Event in tight and cargo fmt

### DIFF
--- a/pallets/check-membership/src/lib.rs
+++ b/pallets/check-membership/src/lib.rs
@@ -9,6 +9,5 @@
 //! The _loose_ variant demonstrates loosely coupling pallets and is itself loosely coupled through
 //! the `AccountSet` trait.
 
-
 pub mod loose;
 pub mod tight;

--- a/pallets/check-membership/src/loose/mod.rs
+++ b/pallets/check-membership/src/loose/mod.rs
@@ -8,6 +8,7 @@
 
 use frame_support::{decl_error, decl_event, decl_module, dispatch::DispatchResult, ensure};
 use frame_system::{self as system, ensure_signed};
+
 use account_set::AccountSet;
 
 #[cfg(test)]

--- a/pallets/check-membership/src/loose/tests.rs
+++ b/pallets/check-membership/src/loose/tests.rs
@@ -97,10 +97,7 @@ fn members_can_call() {
 
 		let expected_event = TestEvent::check_membership(RawEvent::IsAMember(1));
 
-		assert_eq!(
-			System::events()[1].event,
-			expected_event,
-		);
+		assert_eq!(System::events()[1].event, expected_event);
 	})
 }
 

--- a/pallets/check-membership/src/tight/mod.rs
+++ b/pallets/check-membership/src/tight/mod.rs
@@ -14,7 +14,10 @@ mod tests;
 /// The pallet's configuration trait.
 /// Notice the explicit tight coupling to the `vec-set` pallet
 pub trait Trait: system::Trait + vec_set::Trait {
-	type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
+	// type Event: From<Event<Self>> + Into<<Self as system::Trait>::Event>;
+	type Event: From<Event<Self>>
+		+ Into<<Self as system::Trait>::Event>
+		+ Into<<Self as vec_set::Trait>::Event>;
 }
 
 decl_event!(

--- a/pallets/check-membership/src/tight/tests.rs
+++ b/pallets/check-membership/src/tight/tests.rs
@@ -96,10 +96,7 @@ fn members_can_call() {
 
 		let expected_event = TestEvent::check_membership(RawEvent::IsAMember(1));
 
-		assert_eq!(
-			System::events()[1].event,
-			expected_event,
-		);
+		assert_eq!(System::events()[1].event, expected_event);
 	})
 }
 


### PR DESCRIPTION
pub trait Trait: system::Trait + vec_set::Trait 
The logic is like this
type Event should add Self as vec_set 

// type Event: From<Event<Self>  > + Into<<Self as system::Trait>::Event>;
type Event: From<Event<Self>>+ Into<<Self as system::Trait>::Event>+ Into<<Self as vec_set ::Trait>::Event>;