### PR TITLE
Proof-reading edits :bowtie:

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "spellright.language": [],
+    "spellright.documentTypes": [
+        "latex",
+        "plaintext"
+    ]
+}

--- a/text/cache.md
+++ b/text/cache.md
@@ -70,7 +70,7 @@ If the type was not `Copy`, but was [`Clone`](https://doc.rust-lang.org/std/clon
 then it is still better to clone the value in the method than to make another call to runtime
 storage.
 
-The runtime methods enable the calling account to swap the `T::AccountId` value in storage if
+The runtime methods enable the calling account to swap the `T::AccountId` value in storage if:
 
 1. the existing storage value is not in `GroupMembers` AND
 2. the calling account is in `GroupMembers`
@@ -100,7 +100,7 @@ fn swap_king_no_cache(origin) -> DispatchResult {
 ```
 
 If the `existing_key` is used without a `clone` in the event emission instead of `old_king`, then
-the compiler returns the following error
+the compiler returns the following error:
 
 ```bash
 error[E0382]: use of moved value: `existing_king`

--- a/text/events.md
+++ b/text/events.md
@@ -56,7 +56,7 @@ decl_module! {
 ## Declaring Events
 
 To declare an event, use the
-[`decl_event!` macro](https://substrate.dev/rustdocs/v2.0.0/frame_support/macro.decl_event.html). Like any rust
+[`decl_event!` macro](https://substrate.dev/rustdocs/v2.0.0/frame_support/macro.decl_event.html). Like any Rust
 enum, Events have names and can optionally carry data with them. The syntax is slightly different
 depending on whether the events carry data of primitive types, or generic types from the pallet's
 configuration trait. These two techniques are demonstrated in the `simple-event` and `generic-event`

--- a/text/runtime-printing.md
+++ b/text/runtime-printing.md
@@ -13,9 +13,9 @@ dispatchable call that prints a message to the node's output. Printing to the no
 
 ## No Std
 
-The very first line of code tells the rust compiler that this crate should not use rust's standard
+The very first line of code tells the Rust compiler that this crate should not use Rust's standard
 library except when explicitly told to. This is useful because Substrate runtimes compile to Web
-Assembly where the standard library is not available.
+Assembly when the standard library is not available.
 
 ```rust, ignore
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -37,7 +37,7 @@ use sp_runtime::print;
 
 ## Tests
 
-Next we see a reference to the tests module. This pallet, as with most recipes pallets, has tests written in a separate file called
+Following, we see a reference to the tests module. This pallet, as with most recipes pallets, has tests written in a separate file called
 `tests.rs`.
 
 ## Configuration Trait
@@ -77,12 +77,12 @@ decl_module! {
 As you can see, our `hello-substrate` pallet has a dispatchable call that takes a single argument,
 called `origin`. The call returns a
 [`DispatchResult`](https://substrate.dev/rustdocs/v2.0.0/frame_support/dispatch/type.DispatchResult.html) which
-can be either `Ok(())` indicating that the call succeeded, or an `Err` which is demonstrated in most other recipes pallets.
+can be either `Ok(())` indicating that the call succeeded, or an `Err` which is demonstrated in most other pallets from this cookbook.
 
 ### Weight Annotations
 
-Right before the `hello-substrate` function, we see the line `#[weight = 10_000]`. This line
-attaches a default weight to the call. Ultimately weights affect the fees a user will have to pay to
+Right before the `say_hello` function, we see the line `#[weight = 10_000]`. This line
+attaches a default weight to the call. Ultimately, weights affect the fees a user will have to pay to
 call the function. Weights are a very interesting aspect of developing with Substrate, but they too
 shall be covered later in the section on [Weights](./weights.md). For now, and for many of
 the recipes pallets, we will simply use the default weight as we have done here.
@@ -120,7 +120,7 @@ this is explained in the next section.
 Finally, the call returns `Ok(())` to indicate that the call has succeeded. At a glance it seems
 that there is no way for this call to fail, but this is not quite true. The `ensure_signed`
 function, used at the beginning, can return an error if the call was not from a signed origin. This
-is the first time we're seeing the important paradigm "**Verify first, write last**". In Substrate
+is the first time we're seeing the important paradigm "**verify first, write last**". In Substrate
 development, it is important that you always ensure preconditions are met and return errors at the
 beginning. After these checks have completed, then you may begin the function's computation.
 
@@ -128,7 +128,7 @@ beginning. After these checks have completed, then you may begin the function's 
 
 Printing to the terminal from a Rust program is typically very simple using the `println!` macro.
 However, Substrate runtimes are compiled to both Web Assembly and a regular native binary, and do
-not have access to rust's standard library. That means we cannot use the regular `println!`. I
+not have access to Rust's standard library. That means we cannot use the regular `println!` macro. I
 encourage you to modify the code to try using `println!` and confirm that it will not compile.
 Nonetheless, printing a message from the runtime is useful both for logging information, and also
 for debugging.
@@ -148,10 +148,10 @@ datatypes too.
 `-lruntime=debug` when running the kitchen node. So, for the kitchen node, the command would become
 `./target/release/kitchen-node --dev -lruntime=debug`.
 
-The next line demonstrates using `debug::info!` macro to log to the screen and also inspecting the
-variable's content. The syntax inside the macro is very similar to what regular rust macro
+The next line uses `debug::info!` macro to log to the screen and to inspect the
+variable's content. The syntax inside the macro is very similar to what the regular Rust macro
 `println!` takes.
 
 **Runtime logger note:** When we execute the runtime in native, `debug::info!` messages are printed.
-However, if we execute the runtime in Wasm, then an additional step to initialise
+However, if we execute the runtime in WASM, then an additional step to initialise
 [RuntimeLogger](https://substrate.dev/rustdocs/v2.0.0/frame_support/debug/struct.RuntimeLogger.html) is required.

--- a/text/storage-maps.md
+++ b/text/storage-maps.md
@@ -28,12 +28,12 @@ Much of this should look familiar to you from storage values. Reading the line f
 have:
 
 -   `SimpleMap` - the name of the storage map
--   `get(fn simple_map)` - the name of a getter function that will return values from the map.
--   `: map hasher(blake2_128_concat)` - beginning of the type declaration. This is a map and it will
+-   `get(fn simple_map)` - the getter function call that will return values from the map.
+-   `: map hasher(blake2_128_concat)` - the beginning of the type declaration. This is a map and it will
     use the
     [`blake2_128_concat`](https://substrate.dev/rustdocs/v2.0.0/frame_support/trait.Hashable.html#tymethod.blake2_128_concat)
-    hasher. More on this below.
--   `T::AccountId => u32` - The specific key and value tyes of the map. This is a map from
+    hasher. More on this [below](https://substrate.dev/recipes/storage-maps.html#choosing-a-hasher).
+-   `T::AccountId => u32` - the specific key and value tyes of the map. This is a map from
     `AccountId`s to `u32`s.
 
 ## Choosing a Hasher
@@ -67,7 +67,7 @@ reasonable choice.
 The `identity` "hasher" is really not a hasher at all, but merely an
 [identity function](https://en.wikipedia.org/wiki/Identity_function) that returns the same value it
 receives. This hasher is only an option when the key type in your storage map is _already_ a hash,
-and is not controllable by the user. If you're in doubt whether the user can influence the key just
+and is not controllable by the user. If you're in doubt whether the user can influence the key, just
 use blake2.
 
 ## The Storage Map API
@@ -91,5 +91,5 @@ let entry = <SimpleMap<T>>::take(&user);
 
 The rest of the API is documented in the rustdocs on the
 [`StorageMap` trait](https://substrate.dev/rustdocs/v2.0.0/frame_support/storage/trait.StorageMap.html). You do
-not need to explicitly `use` this trait because the `decl_storage!` macro will do it for you if you
+not need to explicitly use this trait because the `decl_storage!` macro will do it for you if you
 use a storage map.


### PR DESCRIPTION
Simple edits to make Recipes prettier. Most of the changes are things like adding in semicolons and capitalizing the R for "Rust". Others include clarification nitpicks.

Note WIP: This first batch of edits only includes 1.1 - 1.6. 